### PR TITLE
Revert "Enable DDR by default on AIX"

### DIFF
--- a/closed/autoconf/custom-hook.m4
+++ b/closed/autoconf/custom-hook.m4
@@ -178,7 +178,7 @@ AC_DEFUN([OPENJ9_CONFIGURE_DDR],
     OPENJ9_ENABLE_DDR=false
   elif test "x$enable_ddr" = x ; then
     case "$OPENJ9_PLATFORM_CODE" in
-      ap64|wa64|xa64|xl64|xz64)
+      wa64|xa64|xl64|xz64)
         AC_MSG_RESULT([yes (default for $OPENJ9_PLATFORM_CODE)])
         OPENJ9_ENABLE_DDR=true
         ;;


### PR DESCRIPTION
Reverts ibmruntimes/openj9-openjdk-jdk11#23

as per eclipse/openj9#3248