### PR TITLE
Removing IBM License

### DIFF
--- a/src/java.desktop/share/native/libmlib_image/mlib_ImageLookUp_Bit.c
+++ b/src/java.desktop/share/native/libmlib_image/mlib_ImageLookUp_Bit.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,11 +22,7 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-/*
- * ===========================================================================
- * (c) Copyright IBM Corp. 2018, 2018 All Rights Reserved
- * ===========================================================================
- */
+
 
 /*
  * FUNCTION


### PR DESCRIPTION
An IBM License is no longer required for this file. Also, the
modification to the Oracle date is not needed, so that's being undone as
well.

Signed-off-by: Adam Farley <adam.farley@uk.ibm.com>