### PR TITLE
Setting build version ID for 11.0.0.2 release

### DIFF
--- a/closed/autoconf/custom-spec.gmk.in
+++ b/closed/autoconf/custom-spec.gmk.in
@@ -58,7 +58,7 @@ USERNAME                := @USERNAME@
 OPENJDK_SHA             := @OPENJDK_SHA@
 OPENJDK_TAG             := @OPENJDK_TAG@
 
-J9JDK_EXT_VERSION       := ${VERSION_NUMBER_FOUR_POSITIONS}
+J9JDK_EXT_VERSION       := 11.0.0.2
 J9JDK_EXT_NAME          := Extensions for OpenJDK for Eclipse OpenJ9
 
 # required by CMake


### PR DESCRIPTION
In the release build for Eclipse OpenJ9 0.11 on OpenJDK 11.0.1, the
version string for the binary as a whole is 11.0.0.2. This is us setting
that.

Signed-off-by: Adam Farley <adam.farley@uk.ibm.com>