### PR TITLE
Put jsig libraries in the correct places

### DIFF
--- a/closed/OpenJ9.gmk
+++ b/closed/OpenJ9.gmk
@@ -1,5 +1,5 @@
 # ===========================================================================
-# (c) Copyright IBM Corp. 2017, 2018 All Rights Reserved
+# (c) Copyright IBM Corp. 2017, 2019 All Rights Reserved
 # ===========================================================================
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
@@ -213,9 +213,10 @@ $(call openj9_add_jdk_shlibs, java.base, \
 	)
 
 ifeq (windows,$(OPENJDK_TARGET_OS))
-$(eval $(call openj9_add_jdk_rules, \
-	$(OUTPUTDIR)/vm/lib/$(call STATIC_LIBRARY,jvm), \
-	$(OUTPUTDIR)/vm/j9vm_jdk11/$(call STATIC_LIBRARY,jdk11_jvm)))
+  $(call openj9_add_jdk_lib, java.base, lib/$(call STATIC_LIBRARY,jsig))
+  $(eval $(call openj9_add_jdk_rules, \
+	$(call FindLibDirForModule, java.base)/$(call STATIC_LIBRARY,jvm), \
+	$(OUTPUTDIR)/vm/redirector/$(call STATIC_LIBRARY,redirector_jvm)))
 endif
 
 $(call openj9_add_jdk_lib, java.base, \

--- a/closed/autoconf/custom-hook.m4
+++ b/closed/autoconf/custom-hook.m4
@@ -1,5 +1,5 @@
 # ===========================================================================
-# (c) Copyright IBM Corp. 2017, 2018 All Rights Reserved
+# (c) Copyright IBM Corp. 2017, 2019 All Rights Reserved
 # ===========================================================================
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
@@ -370,14 +370,6 @@ AC_DEFUN_ONCE([CUSTOM_LATE_HOOK],
 [
   # Configure for openssl build
   CONFIGURE_OPENSSL
-
-  if test "x$OPENJDK_BUILD_OS_ENV" = xwindows.cygwin ; then
-    LDFLAGS_JDKLIB="${LDFLAGS_JDKLIB} -libpath:\$(SUPPORT_OUTPUTDIR)/../vm/lib"
-    OPENJDK_BUILD_LDFLAGS_JDKLIB="${OPENJDK_BUILD_LDFLAGS_JDKLIB} -libpath:\$(SUPPORT_OUTPUTDIR)/../vm/lib"
-  else
-    LDFLAGS_JDKLIB="${LDFLAGS_JDKLIB} -L\$(SUPPORT_OUTPUTDIR)/../vm"
-    OPENJDK_BUILD_LDFLAGS_JDKLIB="${OPENJDK_BUILD_LDFLAGS_JDKLIB} -L\$(SUPPORT_OUTPUTDIR)/../vm"
-  fi
 
   CLOSED_AUTOCONF_DIR="$TOPDIR/closed/autoconf"
 


### PR DESCRIPTION
* on Windows the shared library should be in `bin`, `bin/j9vm` and `bin/server` (in an SDK, the static library should be in `lib`)
* on other platforms, the shared library should be in `lib`, `lib/j9vm` and `lib/server`
* also put the redirector static library where openjdk expects it so adjustments to `LDFLAGS_JDKLIB` are not necessary

This should fix #56.