### PR TITLE
RSA Implementation using OpenSSL

### DIFF
--- a/closed/src/java.base/share/classes/jdk/crypto/jniprovider/NativeCrypto.java
+++ b/closed/src/java.base/share/classes/jdk/crypto/jniprovider/NativeCrypto.java
@@ -123,4 +123,40 @@ public class NativeCrypto {
                                               int aadLen,
                                               int tagLen);
 
+    /* Native RSA interfaces */
+    public static final native long createRSAPublicKey(byte[] n,
+                                                       int nLen,
+                                                       byte[] e,
+                                                       int eLen);
+
+    public static final native long createRSAPrivateCrtKey(byte[] n,
+                                                           int nLen,
+                                                           byte[] d,
+                                                           int dLen,
+                                                           byte[] e,
+                                                           int eLen,
+                                                           byte[] p,
+                                                           int pLen,
+                                                           byte[] q,
+                                                           int qLen,
+                                                           byte[] dp,
+                                                           int dpLen,
+                                                           byte[] dq,
+                                                           int dqLen,
+                                                           byte[] qinv,
+                                                           int qinvLen);
+
+    public static final native void destroyRSAKey(long key);
+
+    public static final native int RSADP(byte[] k,
+                                         int kLen,
+                                         byte[] m,
+                                         int verify,
+                                         long RSAPrivateCrtKey);
+
+    public static final native int RSAEP(byte[] k,
+                                         int kLen,
+                                         byte[] m,
+                                         long RSAPublicKey);
+
 }

--- a/closed/src/java.base/share/classes/sun/security/rsa/NativeRSACore.java
+++ b/closed/src/java.base/share/classes/sun/security/rsa/NativeRSACore.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2003, 2015, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2018, 2019 All Rights Reserved
+ * ===========================================================================
+ */
+
+package sun.security.rsa;
+
+import java.math.BigInteger;
+import java.util.*;
+
+import java.security.SecureRandom;
+import java.security.interfaces.*;
+
+import javax.crypto.BadPaddingException;
+import sun.security.action.GetPropertyAction;
+import jdk.crypto.jniprovider.NativeCrypto;
+
+import sun.security.jca.JCAUtil;
+
+/**
+ * Core of the RSA implementation. Has code to perform public and private key
+ * RSA operations (with and without CRT for private key ops). Private CRT ops
+ * also support blinding to twart timing attacks.
+ *
+ * The code in this class only does the core RSA operation. Padding and
+ * unpadding must be done externally.
+ *
+ * Note: RSA keys should be at least 512 bits long
+ *
+ * @since   1.5
+ * @author  Andreas Sterbenz
+ */
+public final class NativeRSACore {
+
+    /**
+     * Return the number of bytes required to store the magnitude byte[] of
+     * this BigInteger. Do not count a 0x00 byte toByteArray() would
+     * prefix for 2's complement form.
+     */
+    public static int getByteLength(BigInteger b) {
+        int n = b.bitLength();
+        return (n + 7) >> 3;
+    }
+
+    /**
+     * Perform an RSA public key operation.
+     */
+    public static byte[] rsa(byte[] msg, sun.security.rsa.RSAPublicKeyImpl key)
+        throws BadPaddingException {
+        return crypt_Native(msg, key);
+    }
+
+    /**
+     * Perform an RSA private key operation. Uses CRT if the key is a
+     * CRT key. Set 'verify' to true if this function is used for
+     * generating a signature.
+     */
+    public static byte[] rsa(byte[] msg,sun.security.rsa.RSAPrivateCrtKeyImpl key, boolean verify)
+        throws BadPaddingException {
+        return crtCrypt_Native(msg, key, verify);
+    }
+
+    /**
+     * RSA public key ops. Simple modPow().
+     */
+    synchronized private static byte[] crypt_Native(byte[] msg, sun.security.rsa.RSAPublicKeyImpl key)
+        throws BadPaddingException {
+
+        long nativePtr = key.getNativePtr();
+
+        if (nativePtr == -1) {
+            return null;
+        }
+
+        BigInteger n = key.getModulus();
+        byte[] output = new byte[getByteLength(n)];
+
+        int outputLen = NativeCrypto.RSAEP(msg, msg.length, output, nativePtr);
+
+        if (outputLen == -1) {
+            return null;
+        }
+        return output;
+    }
+
+    /**
+     * RSA private key operations with CRT. Algorithm and variable naming
+     * are taken from PKCS#1 v2.1, section 5.1.2.
+     */
+    synchronized private static byte[] crtCrypt_Native(byte[] msg, sun.security.rsa.RSAPrivateCrtKeyImpl key,
+            boolean verify) throws BadPaddingException {
+        long nativePtr = key.getNativePtr();
+
+        if (nativePtr == -1) {
+            return null;
+        }
+
+        int verifyInt;
+        BigInteger n = key.getModulus();
+        int outputLen = getByteLength(n);
+        byte[] output = new byte[outputLen];
+
+        if(verify) {
+            verifyInt = outputLen;
+        } else {
+            verifyInt = -1;
+        }
+
+        outputLen = NativeCrypto.RSADP(msg, msg.length, output, verifyInt, nativePtr);
+
+        if (outputLen == -1) {
+            return null;
+        } else if (outputLen == -2) {
+            throw new BadPaddingException("RSA private key operation failed");
+        }
+
+        return output;
+    }
+}

