### PR TITLE
fix NativeCrypto JNI being publicly accessible

### DIFF
--- a/closed/src/java.base/share/classes/com/sun/crypto/provider/NativeGaloisCounterMode.java
+++ b/closed/src/java.base/share/classes/com/sun/crypto/provider/NativeGaloisCounterMode.java
@@ -24,7 +24,7 @@
  */
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2018, 2018 All Rights Reserved
+ * (c) Copyright IBM Corp. 2018, 2019 All Rights Reserved
  * ===========================================================================
  */
 
@@ -90,6 +90,12 @@ final class NativeGaloisCounterMode extends FeedbackCipher {
     private byte[] aadBufferSave = null;
     private byte[] ibufferSave = null;
     private byte[] ibufferSave_enc = null;
+
+    private static NativeCrypto nativeCrypto;
+
+    static {
+        nativeCrypto = NativeCrypto.getNativeCrypto();
+    }
 
     private static void checkDataLength(int processed, int len) {
         if (processed > MAX_BUF_SIZE - len) {
@@ -338,7 +344,7 @@ final class NativeGaloisCounterMode extends FeedbackCipher {
 
         byte[] aad = ((aadBuffer == null || aadBuffer.size() == 0) ? emptyAAD : aadBuffer.toByteArray());
 
-        NativeCrypto.GCMEncrypt(key, key.length,
+        nativeCrypto.GCMEncrypt(key, key.length,
               iv, iv.length,
               in, inOfs, len,
               out, outOfs,
@@ -429,7 +435,7 @@ final class NativeGaloisCounterMode extends FeedbackCipher {
         len = in.length;
         ibuffer.reset();
 
-        int ret = NativeCrypto.GCMDecrypt(key, key.length,
+        int ret = nativeCrypto.GCMDecrypt(key, key.length,
                 iv, iv.length,
                 in, inOfs, len,
                 out, outOfs,

--- a/closed/src/java.base/share/classes/jdk/crypto/jniprovider/NativeCrypto.java
+++ b/closed/src/java.base/share/classes/jdk/crypto/jniprovider/NativeCrypto.java
@@ -26,6 +26,12 @@ package jdk.crypto.jniprovider;
 
 import java.security.*;
 
+import com.ibm.oti.vm.VM;
+
+import jdk.internal.misc.Unsafe;
+import jdk.internal.reflect.Reflection;
+import jdk.internal.reflect.CallerSensitive;
+
 public class NativeCrypto {
 
     private static boolean loaded = false;
@@ -48,115 +54,130 @@ public class NativeCrypto {
         return loaded;
     }
 
+    private NativeCrypto() {
+        //empty
+    }
+
+    @CallerSensitive
+    public static NativeCrypto getNativeCrypto() {
+
+        ClassLoader callerClassLoader = Reflection.getCallerClass().getClassLoader();
+
+        if ((callerClassLoader != null) && (callerClassLoader != VM.getVMLangAccess().getExtClassLoader())) {
+            throw new SecurityException("NativeCrypto");
+        }
+        return new NativeCrypto();
+    }
+
     /* Native digest interfaces */
-    public static final native long DigestCreateContext(long nativeBuffer,
-                                                        int algoIndex);
+    public final native long DigestCreateContext(long nativeBuffer,
+                                                 int algoIndex);
 
-    public static final native int DigestDestroyContext(long context);
+    public final native int DigestDestroyContext(long context);
 
-    public static final native int DigestUpdate(long context,
-                                                byte[] message,
-                                                int messageOffset,
-                                                int messageLen);
+    public final native int DigestUpdate(long context,
+                                         byte[] message,
+                                         int messageOffset,
+                                         int messageLen);
 
-    public static final native int DigestComputeAndReset(long context,
-                                                         byte[] message,
-                                                         int messageOffset,
-                                                         int messageLen,
-                                                         byte[] digest,
-                                                         int digestOffset,
-                                                         int digestLen);
+    public final native int DigestComputeAndReset(long context,
+                                                  byte[] message,
+                                                  int messageOffset,
+                                                  int messageLen,
+                                                  byte[] digest,
+                                                  int digestOffset,
+                                                  int digestLen);
 
-    public static final native void DigestReset(long context);
+    public final native void DigestReset(long context);
 
     /* Native CBC interfaces */
-    public static final native long CBCCreateContext(long nativeBuffer,
-                                                     long nativeBuffer2);
+    public final native long CBCCreateContext(long nativeBuffer,
+                                              long nativeBuffer2);
 
-    public static final native int CBCDestroyContext(long context);
+    public final native int CBCDestroyContext(long context);
 
-    public static final native int CBCInit(long context,
-                                            int mode,
-                                            byte[] iv,
-                                            int ivlen,
-                                            byte[] key,
-                                            int keylen);
+    public final native int CBCInit(long context,
+                                    int mode,
+                                    byte[] iv,
+                                    int ivlen,
+                                    byte[] key,
+                                    int keylen);
 
-    public static final native int  CBCUpdate(long context,
-                                              byte[] input,
-                                              int inputOffset,
-                                              int inputLen,
-                                              byte[] output,
-                                              int outputOffset);
+    public final native int  CBCUpdate(long context,
+                                       byte[] input,
+                                       int inputOffset,
+                                       int inputLen,
+                                       byte[] output,
+                                       int outputOffset);
 
-    public static final native int  CBCFinalEncrypt(long context,
-                                               byte[] input,
-                                               int inputOffset,
-                                               int inputLen,
-                                               byte[] output,
-                                               int outputOffset);
+    public final native int  CBCFinalEncrypt(long context,
+                                             byte[] input,
+                                             int inputOffset,
+                                             int inputLen,
+                                             byte[] output,
+                                             int outputOffset);
 
     /* Native GCM interfaces */
-    public static final native int GCMEncrypt(byte[] key,
-                                              int keylen,
-                                              byte[] iv,
-                                              int ivlen,
-                                              byte[] input,
-                                              int inOffset,
-                                              int inLen,
-                                              byte[] output,
-                                              int outOffset,
-                                              byte[] aad,
-                                              int aadLen,
-                                              int tagLen);
+    public final native int GCMEncrypt(byte[] key,
+                                       int keylen,
+                                       byte[] iv,
+                                       int ivlen,
+                                       byte[] input,
+                                       int inOffset,
+                                       int inLen,
+                                       byte[] output,
+                                       int outOffset,
+                                       byte[] aad,
+                                       int aadLen,
+                                       int tagLen);
 
-    public static final native int GCMDecrypt(byte[] key,
-                                              int keylen,
-                                              byte[] iv,
-                                              int ivlen,
-                                              byte[] input,
-                                              int inOffset,
-                                              int inLen,
-                                              byte[] output,
-                                              int outOffset,
-                                              byte[] aad,
-                                              int aadLen,
-                                              int tagLen);
+    public final native int GCMDecrypt(byte[] key,
+                                       int keylen,
+                                       byte[] iv,
+                                       int ivlen,
+                                       byte[] input,
+                                       int inOffset,
+                                       int inLen,
+                                       byte[] output,
+                                       int outOffset,
+                                       byte[] aad,
+                                       int aadLen,
+                                       int tagLen);
 
     /* Native RSA interfaces */
-    public static final native long createRSAPublicKey(byte[] n,
-                                                       int nLen,
-                                                       byte[] e,
-                                                       int eLen);
+    public final native long createRSAPublicKey(byte[] n,
+                                                int nLen,
+                                                byte[] e,
+                                                int eLen);
 
-    public static final native long createRSAPrivateCrtKey(byte[] n,
-                                                           int nLen,
-                                                           byte[] d,
-                                                           int dLen,
-                                                           byte[] e,
-                                                           int eLen,
-                                                           byte[] p,
-                                                           int pLen,
-                                                           byte[] q,
-                                                           int qLen,
-                                                           byte[] dp,
-                                                           int dpLen,
-                                                           byte[] dq,
-                                                           int dqLen,
-                                                           byte[] qinv,
-                                                           int qinvLen);
+    public final native long createRSAPrivateCrtKey(byte[] n,
+                                                    int nLen,
+                                                    byte[] d,
+                                                    int dLen,
+                                                    byte[] e,
+                                                    int eLen,
+                                                    byte[] p,
+                                                    int pLen,
+                                                    byte[] q,
+                                                    int qLen,
+                                                    byte[] dp,
+                                                    int dpLen,
+                                                    byte[] dq,
+                                                    int dqLen,
+                                                    byte[] qinv,
+                                                    int qinvLen);
 
-    public static final native void destroyRSAKey(long key);
+    public final native void destroyRSAKey(long key);
 
-    public static final native int RSADP(byte[] k,
-                                         int kLen,
-                                         byte[] m,
-                                         int verify,
-                                         long RSAPrivateCrtKey);
+    public final native int RSADP(byte[] k,
+                                  int kLen,
+                                  byte[] m,
+                                  int verify,
+                                  long RSAPrivateCrtKey);
 
-    public static final native int RSAEP(byte[] k,
-                                         int kLen,
-                                         byte[] m,
-                                         long RSAPublicKey);
+    public final native int RSAEP(byte[] k,
+                                  int kLen,
+                                  byte[] m,
+                                  long RSAPublicKey);
 
 }

--- a/closed/src/java.base/share/classes/sun/security/provider/NativeDigest.java
+++ b/closed/src/java.base/share/classes/sun/security/provider/NativeDigest.java
@@ -55,6 +55,12 @@ abstract class NativeDigest extends MessageDigestSpi implements Cloneable {
     //  0: is already reset
     private long bytesProcessed;
 
+    private static NativeCrypto nativeCrypto;
+
+    static {
+        nativeCrypto = NativeCrypto.getNativeCrypto();
+    }
+
     /**
      * Main constructor.
      */
@@ -63,7 +69,7 @@ abstract class NativeDigest extends MessageDigestSpi implements Cloneable {
         this.algorithm = algorithm;
         this.digestLength = digestLength;
         this.algIndx = algIndx;
-        this.context = NativeCrypto.DigestCreateContext(0, algIndx);
+        this.context = nativeCrypto.DigestCreateContext(0, algIndx);
     }
 
     // return digest length. See JCA doc.
@@ -94,7 +100,7 @@ abstract class NativeDigest extends MessageDigestSpi implements Cloneable {
 
         bytesProcessed += len;
 
-        NativeCrypto.DigestUpdate(context, b, ofs, len);
+        nativeCrypto.DigestUpdate(context, b, ofs, len);
     }
 
     // reset this object. See JCA doc.
@@ -104,7 +110,7 @@ abstract class NativeDigest extends MessageDigestSpi implements Cloneable {
             return;
         }
 
-        NativeCrypto.DigestReset(context);
+        nativeCrypto.DigestReset(context);
         bytesProcessed = 0;
     }
 
@@ -135,7 +141,7 @@ abstract class NativeDigest extends MessageDigestSpi implements Cloneable {
             throw new DigestException("Buffer too short to store digest");
         }
 
-        NativeCrypto.DigestComputeAndReset(context, null, 0, 0, out, ofs, len);
+        nativeCrypto.DigestComputeAndReset(context, null, 0, 0, out, ofs, len);
 
         bytesProcessed = 0;
         return digestLength;
@@ -143,7 +149,7 @@ abstract class NativeDigest extends MessageDigestSpi implements Cloneable {
 
     public Object clone() throws CloneNotSupportedException {
         NativeDigest copy = (NativeDigest) super.clone();
-        copy.context    = NativeCrypto.DigestCreateContext(context, algIndx);
+        copy.context    = nativeCrypto.DigestCreateContext(context, algIndx);
         return copy;
     }
 
@@ -152,6 +158,6 @@ abstract class NativeDigest extends MessageDigestSpi implements Cloneable {
      */
     @Override
     public void finalize() {
-        NativeCrypto.DigestDestroyContext(context);
+        nativeCrypto.DigestDestroyContext(context);
     }
 }

--- a/closed/src/java.base/share/classes/sun/security/rsa/NativeRSACore.java
+++ b/closed/src/java.base/share/classes/sun/security/rsa/NativeRSACore.java
@@ -57,6 +57,12 @@ import sun.security.jca.JCAUtil;
  */
 public final class NativeRSACore {
 
+    private static NativeCrypto nativeCrypto;
+
+    static {
+        nativeCrypto = NativeCrypto.getNativeCrypto();
+    }
+
     /**
      * Return the number of bytes required to store the magnitude byte[] of
      * this BigInteger. Do not count a 0x00 byte toByteArray() would
@@ -100,7 +106,7 @@ public final class NativeRSACore {
         BigInteger n = key.getModulus();
         byte[] output = new byte[getByteLength(n)];
 
-        int outputLen = NativeCrypto.RSAEP(msg, msg.length, output, nativePtr);
+        int outputLen = nativeCrypto.RSAEP(msg, msg.length, output, nativePtr);
 
         if (outputLen == -1) {
             return null;
@@ -131,7 +137,7 @@ public final class NativeRSACore {
             verifyInt = -1;
         }
 
-        outputLen = NativeCrypto.RSADP(msg, msg.length, output, verifyInt, nativePtr);
+        outputLen = nativeCrypto.RSADP(msg, msg.length, output, verifyInt, nativePtr);
 
         if (outputLen == -1) {
             return null;

--- a/src/java.base/share/classes/sun/security/rsa/RSAPrivateCrtKeyImpl.java
+++ b/src/java.base/share/classes/sun/security/rsa/RSAPrivateCrtKeyImpl.java
@@ -77,6 +77,12 @@ public final class RSAPrivateCrtKeyImpl
     // Must be null for "RSA" keys.
     private AlgorithmParameterSpec keyParams;
 
+    private static NativeCrypto nativeCrypto;
+
+    static {
+        nativeCrypto = NativeCrypto.getNativeCrypto();
+    }
+
     /**
      * Generate a new key from its encoding. Returns a CRT key if possible
      * and a non-CRT key otherwise. Used by RSAKeyFactory.
@@ -270,7 +276,7 @@ public final class RSAPrivateCrtKeyImpl
         byte[] dQ_2c   = dQ.toByteArray();
         byte[] qInv_2c = qInv.toByteArray();
 
-        nativeRSAKey = NativeCrypto.createRSAPrivateCrtKey(n_2c,n_2c.length, d_2c, d_2c.length, e_2c, e_2c.length,
+        nativeRSAKey = nativeCrypto.createRSAPrivateCrtKey(n_2c,n_2c.length, d_2c, d_2c.length, e_2c, e_2c.length,
                 p_2c, p_2c.length, q_2c, q_2c.length,
                 dP_2c, dP_2c.length, dQ_2c, dQ_2c.length, qInv_2c, qInv_2c.length);
         return nativeRSAKey;
@@ -279,7 +285,7 @@ public final class RSAPrivateCrtKeyImpl
     @Override
     public void finalize() {
         if (nativeRSAKey != 0x0 && nativeRSAKey != -1) {
-            NativeCrypto.destroyRSAKey(nativeRSAKey);
+            nativeCrypto.destroyRSAKey(nativeRSAKey);
         }
     }
 

--- a/src/java.base/share/classes/sun/security/rsa/RSAPublicKeyImpl.java
+++ b/src/java.base/share/classes/sun/security/rsa/RSAPublicKeyImpl.java
@@ -69,6 +69,12 @@ public final class RSAPublicKeyImpl extends X509Key implements RSAPublicKey {
     // must be null for "RSA" keys.
     private AlgorithmParameterSpec keyParams;
 
+    private static NativeCrypto nativeCrypto;
+
+    static {
+        nativeCrypto = nativeCrypto.getNativeCrypto();
+    }
+
     /**
      * Generate a new RSAPublicKey from the specified encoding.
      * Used by SunPKCS11 provider.
@@ -228,14 +234,14 @@ public final class RSAPublicKeyImpl extends X509Key implements RSAPublicKey {
         byte[] n_2c = n.toByteArray();
         byte[] e_2c = e.toByteArray();
 
-        nativeRSAKey = NativeCrypto.createRSAPublicKey(n_2c,n_2c.length, e_2c, e_2c.length);
+        nativeRSAKey = nativeCrypto.createRSAPublicKey(n_2c,n_2c.length, e_2c, e_2c.length);
         return nativeRSAKey;
     }
 
     @Override
     public void finalize() {
         if (nativeRSAKey != 0x0 && nativeRSAKey != -1) {
-           NativeCrypto.destroyRSAKey(nativeRSAKey);
+           nativeCrypto.destroyRSAKey(nativeRSAKey);
         }
     }
 }


### PR DESCRIPTION
NativeCrypto.java now needs to be initialized (through NativeCrypto.getNativeCrypto()) first before accessing JNI functions.