### PR TITLE
Fix OpenSSL build commands and dependencies

### DIFF
--- a/closed/make/Main.gmk
+++ b/closed/make/Main.gmk
@@ -5,7 +5,7 @@
 # under the terms of the GNU General Public License version 2 only, as
 # published by the Free Software Foundation.
 #
-# IBM designates this particular file as subject to the "Classpath" exception 
+# IBM designates this particular file as subject to the "Classpath" exception
 # as provided by IBM in the LICENSE file that accompanied this code.
 #
 # This code is distributed in the hope that it will be useful, but WITHOUT
@@ -23,6 +23,7 @@ CLEAN_DIRS += vm
 .PHONY : \
 	j9vm-build \
 	java.base-libs \
+	openssl-build \
 	test-image-openj9 \
 	#
 
@@ -35,10 +36,12 @@ DEFAULT_JMOD_DEPS := j9vm-build
 PHASE_MAKEDIRS := $(TOPDIR)/closed/make/closed_make $(PHASE_MAKEDIRS)
 
 OPENJ9_MAKE := $(MAKE) -f $(TOPDIR)/closed/OpenJ9.gmk SPEC=$(SPEC) VERSION_MAJOR=$(VERSION_FEATURE) OPENJDK_VERSION_NUMBER_FOUR_POSITIONS=$(VERSION_NUMBER_FOUR_POSITIONS)
-
 OPENSSL_MAKE := $(MAKE) -f $(TOPDIR)/closed/openssl.gmk SPEC=$(SPEC)
+
 openssl-build : buildtools-langtools
 	+$(OPENSSL_MAKE)
+
+java.base-copy : openssl-build
 
 java.base-libs : java.base-copy j9vm-build
 

--- a/closed/make/copy/Copy-java.base.gmk
+++ b/closed/make/copy/Copy-java.base.gmk
@@ -5,7 +5,7 @@
 # under the terms of the GNU General Public License version 2 only, as
 # published by the Free Software Foundation.
 #
-# IBM designates this particular file as subject to the "Classpath" exception 
+# IBM designates this particular file as subject to the "Classpath" exception
 # as provided by IBM in the LICENSE file that accompanied this code.
 #
 # This code is distributed in the hope that it will be useful, but WITHOUT
@@ -68,12 +68,12 @@ ifneq ($(OPENSSL_BUNDLE_LIB_PATH), )
   else
     OPENSSL_LIB_NAME = libcrypto.so
   endif
-   OPENSSL_TARGET_LIB = $(LIB_DST_DIR)/$(OPENSSL_LIB_NAME)
-   $(OPENSSL_TARGET_LIB): $(OPENSSL_BUNDLE_LIB_PATH)/$(OPENSSL_LIB_NAME)
-	$(CP) $(OPENSSL_BUNDLE_LIB_PATH)/$(OPENSSL_LIB_NAME) $@
-    ifeq ($(OPENJDK_BUILD_OS), windows)
-	$(CHMOD) +rx $@
-    endif
-   TARGETS += $(OPENSSL_TARGET_LIB)
+  OPENSSL_TARGET_LIB = $(LIB_DST_DIR)/$(OPENSSL_LIB_NAME)
+  TARGETS += $(OPENSSL_TARGET_LIB)
+  $(OPENSSL_TARGET_LIB) : $(OPENSSL_BUNDLE_LIB_PATH)/$(OPENSSL_LIB_NAME)
+	$(CP) $< $@
+  ifeq ($(OPENJDK_BUILD_OS), windows)
+	$(CHMOD) a+rx $@
+  endif
 endif
- ################################################################################
+################################################################################

--- a/closed/openssl.gmk
+++ b/closed/openssl.gmk
@@ -27,7 +27,7 @@ endif
 include $(SPEC)
 
 # config command guess the operating system and Configure openssl accordignly.
-# However, on some platforms (like AIX, Windows) it is essential to configure 
+# However, on some platforms (like AIX, Windows) it is essential to configure
 # with one of the platform list provided by command ./Configure LIST command
 #     For AIX PPC64, it is aix64-cc
 #     For Linux ppc64le, it is linux-ppc64le
@@ -36,26 +36,26 @@ include $(SPEC)
 #     For Windows x64, it is VC-WIN64A
 #     For Windows x32, it is VC-WIN32
 #     For Mac OSX, it is darwin64-x86_64-cc
-build_openssl:
+build_openssl :
 ifeq ($(BUILD_OPENSSL), yes)
 	$(ECHO) Compiling OpenSSL in $(OPENSSL_DIR)
   ifeq ($(OPENJDK_TARGET_OS), linux)
     ifeq ($(OPENJDK_TARGET_CPU), x86_64)
-        ($(CD) $(OPENSSL_DIR) && ./Configure linux-x86_64 && $(MAKE))
+		($(CD) $(OPENSSL_DIR) && ./Configure linux-x86_64 && $(MAKE))
     else ifeq ($(OPENJDK_TARGET_CPU), s390x)
-        ($(CD) $(OPENSSL_DIR) && ./Configure linux64-s390x && $(MAKE))
+		($(CD) $(OPENSSL_DIR) && ./Configure linux64-s390x && $(MAKE))
     else ifeq ($(OPENJDK_TARGET_CPU), ppc64le)
-        ($(CD) $(OPENSSL_DIR) && ./Configure linux-ppc64le && $(MAKE))
+		($(CD) $(OPENSSL_DIR) && ./Configure linux-ppc64le && $(MAKE))
     else
-        ($(CD) $(OPENSSL_DIR) && ./config && $(MAKE))
+		($(CD) $(OPENSSL_DIR) && ./config && $(MAKE))
     endif
   else ifeq ($(OPENJDK_TARGET_OS), macosx)
 	($(CD) $(OPENSSL_DIR) && ./Configure darwin64-x86_64-cc -shared  && $(MAKE))
   else ifeq ($(OPENJDK_TARGET_OS), windows)
     ifeq ($(OPENJDK_TARGET_CPU), x86_64)
-        ($(CD) $(OPENSSL_DIR) && ./Configure VC-WIN64A && $(MAKE))
+		($(CD) $(OPENSSL_DIR) && ./Configure VC-WIN64A && $(MAKE))
     else
-        ($(CD) $(OPENSSL_DIR) && ./Configure VC-WIN32 && $(MAKE))
+		($(CD) $(OPENSSL_DIR) && ./Configure VC-WIN32 && $(MAKE))
     endif
   else ifeq ($(OPENJDK_TARGET_OS), aix)
 	($(CD) $(OPENSSL_DIR) && ./Configure aix64-cc && $(MAKE))


### PR DESCRIPTION
Make command lines must start with a TAB character.