--- a/closed/src/java.base/share/native/libjncrypto/NativeCrypto.c
+++ b/closed/src/java.base/share/native/libjncrypto/NativeCrypto.c
@@ -25,6 +25,7 @@
 #include <openssl/evp.h>
 #include <openssl/aes.h>
 #include <openssl/err.h>
+#include <openssl/rsa.h>
 
 #include <jni.h>
 #include <stdio.h>
@@ -121,10 +122,10 @@ JNIEXPORT jlong JNICALL Java_jdk_crypto_jniprovider_NativeCrypto_DigestCreateCon
  * Signature: (J)I
  */
 JNIEXPORT jint JNICALL Java_jdk_crypto_jniprovider_NativeCrypto_DigestDestroyContext
-  (JNIEnv *env, jclass thisObj, jlong c){
+  (JNIEnv *env, jclass thisObj, jlong c) {
 
     OpenSSLMDContext *context = (OpenSSLMDContext*) c;
-    if (context == NULL){
+    if (context == NULL) {
         return -1;
     }
 
@@ -216,7 +217,7 @@ JNIEXPORT jint JNICALL Java_jdk_crypto_jniprovider_NativeCrypto_DigestComputeAnd
  * Signature: (J)V
  */
 JNIEXPORT void JNICALL Java_jdk_crypto_jniprovider_NativeCrypto_DigestReset
-  (JNIEnv *env, jclass thisObj, jlong c){
+  (JNIEnv *env, jclass thisObj, jlong c) {
 
     OpenSSLMDContext *context = (OpenSSLMDContext*) c;
 
@@ -651,4 +652,346 @@ JNIEXPORT jint JNICALL Java_jdk_crypto_jniprovider_NativeCrypto_GCMDecrypt
         /* Tag Mismatch */
         return -1;
     }
+}
+
+BIGNUM* convertJavaBItoBN(unsigned char* in, int len);
+
+/* Create an RSA Public Key
+ * Returns -1 on error
+ *
+ * Class:     jdk_crypto_jniprovider_NativeCrypto
+ * Method:    createRSAPublicKey
+ * Signature: ([BI[BI)J
+ */
+JNIEXPORT jlong JNICALL Java_jdk_crypto_jniprovider_NativeCrypto_createRSAPublicKey
+  (JNIEnv *env, jclass obj, jbyteArray n, jint nLen, jbyteArray e, jint eLen) {
+
+    unsigned char* nNative;
+    unsigned char* eNative;
+
+    nNative = (unsigned char*)((*env)->GetPrimitiveArrayCritical(env, n, 0));
+    if (nNative == NULL) {
+        return -1;
+    }
+
+    eNative = (unsigned char*)((*env)->GetPrimitiveArrayCritical(env, e, 0));
+    if (eNative == NULL) {
+        (*env)->ReleasePrimitiveArrayCritical(env, n, nNative,  0);
+        return -1;
+    }
+
+    RSA* publicRSAKey = RSA_new();
+
+    BIGNUM* nBN = convertJavaBItoBN(nNative,nLen);
+    BIGNUM* eBN = convertJavaBItoBN(eNative,eLen);
+    
+    if (publicRSAKey == NULL || nBN == NULL || eBN == NULL) {
+        (*env)->ReleasePrimitiveArrayCritical(env, n, nNative,  0);
+        (*env)->ReleasePrimitiveArrayCritical(env, e, eNative,  0);
+        return -1;
+    }
+
+    int ret = RSA_set0_key(publicRSAKey, nBN, eBN, NULL);
+
+    (*env)->ReleasePrimitiveArrayCritical(env, n, nNative,  0);
+    (*env)->ReleasePrimitiveArrayCritical(env, e, eNative,  0);
+
+    if (ret == 0) {
+        return -1;
+    }
+
+    return (jlong)publicRSAKey;
+}
+
+/* Create an RSA Private CRT Key
+ * Returns -1 on error
+ *
+ * Class:     jdk_crypto_jniprovider_NativeCrypto
+ * Method:    createRSAPrivateCrtKey
+ * Signature: ([BI[BI[BI[BI[BI[BI[BI[BI)J
+ */
+JNIEXPORT jlong JNICALL Java_jdk_crypto_jniprovider_NativeCrypto_createRSAPrivateCrtKey
+  (JNIEnv *env, jclass obj, jbyteArray n, jint nLen, jbyteArray d, jint dLen, jbyteArray e, jint eLen, jbyteArray p, jint pLen, jbyteArray q, jint qLen, jbyteArray dp, jint dpLen, jbyteArray dq, jint dqLen, jbyteArray qinv, jint qinvLen) {
+    unsigned char* nNative;
+    unsigned char* dNative;
+    unsigned char* eNative;
+    unsigned char* pNative;
+    unsigned char* qNative;
+    unsigned char* dpNative;
+    unsigned char* dqNative;
+    unsigned char* qinvNative;
+
+    nNative    = (unsigned char*)((*env)->GetPrimitiveArrayCritical(env, n, 0));
+    if (nNative == NULL) {
+        return -1;
+    }
+
+    dNative    = (unsigned char*)((*env)->GetPrimitiveArrayCritical(env, d, 0));
+    if (dNative == NULL) {
+        (*env)->ReleasePrimitiveArrayCritical(env, n, nNative,  0);
+        return -1;
+    }
+
+    eNative    = (unsigned char*)((*env)->GetPrimitiveArrayCritical(env, e, 0));
+    if (eNative == NULL) {
+        (*env)->ReleasePrimitiveArrayCritical(env, n, nNative,  0);
+        (*env)->ReleasePrimitiveArrayCritical(env, d, dNative,  0);
+        return -1;
+    }
+
+    pNative    = (unsigned char*)((*env)->GetPrimitiveArrayCritical(env, p, 0));
+    if (pNative == NULL) {
+        (*env)->ReleasePrimitiveArrayCritical(env, n, nNative,  0);
+        (*env)->ReleasePrimitiveArrayCritical(env, d, dNative,  0);
+        (*env)->ReleasePrimitiveArrayCritical(env, e, eNative,  0);
+        return -1;
+    }
+
+    qNative    = (unsigned char*)((*env)->GetPrimitiveArrayCritical(env, q, 0));
+    if (qNative == NULL) {
+        (*env)->ReleasePrimitiveArrayCritical(env, n, nNative,  0);
+        (*env)->ReleasePrimitiveArrayCritical(env, d, dNative,  0);
+        (*env)->ReleasePrimitiveArrayCritical(env, e, eNative,  0);
+        (*env)->ReleasePrimitiveArrayCritical(env, p, pNative,  0);
+        return -1;
+    }
+
+    dpNative   = (unsigned char*)((*env)->GetPrimitiveArrayCritical(env, dp, 0));
+    if (dpNative == NULL) {
+        (*env)->ReleasePrimitiveArrayCritical(env, n, nNative,  0);
+        (*env)->ReleasePrimitiveArrayCritical(env, d, dNative,  0);
+        (*env)->ReleasePrimitiveArrayCritical(env, e, eNative,  0);
+        (*env)->ReleasePrimitiveArrayCritical(env, p, pNative,  0);
+        (*env)->ReleasePrimitiveArrayCritical(env, q, qNative,  0);
+        return -1;
+    }
+
+    dqNative   = (unsigned char*)((*env)->GetPrimitiveArrayCritical(env, dq, 0));
+    if (dqNative == NULL) {
+        (*env)->ReleasePrimitiveArrayCritical(env, n, nNative,  0);
+        (*env)->ReleasePrimitiveArrayCritical(env, d, dNative,  0);
+        (*env)->ReleasePrimitiveArrayCritical(env, e, eNative,  0);
+        (*env)->ReleasePrimitiveArrayCritical(env, p, pNative,  0);
+        (*env)->ReleasePrimitiveArrayCritical(env, q, qNative,  0);
+        (*env)->ReleasePrimitiveArrayCritical(env, dp, dpNative,  0);
+        return -1;
+    }
+
+    qinvNative = (unsigned char*)((*env)->GetPrimitiveArrayCritical(env, qinv, 0));
+    if (qinvNative == NULL) {
+        (*env)->ReleasePrimitiveArrayCritical(env, n, nNative,  0);
+        (*env)->ReleasePrimitiveArrayCritical(env, d, dNative,  0);
+        (*env)->ReleasePrimitiveArrayCritical(env, e, eNative,  0);
+        (*env)->ReleasePrimitiveArrayCritical(env, p, pNative,  0);
+        (*env)->ReleasePrimitiveArrayCritical(env, q, qNative,  0);
+        (*env)->ReleasePrimitiveArrayCritical(env, dp, dpNative,  0);
+        (*env)->ReleasePrimitiveArrayCritical(env, dq, dqNative,  0);
+        return -1;
+    }
+
+    RSA* privateRSACrtKey = RSA_new();
+
+    BIGNUM* nBN = convertJavaBItoBN(nNative,nLen);
+    BIGNUM* eBN = convertJavaBItoBN(eNative,eLen);
+    BIGNUM* dBN = convertJavaBItoBN(dNative,dLen);
+
+    if (privateRSACrtKey == NULL || nBN == NULL || eBN == NULL || dBN == NULL) {
+
+        (*env)->ReleasePrimitiveArrayCritical(env, n, nNative, 0);
+        (*env)->ReleasePrimitiveArrayCritical(env, d, dNative, 0);
+        (*env)->ReleasePrimitiveArrayCritical(env, e, eNative, 0);
+        (*env)->ReleasePrimitiveArrayCritical(env, p, pNative, 0);
+        (*env)->ReleasePrimitiveArrayCritical(env, q, qNative, 0);
+        (*env)->ReleasePrimitiveArrayCritical(env, dp, dpNative, 0);
+        (*env)->ReleasePrimitiveArrayCritical(env, dq, dqNative, 0);
+        (*env)->ReleasePrimitiveArrayCritical(env, qinv, qinvNative, 0);
+        return -1;
+    }
+
+    int ret;
+
+    ret = RSA_set0_key(privateRSACrtKey, nBN, eBN, dBN);
+
+    BIGNUM* pBN = convertJavaBItoBN(pNative,pLen);
+    BIGNUM* qBN = convertJavaBItoBN(qNative,qLen);
+
+    if (ret == 0 || pBN == NULL || qBN == NULL) {
+        (*env)->ReleasePrimitiveArrayCritical(env, n, nNative, 0);
+        (*env)->ReleasePrimitiveArrayCritical(env, d, dNative, 0);
+        (*env)->ReleasePrimitiveArrayCritical(env, e, eNative, 0);
+        (*env)->ReleasePrimitiveArrayCritical(env, p, pNative, 0);
+        (*env)->ReleasePrimitiveArrayCritical(env, q, qNative, 0);
+        (*env)->ReleasePrimitiveArrayCritical(env, dp, dpNative, 0);
+        (*env)->ReleasePrimitiveArrayCritical(env, dq, dqNative, 0);
+        (*env)->ReleasePrimitiveArrayCritical(env, qinv, qinvNative, 0);
+        return -1;
+    }
+
+    ret = RSA_set0_factors(privateRSACrtKey, pBN, qBN);
+
+    BIGNUM* dpBN   = convertJavaBItoBN(dpNative,  dpLen);
+    BIGNUM* dqBN   = convertJavaBItoBN(dqNative,  dqLen);
+    BIGNUM* qinvBN = convertJavaBItoBN(qinvNative,qinvLen);
+
+    if (ret == 0 || dpBN == NULL || dqBN == NULL || qinvBN == NULL) {
+        (*env)->ReleasePrimitiveArrayCritical(env, n, nNative, 0);
+        (*env)->ReleasePrimitiveArrayCritical(env, d, dNative, 0);
+        (*env)->ReleasePrimitiveArrayCritical(env, e, eNative, 0);
+        (*env)->ReleasePrimitiveArrayCritical(env, p, pNative, 0);
+        (*env)->ReleasePrimitiveArrayCritical(env, q, qNative, 0);
+        (*env)->ReleasePrimitiveArrayCritical(env, dp, dpNative, 0);
+        (*env)->ReleasePrimitiveArrayCritical(env, dq, dqNative, 0);
+        (*env)->ReleasePrimitiveArrayCritical(env, qinv, qinvNative, 0);
+        return -1;
+    }
+
+    ret = RSA_set0_crt_params(privateRSACrtKey, dpBN, dqBN, qinvBN);
+
+    (*env)->ReleasePrimitiveArrayCritical(env, n, nNative, 0);
+    (*env)->ReleasePrimitiveArrayCritical(env, d, dNative, 0);
+    (*env)->ReleasePrimitiveArrayCritical(env, e, eNative, 0);
+    (*env)->ReleasePrimitiveArrayCritical(env, p, pNative, 0);
+    (*env)->ReleasePrimitiveArrayCritical(env, q, qNative, 0);
+    (*env)->ReleasePrimitiveArrayCritical(env, dp, dpNative, 0);
+    (*env)->ReleasePrimitiveArrayCritical(env, dq, dqNative, 0);
+    (*env)->ReleasePrimitiveArrayCritical(env, qinv, qinvNative, 0);
+    
+    if (ret == 0)
+        return -1;
+
+    return (jlong)privateRSACrtKey;
+}
+
+/* Free RSA Public/Private Key
+ * Class:     jdk_crypto_jniprovider_NativeCrypto
+ * Method:    destroyRSAKey
+ * Signature: (J)V
+ */
+JNIEXPORT void JNICALL Java_jdk_crypto_jniprovider_NativeCrypto_destroyRSAKey
+  (JNIEnv *env, jclass obj, jlong rsaKey) {
+    RSA_free((RSA*)rsaKey);
+}
+
+/* RSAEP Cryptographic Primitive, RSA Public Key operation
+ * Returns -1 on error
+ *
+ * Class:     jdk_crypto_jniprovider_NativeCrypto
+ * Method:    RSAEP
+ * Signature: ([BI[BJ)I
+ */
+JNIEXPORT jint JNICALL Java_jdk_crypto_jniprovider_NativeCrypto_RSAEP
+  (JNIEnv *env, jclass obj, jbyteArray k, jint kLen, jbyteArray m, jlong publicRSAKey) {
+
+    unsigned char* kNative;
+    unsigned char* mNative;
+
+    kNative = (unsigned char*)((*env)->GetPrimitiveArrayCritical(env, k, 0));
+    if (kNative == NULL) {
+        return -1;
+    }
+
+    mNative = (unsigned char*)((*env)->GetPrimitiveArrayCritical(env, m, 0));
+    if (mNative == NULL) {
+        (*env)->ReleasePrimitiveArrayCritical(env, k, kNative,  0);
+        return -1;
+    }
+
+    RSA* rsaKey = (RSA*)publicRSAKey;
+
+    // OSSL_RSA_public_decrypt returns -1 on error
+    int msg_len = RSA_public_decrypt(kLen, kNative, mNative, rsaKey, RSA_NO_PADDING);
+
+    (*env)->ReleasePrimitiveArrayCritical(env, k, kNative,  0);
+    (*env)->ReleasePrimitiveArrayCritical(env, m, mNative,  0);
+    return msg_len;
+}
+
+/* RSADP Cryptographic Primitive, RSA Private Key operation
+ * Returns -1 on error
+ * The param verify is -1 for 'no verify', otherwise it is size of m (with verify)
+ *
+ * Class:     jdk_crypto_jniprovider_NativeCrypto
+ * Method:    RSADP
+ * Signature: ([BI[BIJ)I
+ */
+JNIEXPORT jint JNICALL Java_jdk_crypto_jniprovider_NativeCrypto_RSADP
+  (JNIEnv *env, jclass obj, jbyteArray k, jint kLen, jbyteArray m, jint verify, jlong privateRSAKey) {
+
+    unsigned char* kNative;
+    unsigned char* mNative;
+
+    kNative = (unsigned char*)((*env)->GetPrimitiveArrayCritical(env, k, 0));
+    if (kNative == NULL) {
+        return -1;
+    }
+
+    mNative = (unsigned char*)((*env)->GetPrimitiveArrayCritical(env, m, 0));
+    if (mNative == NULL) {
+        (*env)->ReleasePrimitiveArrayCritical(env, k, kNative,  0);
+        return -1;
+    }
+
+    RSA* rsaKey = (RSA*)privateRSAKey;
+
+    // OSSL_RSA_private_encrypt returns -1 on error
+    int msg_len = RSA_private_encrypt(kLen, kNative, mNative, rsaKey, RSA_NO_PADDING);
+
+    if (verify != -1 && msg_len != -1) {
+        if (verify == kLen) {
+            unsigned char* k2 = malloc(kLen * (sizeof(unsigned char)));
+            if (k2 != NULL) {
+
+                //mNative is size 'verify'
+                int msg_len2 = RSA_public_decrypt(verify, mNative, k2, rsaKey, RSA_NO_PADDING);
+                if (msg_len2 != -1) {
+
+                    int i;
+                    for (i = 0; i < verify; i++) {
+                        if (kNative[i] != k2[i]) {
+                            msg_len = -2;
+                            break;
+                        }
+                    }
+                } else {
+                    msg_len = -1;
+                }
+                free(k2);
+            } else {
+                msg_len = -1;
+            }
+        } else {
+            msg_len = -2;
+        }
+    }
+
+    (*env)->ReleasePrimitiveArrayCritical(env, k, kNative,  0);
+    (*env)->ReleasePrimitiveArrayCritical(env, m, mNative,  0);
+
+    return msg_len;
+}
+
+/*
+ * Converts 2's complement representation of a big integer
+ * into an OpenSSL BIGNUM
+ */
+BIGNUM* convertJavaBItoBN(unsigned char* in, int len) {
+    // first bit is neg
+    int neg = (in[0] & 0x80);
+    if (neg != 0) {
+        // number is negative in two's complement form
+        // need to extract magnitude
+        int c = 1;
+        int i = 0;
+        for (i = len - 1; i >= 0; i--) {
+            in[i] ^= 0xff; // flip bits
+            if(c) { // add 1 for as long as needed
+                c = (++in[i]) == 0;
+            }
+        }
+    }
+    BIGNUM* bn = BN_bin2bn(in, len, NULL);
+    if (bn != NULL) {
+        BN_set_negative(bn, neg);
+    }
+    return bn;
 }

--- a/src/java.base/share/classes/com/sun/crypto/provider/CipherCore.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/CipherCore.java
@@ -24,7 +24,7 @@
  */
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2018, 2018 All Rights Reserved
+ * (c) Copyright IBM Corp. 2018, 2019 All Rights Reserved
  * ===========================================================================
  */
 
@@ -70,7 +70,7 @@ final class CipherCore {
      * The property 'jdk.nativeCBC' is used to disable Native CBC alone,
      * 'jdk.nativeGCM' is used to disable Native GCM alone and
      * 'jdk.nativeCrypto' is used to disable all native cryptos (Digest,
-     * CBC and GCM).
+     * CBC, GCM, and RSA).
      */
     private static boolean useNativeCrypto = true;
     private static boolean useNativeCBC = true;

--- a/src/java.base/share/classes/sun/security/provider/SunEntries.java
+++ b/src/java.base/share/classes/sun/security/provider/SunEntries.java
@@ -24,7 +24,7 @@
  */
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2018, 2018 All Rights Reserved
+ * (c) Copyright IBM Corp. 2018, 2019 All Rights Reserved
  * ===========================================================================
  */
 
@@ -92,7 +92,7 @@ final class SunEntries {
      * By default, the native crypto is enabled  and uses native library crypto.
      * The property 'jdk.nativeDigest' is used to disable Native digest alone
      * and 'jdk.nativeCrypto' is used to disable all native cryptos (Digest,
-     * CBC and GCM).
+     * CBC, GCM, and RSA).
      */
     private static boolean useNativeDigest = true;
 

--- a/src/java.base/share/classes/sun/security/rsa/RSACore.java
+++ b/src/java.base/share/classes/sun/security/rsa/RSACore.java
@@ -22,6 +22,11 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2018, 2019 All Rights Reserved
+ * ===========================================================================
+ */
 
 package sun.security.rsa;
 
@@ -32,6 +37,8 @@ import java.security.SecureRandom;
 import java.security.interfaces.*;
 
 import javax.crypto.BadPaddingException;
+import sun.security.action.GetPropertyAction;
+import jdk.crypto.jniprovider.NativeCrypto;
 
 import sun.security.jca.JCAUtil;
 
@@ -49,6 +56,20 @@ import sun.security.jca.JCAUtil;
  * @author  Andreas Sterbenz
  */
 public final class RSACore {
+
+    /*
+     * Check whether native crypto is enabled with property.
+     *
+     * By default, the native crypto is enabled and uses the native
+     * crypto library implementation.
+     *
+     * The property 'jdk.nativeRSA' is used to enable Native RSA alone,
+     * and 'jdk.nativeCrypto' is used to enable all native cryptos (Digest,
+     * CBC, GCM, and RSA).
+     */
+    private static boolean useNativeCrypto = true;
+
+    private static boolean useNativeRsa = true;
 
     // globally enable/disable use of blinding
     private static final boolean ENABLE_BLINDING = true;
@@ -97,6 +118,13 @@ public final class RSACore {
      */
     public static byte[] rsa(byte[] msg, RSAPublicKey key)
             throws BadPaddingException {
+        if (useNativeRsa && key instanceof sun.security.rsa.RSAPublicKeyImpl) {
+             byte[] ret = NativeRSACore.rsa(msg, (sun.security.rsa.RSAPublicKeyImpl) key);
+             if (ret != null) {
+                 return ret;
+             }
+             useNativeRsa = false;
+        }
         return crypt(msg, key.getModulus(), key.getPublicExponent());
     }
 
@@ -117,8 +145,15 @@ public final class RSACore {
      * generating a signature.
      */
     public static byte[] rsa(byte[] msg, RSAPrivateKey key, boolean verify)
-            throws BadPaddingException {
+        throws BadPaddingException {
         if (key instanceof RSAPrivateCrtKey) {
+            if (useNativeRsa && key instanceof sun.security.rsa.RSAPrivateCrtKeyImpl) {
+                byte[] ret = NativeRSACore.rsa(msg, (sun.security.rsa.RSAPrivateCrtKeyImpl) key, verify);
+                if (ret != null) {
+                    return ret;
+                }
+                useNativeRsa = false;
+            }
             return crtCrypt(msg, (RSAPrivateCrtKey)key, verify);
         } else {
             return priCrypt(msg, key.getModulus(), key.getPrivateExponent());
@@ -238,6 +273,48 @@ public final class RSACore {
         byte[] t = new byte[len];
         System.arraycopy(b, 0, t, (len - n), n);
         return t;
+    }
+
+    static {
+
+        String nativeCryptTrace = GetPropertyAction.privilegedGetProperty("jdk.nativeCryptoTrace");
+        String nativeCryptStr = GetPropertyAction.privilegedGetProperty("jdk.nativeCrypto");
+        String nativeRsaStr = GetPropertyAction.privilegedGetProperty("jdk.nativeRSA");
+
+        if (Boolean.parseBoolean(nativeCryptStr) || nativeCryptStr == null) {
+                /* nativeCrypto is enabled */
+                if (!(Boolean.parseBoolean(nativeRsaStr) || nativeRsaStr == null)) {
+                        useNativeRsa = false;
+                }
+        } else {
+                /* nativeCrypto is disabled */
+                useNativeRsa = false;
+        }
+
+        if (useNativeRsa) {
+            /*
+             * User want to use native crypto implementation.
+             * Make sure the native crypto libraries are loaded successfully.
+             * Otherwise, throw a warning message and fall back to the in-built
+             * java crypto implementation.
+             */
+            if (!NativeCrypto.isLoaded()) {
+                useNativeRsa = false;
+
+                if (nativeCryptTrace != null) {
+                   System.err.println("Warning: Native crypto library load failed." +
+                                   " Using Java crypto implementation");
+                }
+            } else {
+                if (nativeCryptTrace != null) {
+                   System.err.println("RSACore load - using Native crypto library.");
+                }
+            }
+        } else {
+            if (nativeCryptTrace != null) {
+               System.err.println("RSACore load - Native crypto library disabled.");
+            }
+        }
     }
 
     /**

--- a/src/java.base/share/classes/sun/security/rsa/RSAPrivateCrtKeyImpl.java
+++ b/src/java.base/share/classes/sun/security/rsa/RSAPrivateCrtKeyImpl.java
@@ -22,6 +22,11 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2018, 2019 All Rights Reserved
+ * ===========================================================================
+ */
 
 package sun.security.rsa;
 
@@ -38,6 +43,7 @@ import sun.security.x509.AlgorithmId;
 import sun.security.pkcs.PKCS8Key;
 
 import static sun.security.rsa.RSAUtil.KeyType;
+import jdk.crypto.jniprovider.NativeCrypto;
 
 /**
  * RSA private key implementation for "RSA", "RSASSA-PSS" algorithms in CRT form.
@@ -231,6 +237,50 @@ public final class RSAPrivateCrtKeyImpl
     @Override
     public BigInteger getCrtCoefficient() {
         return coeff;
+    }
+
+    private long nativeRSAKey = 0x0;
+
+    /**
+     * Get native RSA Public Key context pointer. 
+     * Create native context if uninitialized.
+     */
+    protected long getNativePtr() {
+        if (nativeRSAKey != 0x0) {
+            return nativeRSAKey;
+        }
+
+        BigInteger n =    this.getModulus();
+        BigInteger d =    this.getPrivateExponent();
+        BigInteger e =    this.getPublicExponent();
+        BigInteger p =    this.getPrimeP();
+        BigInteger q =    this.getPrimeQ();
+        BigInteger dP =   this.getPrimeExponentP();
+        BigInteger dQ =   this.getPrimeExponentQ();
+        BigInteger qInv = this.getCrtCoefficient();
+
+        byte[] n_2c = n.toByteArray();
+        byte[] d_2c = d.toByteArray();
+        byte[] e_2c = e.toByteArray();
+
+        byte[] p_2c = p.toByteArray();
+        byte[] q_2c = q.toByteArray();
+
+        byte[] dP_2c   = dP.toByteArray();
+        byte[] dQ_2c   = dQ.toByteArray();
+        byte[] qInv_2c = qInv.toByteArray();
+
+        nativeRSAKey = NativeCrypto.createRSAPrivateCrtKey(n_2c,n_2c.length, d_2c, d_2c.length, e_2c, e_2c.length,
+                p_2c, p_2c.length, q_2c, q_2c.length,
+                dP_2c, dP_2c.length, dQ_2c, dQ_2c.length, qInv_2c, qInv_2c.length);
+        return nativeRSAKey;
+    }
+
+    @Override
+    public void finalize() {
+        if (nativeRSAKey != 0x0 && nativeRSAKey != -1) {
+            NativeCrypto.destroyRSAKey(nativeRSAKey);
+        }
     }
 
     // see JCA doc


### PR DESCRIPTION
Added modifications to RSACore and relevant RSA classes to leverage OpenSSL by default, there is an option jdk.nativeRSA=false to disable. The existing option to manipulate native crypto are also supported (jdk.NativeCrypto).

Signed-off-by: Jerry Lui <jerrylui@ibm.com>