### PR TITLE
Use the OpenJ9 and OMR openj9-0.12.0-rc2 tags for the 0.12 release

### DIFF
--- a/closed/get_j9_source.sh
+++ b/closed/get_j9_source.sh
@@ -54,10 +54,10 @@ declare -A git_urls
 declare -A shas
 
 git_urls[openj9]=https://github.com/eclipse/openj9
-branches[openj9]=openj9-0.12.0-rc1
+branches[openj9]=openj9-0.12.0-rc2
 
 git_urls[omr]=https://github.com/eclipse/openj9-omr
-branches[omr]=openj9-0.12.0-rc1
+branches[omr]=openj9-0.12.0-rc2
 
 pflag=false
 


### PR DESCRIPTION
Signed-off-by: Peter Shipton <Peter_Shipton@ca.ibm.com>