### PR TITLE
crypto library does not load on osx and windows jdk11

### DIFF
--- a/closed/autoconf/custom-hook.m4
+++ b/closed/autoconf/custom-hook.m4
@@ -1,5 +1,5 @@
 # ===========================================================================
-# (c) Copyright IBM Corp. 2017, 2018 All Rights Reserved
+# (c) Copyright IBM Corp. 2017, 2019 All Rights Reserved
 # ===========================================================================
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
@@ -407,25 +407,25 @@ AC_DEFUN([CONFIGURE_OPENSSL],
       BUNDLE_OPENSSL=no
     fi
     # if --with-openssl=fetched
-    if test "x$with_openssl" = xfetched; then
-      if test "x$OPENJDK_BUILD_OS" = xwindows; then
+    if test "x$with_openssl" = xfetched ; then
+      if test "x$OPENJDK_BUILD_OS" = xwindows ; then
         AC_MSG_RESULT([no])
         printf "On Windows, value of \"fetched\" is currently not supported with --with-openssl. Please build OpenSSL using VisualStudio outside cygwin and specify the path with --with-openssl\n"
         AC_MSG_ERROR([Cannot continue])
       fi
       if test -d "$TOPDIR/openssl" ; then
-        OPENSSL_DIR=$TOPDIR/openssl
+        OPENSSL_DIR="$TOPDIR/openssl"
         FOUND_OPENSSL=yes
         OPENSSL_CFLAGS="-I${OPENSSL_DIR}/include"
         OPENSSL_LIBS="-L${OPENSSL_DIR} -lcrypto"
-        if test -s $OPENSSL_DIR/${LIBRARY_PREFIX}crypto${SHARED_LIBRARY_SUFFIX}.1.1; then
+        if test -s "$OPENSSL_DIR/${LIBRARY_PREFIX}crypto${SHARED_LIBRARY_SUFFIX}" ; then
           BUILD_OPENSSL=no
         else
           BUILD_OPENSSL=yes
         fi
 
         if test "x$BUNDLE_OPENSSL" = xyes ; then
-          OPENSSL_BUNDLE_LIB_PATH=$OPENSSL_DIR
+          OPENSSL_BUNDLE_LIB_PATH="${OPENSSL_DIR}"
         fi
         AC_MSG_RESULT([yes])
       else
@@ -438,46 +438,81 @@ AC_DEFUN([CONFIGURE_OPENSSL],
     fi
 
     # if --with-openssl=system
-    if test "x$FOUND_OPENSSL" != xyes && test "x$with_openssl" = xsystem; then
-      if test "x$OPENJDK_BUILD_OS" = xwindows; then
+    if test "x$FOUND_OPENSSL" != xyes && test "x$with_openssl" = xsystem ; then
+      if test "x$OPENJDK_BUILD_OS" = xwindows ; then
         AC_MSG_RESULT([no])
         printf "On Windows, value of \"system\" is currently not supported with --with-openssl. Please build OpenSSL using VisualStudio outside cygwin and specify the path with --with-openssl\n"
         AC_MSG_ERROR([Cannot continue])
       fi
       # Check modules using pkg-config, but only if we have it
       PKG_CHECK_MODULES(OPENSSL, openssl >= 1.1.0, [FOUND_OPENSSL=yes], [FOUND_OPENSSL=no])
-      if test "x$FOUND_OPENSSL" != xyes; then
+      if test "x$FOUND_OPENSSL" != xyes ; then
         AC_MSG_ERROR([Unable to find openssl 1.1.0(and above) installed on System. Please use other options for '--with-openssl'])
+      fi
+      # The crypto library bundling option is not available when --with-openssl=system.
+      if test "x$BUNDLE_OPENSSL" = xyes ; then
+        AC_MSG_RESULT([no])
+        printf "The option --enable_openssl_bundling is not available with --with-openssl=system. Use option fetched or openssl-custom-path to bundle crypto library\n"
+        AC_MSG_ERROR([Cannot continue])
       fi
     fi
 
     # if --with-openssl=/custom/path/where/openssl/is/present
-    if test "x$FOUND_OPENSSL" != xyes; then
+    if test "x$FOUND_OPENSSL" != xyes ; then
       # User specified path where openssl is installed
       OPENSSL_DIR=$with_openssl
       BASIC_FIXUP_PATH(OPENSSL_DIR)
-      if test -s "$OPENSSL_DIR/include/openssl/evp.h"; then
-        if test "x$OPENJDK_BUILD_OS_ENV" = xwindows.cygwin; then
+      if test -s "$OPENSSL_DIR/include/openssl/evp.h" ; then
+        if test "x$OPENJDK_BUILD_OS_ENV" = xwindows.cygwin ; then
           # On Windows, check for libcrypto.lib
-          if test -s "$OPENSSL_DIR/lib/libcrypto.lib"; then
+          if test -s "$OPENSSL_DIR/lib/libcrypto.lib" ; then
             FOUND_OPENSSL=yes
             OPENSSL_CFLAGS="-I${OPENSSL_DIR}/include"
             OPENSSL_LIBS="-libpath:${OPENSSL_DIR}/lib libcrypto.lib"
+            if test "x$BUNDLE_OPENSSL" = xyes ; then
+              if test -d "$OPENSSL_DIR/bin" ; then
+                OPENSSL_BUNDLE_LIB_PATH="${OPENSSL_DIR}/bin"
+              else
+                OPENSSL_BUNDLE_LIB_PATH="${OPENSSL_DIR}"
+              fi
+            fi
           fi
         else
-          if test -s "$OPENSSL_DIR/lib/${LIBRARY_PREFIX}crypto${SHARED_LIBRARY_SUFFIX}.1.1" ; then
+          if test -s "$OPENSSL_DIR/lib/${LIBRARY_PREFIX}crypto${SHARED_LIBRARY_SUFFIX}" ; then
             FOUND_OPENSSL=yes
             OPENSSL_CFLAGS="-I${OPENSSL_DIR}/include"
             OPENSSL_LIBS="-L${OPENSSL_DIR}/lib -lcrypto"
             if test "x$BUNDLE_OPENSSL" = xyes ; then
-              OPENSSL_BUNDLE_LIB_PATH=$OPENSSL_DIR/lib
+              # On Mac OSX, create local copy of the crypto library to update @rpath
+              # as the default is /usr/local/lib.
+              if test "x$OPENJDK_BUILD_OS" = xmacosx ; then
+                LOCAL_CRYPTO="$TOPDIR/openssl"
+                $MKDIR -p "${LOCAL_CRYPTO}"
+                $CP "${OPENSSL_DIR}/libcrypto.1.1.dylib" "${LOCAL_CRYPTO}"
+                $CP -a "${OPENSSL_DIR}/libcrypto.dylib" "${LOCAL_CRYPTO}"
+                OPENSSL_LIBS="-L${LOCAL_CRYPTO} -lcrypto"
+                OPENSSL_BUNDLE_LIB_PATH="${LOCAL_CRYPTO}"
+              else
+                OPENSSL_BUNDLE_LIB_PATH="${OPENSSL_DIR}/lib"
+              fi
             fi
-          elif test -s "$OPENSSL_DIR/${LIBRARY_PREFIX}crypto${SHARED_LIBRARY_SUFFIX}.1.1" ; then
+          elif test -s "$OPENSSL_DIR/${LIBRARY_PREFIX}crypto${SHARED_LIBRARY_SUFFIX}" ; then
             FOUND_OPENSSL=yes
             OPENSSL_CFLAGS="-I${OPENSSL_DIR}/include"
             OPENSSL_LIBS="-L${OPENSSL_DIR} -lcrypto"
             if test "x$BUNDLE_OPENSSL" = xyes ; then
-              OPENSSL_BUNDLE_LIB_PATH=$OPENSSL_DIR
+              # On Mac OSX, create local copy of the crypto library to update @rpath
+              # as the default is /usr/local/lib.
+              if test "x$OPENJDK_BUILD_OS" = xmacosx ; then
+                LOCAL_CRYPTO="$TOPDIR/openssl"
+                $MKDIR -p "${LOCAL_CRYPTO}"
+                $CP "${OPENSSL_DIR}/libcrypto.1.1.dylib" "${LOCAL_CRYPTO}"
+                $CP -a "${OPENSSL_DIR}/libcrypto.dylib" "${LOCAL_CRYPTO}"
+                OPENSSL_LIBS="-L${LOCAL_CRYPTO} -lcrypto"
+                OPENSSL_BUNDLE_LIB_PATH="${LOCAL_CRYPTO}"
+              else
+                OPENSSL_BUNDLE_LIB_PATH="${OPENSSL_DIR}"
+              fi
             fi
           fi
         fi

--- a/closed/make/copy/Copy-java.base.gmk
+++ b/closed/make/copy/Copy-java.base.gmk
@@ -1,5 +1,5 @@
 # ===========================================================================
-# (c) Copyright IBM Corp. 2017, 2018 All Rights Reserved
+# (c) Copyright IBM Corp. 2017, 2019 All Rights Reserved
 # ===========================================================================
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
@@ -68,6 +68,15 @@ ifneq ($(OPENSSL_BUNDLE_LIB_PATH), )
   else
     OPENSSL_LIB_NAME = libcrypto.so
   endif
+
+  # On Mac OS, update the crypto library path to @rpath as the default is /usr/local/lib/
+  ifeq ($(OPENJDK_BUILD_OS), macosx)
+    .PHONY : RPATH_CRYPTO_LIB
+    TARGETS += RPATH_CRYPTO_LIB
+    RPATH_CRYPTO_LIB :
+	install_name_tool -id "@rpath/$(OPENSSL_LIB_NAME)" "$(OPENSSL_BUNDLE_LIB_PATH)/$(OPENSSL_LIB_NAME)"
+  endif
+
   OPENSSL_TARGET_LIB = $(LIB_DST_DIR)/$(OPENSSL_LIB_NAME)
   TARGETS += $(OPENSSL_TARGET_LIB)
   $(OPENSSL_TARGET_LIB) : $(OPENSSL_BUNDLE_LIB_PATH)/$(OPENSSL_LIB_NAME)


### PR DESCRIPTION
The issue with mac OSX is that libjncrypto.dylib is linked to
/usr/local/lib/libcrypto.1.1.dylib instead of linking with rpath
i.e @rpath/libcrypto.1.1.dylib.
This is because libcrypto.1.1.dylib by default is built with
/usr/local/lib as the path instead of rpath.
To fix the issue, updated the path entry of libcrypto.1.1.dylib
with @rpath using install_name_tool.

Signed-off-by: Nasser Ebrahim <enasser@in.ibm.com>