### PR TITLE
Add native reset routine and a finalizer for native digest

### DIFF
--- a/closed/src/java.base/share/classes/jdk/crypto/jniprovider/NativeCrypto.java
+++ b/closed/src/java.base/share/classes/jdk/crypto/jniprovider/NativeCrypto.java
@@ -1,6 +1,6 @@
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2018, 2018 All Rights Reserved
+ * (c) Copyright IBM Corp. 2018, 2019 All Rights Reserved
  * ===========================================================================
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -52,6 +52,8 @@ public class NativeCrypto {
     public static final native long DigestCreateContext(long nativeBuffer,
                                                         int algoIndex);
 
+    public static final native int DigestDestroyContext(long context);
+
     public static final native int DigestUpdate(long context,
                                                 byte[] message,
                                                 int messageOffset,
@@ -64,6 +66,8 @@ public class NativeCrypto {
                                                          byte[] digest,
                                                          int digestOffset,
                                                          int digestLen);
+
+    public static final native void DigestReset(long context);
 
     /* Native CBC interfaces */
     public static final native long CBCCreateContext(long nativeBuffer,

--- a/closed/src/java.base/share/classes/sun/security/provider/NativeDigest.java
+++ b/closed/src/java.base/share/classes/sun/security/provider/NativeDigest.java
@@ -24,7 +24,7 @@
  */
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2018, 2018 All Rights Reserved
+ * (c) Copyright IBM Corp. 2018, 2019 All Rights Reserved
  * ===========================================================================
  */
 
@@ -52,7 +52,6 @@ abstract class NativeDigest extends MessageDigestSpi implements Cloneable {
     // number of bytes processed so far. subclasses should not modify
     // this value.
     // also used as a flag to indicate reset status
-    // -1: need to call engineReset() before next call to update()
     //  0: is already reset
     private long bytesProcessed;
 
@@ -93,10 +92,6 @@ abstract class NativeDigest extends MessageDigestSpi implements Cloneable {
             throw new ArrayIndexOutOfBoundsException();
         }
 
-        if (bytesProcessed < 0) {
-            engineReset();
-        }
-
         bytesProcessed += len;
 
         NativeCrypto.DigestUpdate(context, b, ofs, len);
@@ -109,6 +104,7 @@ abstract class NativeDigest extends MessageDigestSpi implements Cloneable {
             return;
         }
 
+        NativeCrypto.DigestReset(context);
         bytesProcessed = 0;
     }
 
@@ -139,13 +135,9 @@ abstract class NativeDigest extends MessageDigestSpi implements Cloneable {
             throw new DigestException("Buffer too short to store digest");
         }
 
-        if (bytesProcessed < 0) {
-            engineReset();
-        }
-
         NativeCrypto.DigestComputeAndReset(context, null, 0, 0, out, ofs, len);
 
-        bytesProcessed = -1;
+        bytesProcessed = 0;
         return digestLength;
     }
 
@@ -155,4 +147,11 @@ abstract class NativeDigest extends MessageDigestSpi implements Cloneable {
         return copy;
     }
 
+    /*
+     * Finalize method to release the Digest contexts.
+     */
+    @Override
+    public void finalize() {
+        NativeCrypto.DigestDestroyContext(context);
+    }
 }

--- a/closed/src/java.base/share/native/libjncrypto/NativeCrypto.c
+++ b/closed/src/java.base/share/native/libjncrypto/NativeCrypto.c
@@ -1,6 +1,6 @@
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2018, 2018 All Rights Reserved
+ * (c) Copyright IBM Corp. 2018, 2019 All Rights Reserved
  * ===========================================================================
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -115,6 +115,24 @@ JNIEXPORT jlong JNICALL Java_jdk_crypto_jniprovider_NativeCrypto_DigestCreateCon
     return (jlong)context;
 }
 
+/*
+ * Class:     jdk_crypto_jniprovider_NativeCrypto
+ * Method:    DigestDestroyContext
+ * Signature: (J)I
+ */
+JNIEXPORT jint JNICALL Java_jdk_crypto_jniprovider_NativeCrypto_DigestDestroyContext
+  (JNIEnv *env, jclass thisObj, jlong c){
+
+    OpenSSLMDContext *context = (OpenSSLMDContext*) c;
+    if (context == NULL){
+        return -1;
+    }
+
+    EVP_MD_CTX_free(context->ctx);
+    free(context);
+    return 0;
+}
+
 /* Update Digest context
  *
  * Class:     jdk_crypto_jniprovider_NativeCrypto
@@ -189,6 +207,23 @@ JNIEXPORT jint JNICALL Java_jdk_crypto_jniprovider_NativeCrypto_DigestComputeAnd
         handleErrors();
 
     return size;
+}
+
+/* Reset Digest
+ *
+ * Class:     jdk_crypto_jniprovider_NativeCrypto
+ * Method:    DigestReset
+ * Signature: (J)V
+ */
+JNIEXPORT void JNICALL Java_jdk_crypto_jniprovider_NativeCrypto_DigestReset
+  (JNIEnv *env, jclass thisObj, jlong c){
+
+    OpenSSLMDContext *context = (OpenSSLMDContext*) c;
+
+    EVP_MD_CTX_reset(context->ctx);
+
+    if (1 != EVP_DigestInit_ex(context->ctx, context->digestAlg, NULL))
+        handleErrors();
 }
 
 /* Create Cipher context


### PR DESCRIPTION
-fixes [eclipse/openj9/#4315](https://github.com/eclipse/openj9/issues/4315)
-fixes a memory leak in native digest,  issue [eclipse/openj9/#4348](https://github.com/eclipse/openj9/issues/4348)

Signed-off-by: Jerry Lui jerrylui@ibm.com