### PR TITLE
Update get sources to pull the openj9-0.10.0 release tag

### DIFF
--- a/closed/get_j9_source.sh
+++ b/closed/get_j9_source.sh
@@ -51,10 +51,10 @@ declare -A git_urls
 declare -A shas
 
 git_urls[openj9]=https://github.com/eclipse/openj9
-branches[openj9]=openj9-0.10.0-rc2
+branches[openj9]=openj9-0.10.0
 
 git_urls[omr]=https://github.com/eclipse/openj9-omr
-branches[omr]=openj9-0.10.0-rc2
+branches[omr]=openj9-0.10.0
 
 pflag=false
 


### PR DESCRIPTION
Signed-off-by: Peter Shipton <Peter_Shipton@ca.ibm.com>