### PR TITLE
Fix compile warnings with gcc 7.3

### DIFF
--- a/src/java.base/share/native/libfdlibm/k_rem_pio2.c
+++ b/src/java.base/share/native/libfdlibm/k_rem_pio2.c
@@ -1,4 +1,8 @@
 /*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2018, 2018 All Rights Reserved
+ * ===========================================================================
+ *
  * Copyright (c) 1998, 2013, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -252,7 +256,7 @@ recompute:
             j = 0;
             for (i=jz-1;i>=jk;i--) j |= iq[i];
             if(j==0) { /* need recomputation */
-                for(k=1;iq[jk-k]==0;k++);   /* k = no. of terms needed */
+                for(k=1;k<=jk&&iq[jk-k]==0;k++);   /* k = no. of terms needed */
 
                 for(i=jz+1;i<=jz+k;i++) {   /* add q[jz+1] to q[jz+k] */
                     f[jx+i] = (double) ipio2[jv+i];

--- a/src/java.desktop/share/native/libmlib_image/mlib_ImageLookUp_Bit.c
+++ b/src/java.desktop/share/native/libmlib_image/mlib_ImageLookUp_Bit.c
@@ -1,4 +1,8 @@
 /*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2018, 2018 All Rights Reserved
+ * ===========================================================================
+ *
  * Copyright (c) 2003, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -259,18 +263,18 @@ mlib_status mlib_ImageLookUp_Bit_U8_1(const mlib_u8 *src,
       }
 
 #ifdef _LITTLE_ENDIAN
-      emask = (mlib_u32)((mlib_s32)(-1)) >> ((4 - (size - i)) * 8);
+      emask = (mlib_u32)-(((mlib_s32)1) >> ((4 - (size - i)) * 8));
 #else
-      emask = (mlib_s32)(-1) << ((4 - (size - i)) * 8);
+      emask = (mlib_u32)-(((mlib_s32)1) << ((4 - (size - i)) * 8));
 #endif /* _LITTLE_ENDIAN */
       ((mlib_u32*)da)[0] = (val1 & emask) | (((mlib_u32*)da)[0] &~ emask);
 
 #else /* _NO_LONGLONG */
 
 #ifdef _LITTLE_ENDIAN
-      mlib_u64 emask = (mlib_u64)((mlib_s64)(-1)) >> ((8 - (size - i)) * 8);
+      mlib_u64 emask = (mlib_u64)-(((mlib_s64)1) >> ((8 - (size - i)) * 8));
 #else
-      mlib_u64 emask = (mlib_s64)(-1) << ((8 - (size - i)) * 8);
+      mlib_u64 emask = (mlib_u64)-(((mlib_s64)1) << ((8 - (size - i)) * 8));
 #endif /* _LITTLE_ENDIAN */
 
       ((mlib_u64*)da)[0] = (((mlib_u64*)dd_array)[sa[0]] & emask) | (((mlib_u64*)da)[0] &~ emask);
@@ -395,9 +399,9 @@ mlib_status mlib_ImageLookUp_Bit_U8_2(const mlib_u8 *src,
       }
 
 #ifdef _LITTLE_ENDIAN
-      emask = (mlib_u32)((mlib_s32)(-1)) >> ((4 - (size - i)) * 8);
+      emask = (mlib_u32)-(((mlib_s32)1) >> ((4 - (size - i)) * 8));
 #else
-      emask = (mlib_s32)(-1) << ((4 - (size - i)) * 8);
+      emask = (mlib_u32)-(((mlib_s32)1) << ((4 - (size - i)) * 8));
 #endif /* _LITTLE_ENDIAN */
       ((mlib_u32*)da)[0] = (dd1 & emask) | (((mlib_u32*)da)[0] &~ emask);
 
@@ -413,9 +417,9 @@ mlib_status mlib_ImageLookUp_Bit_U8_2(const mlib_u8 *src,
       }
 
 #ifdef _LITTLE_ENDIAN
-      emask = (mlib_u64)((mlib_s64)(-1)) >> ((8 - (size - i)) * 8);
+      emask = (mlib_u64)-(((mlib_s64)1) >> ((8 - (size - i)) * 8));
 #else
-      emask = (mlib_s64)(-1) << ((8 - (size - i)) * 8);
+      emask = (mlib_u64)-(((mlib_s64)1) << ((8 - (size - i)) * 8));
 #endif /* _LITTLE_ENDIAN */
       ((mlib_u64*)da)[0] = (dd & emask) | (((mlib_u64*)da)[0] &~ emask);
 
@@ -565,9 +569,9 @@ mlib_status mlib_ImageLookUp_Bit_U8_3(const mlib_u8 *src,
       }
 
 #ifdef _LITTLE_ENDIAN
-      emask = (mlib_u32)((mlib_s32)(-1)) >> ((4 - (size - i)) * 8);
+      emask = (mlib_u32)-(((mlib_s32)1) >> ((4 - (size - i)) * 8));
 #else
-      emask = (mlib_s32)(-1) << ((4 - (size - i)) * 8);
+      emask = (mlib_u32)-(((mlib_s32)1) << ((4 - (size - i)) * 8));
 #endif /* _LITTLE_ENDIAN */
       da[0] = (dd & emask) | (da[0] &~ emask);
     }


### PR DESCRIPTION
* add to loop test so the compiler can see the index is valid
* avoid left shifts of negative values