### PR TITLE
Backport JDK-8213202: Possible race condition in TLS 1.3 session resumption

### DIFF
--- a/src/java.base/share/classes/sun/security/ssl/ClientHandshakeContext.java
+++ b/src/java.base/share/classes/sun/security/ssl/ClientHandshakeContext.java
@@ -22,6 +22,11 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2019, 2019 All Rights Reserved.
+ * ===========================================================================
+ */
 
 package sun.security.ssl;
 
@@ -89,6 +94,9 @@ class ClientHandshakeContext extends HandshakeContext {
     X509Certificate[] deferredCerts;
 
     ClientHelloMessage initialClientHelloMsg = null;
+
+    // PSK identity is selected in first Hello and used again after HRR
+    byte[] pskIdentity;
 
     ClientHandshakeContext(SSLContextImpl sslContext,
             TransportContext conContext) throws IOException {

--- a/src/java.base/share/classes/sun/security/ssl/SSLSessionImpl.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLSessionImpl.java
@@ -24,7 +24,7 @@
  */
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2018, 2018 All Rights Reserved
+ * (c) Copyright IBM Corp. 2018, 2019 All Rights Reserved
  * ===========================================================================
  */
 package sun.security.ssl;
@@ -308,13 +308,6 @@ final class SSLSessionImpl extends ExtendedSSLSession {
 
     String getIdentificationProtocol() {
         return this.identificationProtocol;
-    }
-
-    /*
-     * Get the PSK identity. Take care not to use it in multiple connections.
-     */
-    synchronized Optional<byte[]> getPskIdentity() {
-        return Optional.ofNullable(pskIdentity);
     }
 
     /* PSK identities created from new_session_ticket messages should only


### PR DESCRIPTION
OpenJDK JDK12 patch backport of fixes for JDK-8213202, changesets:
http://hg.openjdk.java.net/jdk/jdk/rev/f8fb0c86f2b3
http://hg.openjdk.java.net/jdk/jdk/rev/01b519fcb8a8

Signed-off-by: andrew-m-leonard <andrew_m_leonard@uk.ibm.com>