### PR TITLE
Avoid signed types in mask expressions

### DIFF
--- a/src/java.desktop/share/native/libmlib_image/mlib_ImageLookUp_Bit.c
+++ b/src/java.desktop/share/native/libmlib_image/mlib_ImageLookUp_Bit.c
@@ -263,18 +263,18 @@ mlib_status mlib_ImageLookUp_Bit_U8_1(const mlib_u8 *src,
       }
 
 #ifdef _LITTLE_ENDIAN
-      emask = ((mlib_u32)(-1)) >> ((4 - (size - i)) * 8);
+      emask = (~(mlib_u32)0) >> ((4 - (size - i)) * 8);
 #else
-      emask = (mlib_u32)-(((mlib_s32)1) << ((4 - (size - i)) * 8));
+      emask = (~(mlib_u32)0) << ((4 - (size - i)) * 8);
 #endif /* _LITTLE_ENDIAN */
       ((mlib_u32*)da)[0] = (val1 & emask) | (((mlib_u32*)da)[0] &~ emask);
 
 #else /* _NO_LONGLONG */
 
 #ifdef _LITTLE_ENDIAN
-      mlib_u64 emask = ((mlib_u64)-1) >> ((8 - (size - i)) * 8);
+      mlib_u64 emask = (~(mlib_u64)0) >> ((8 - (size - i)) * 8);
 #else
-      mlib_u64 emask = (mlib_u64)-(((mlib_s64)1) << ((8 - (size - i)) * 8));
+      mlib_u64 emask = (~(mlib_u64)0) << ((8 - (size - i)) * 8);
 #endif /* _LITTLE_ENDIAN */
 
       ((mlib_u64*)da)[0] = (((mlib_u64*)dd_array)[sa[0]] & emask) | (((mlib_u64*)da)[0] &~ emask);
@@ -399,9 +399,9 @@ mlib_status mlib_ImageLookUp_Bit_U8_2(const mlib_u8 *src,
       }
 
 #ifdef _LITTLE_ENDIAN
-      emask = ((mlib_u32)(-1)) >> ((4 - (size - i)) * 8);
+      emask = (~(mlib_u32)0) >> ((4 - (size - i)) * 8);
 #else
-      emask = (mlib_u32)-(((mlib_s32)1) << ((4 - (size - i)) * 8));
+      emask = (~(mlib_u32)0) << ((4 - (size - i)) * 8);
 #endif /* _LITTLE_ENDIAN */
       ((mlib_u32*)da)[0] = (dd1 & emask) | (((mlib_u32*)da)[0] &~ emask);
 
@@ -417,9 +417,9 @@ mlib_status mlib_ImageLookUp_Bit_U8_2(const mlib_u8 *src,
       }
 
 #ifdef _LITTLE_ENDIAN
-      emask = ((mlib_u64)(-1)) >> ((8 - (size - i)) * 8);
+      emask = (~(mlib_u64)0) >> ((8 - (size - i)) * 8);
 #else
-      emask = (mlib_u64)-(((mlib_s64)1) << ((8 - (size - i)) * 8));
+      emask = (~(mlib_u64)0) << ((8 - (size - i)) * 8);
 #endif /* _LITTLE_ENDIAN */
       ((mlib_u64*)da)[0] = (dd & emask) | (((mlib_u64*)da)[0] &~ emask);
 
@@ -569,9 +569,9 @@ mlib_status mlib_ImageLookUp_Bit_U8_3(const mlib_u8 *src,
       }
 
 #ifdef _LITTLE_ENDIAN
-      emask = ((mlib_u32)(-1)) >> ((4 - (size - i)) * 8);
+      emask = (~(mlib_u32)0) >> ((4 - (size - i)) * 8);
 #else
-      emask = (mlib_u32)-(((mlib_s32)1) << ((4 - (size - i)) * 8));
+      emask = (~(mlib_u32)0) << ((4 - (size - i)) * 8);
 #endif /* _LITTLE_ENDIAN */
       da[0] = (dd & emask) | (da[0] &~ emask);
     }


### PR DESCRIPTION
This is an improvement over #12 and #13 which avoids signed types altogether in the shift expressions flagged by the compiler. The pattern is much simpler and clearly symmetric between big- and little-endian platforms.