### PR TITLE
Add OSX compressedrefs support - map memory below 4 GB

### DIFF
--- a/closed/autoconf/custom-spec.gmk.in
+++ b/closed/autoconf/custom-spec.gmk.in
@@ -85,3 +85,10 @@ ifeq ($(OPENJDK_TARGET_OS), windows)
   export LIB := "@VS_LIB@"
   export MSVC_VERSION := @TOOLCHAIN_VERSION@
 endif
+
+ifeq ($(OPENJDK_BUILD_OS), macosx)
+  ifeq ($(OPENJ9_LIBS_SUBDIR), compressedrefs)
+    # Set page zero size to 4KB for mapping memory below 4GB.
+    LDFLAGS_JDKEXE += -pagezero_size 0x1000
+  endif
+endif


### PR DESCRIPTION
Append "-pagezero_size 0x1000" to LDFLAGS_JDKEXE on OSX 64-bit
compressedrefs build. This allows memory to be mapped below 4GB.

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>