### PR TITLE
Use -pagezero_size always on OSX

### DIFF
--- a/closed/autoconf/custom-spec.gmk.in
+++ b/closed/autoconf/custom-spec.gmk.in
@@ -103,8 +103,7 @@ ifeq ($(OPENJDK_BUILD_OS), macosx)
   # variable is defined to support dependencies where the compiler option
   # is not applied.
   export MACOSX_DEPLOYMENT_TARGET := @MACOSX_VERSION_MIN@
-  ifeq ($(OPENJ9_LIBS_SUBDIR), compressedrefs)
-    # Set page zero size to 4KB for mapping memory below 4GB.
-    LDFLAGS_JDKEXE += -pagezero_size 0x1000
-  endif
+
+  # Set page zero size to 4KB for mapping memory below 4GB.
+  LDFLAGS_JDKEXE += -pagezero_size 0x1000
 endif


### PR DESCRIPTION
-pagezero_size 0x1000 can be used for both compressedrefs and
non-compressedrefs variants. This will allow executables to work with
both compressedrefs and non-compressedrefs OpenJ9 librarires.

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>