### PR TITLE
Add dependency in Main.mk to support the generation of jvmti.h

### DIFF
--- a/closed/make/Main.gmk
+++ b/closed/make/Main.gmk
@@ -41,9 +41,9 @@ OPENSSL_MAKE := $(MAKE) -f $(TOPDIR)/closed/openssl.gmk SPEC=$(SPEC)
 openssl-build : buildtools-langtools
 	+$(OPENSSL_MAKE)
 
-java.base-copy : openssl-build
+java.base-copy : j9vm-build
 
-java.base-libs : java.base-copy j9vm-build
+java.base-libs : java.base-copy
 
 j9vm-build : openssl-build
 	+$(OPENJ9_MAKE) openj9_build_jdk

--- a/closed/make/copy/Copy-java.base.gmk
+++ b/closed/make/copy/Copy-java.base.gmk
@@ -23,7 +23,7 @@ TARGETS += \
 	$(INCLUDE_TARGET_DIR)/ibmjvmti.h \
 	#
 
-$(INCLUDE_TARGET_DIR)/jvmti.h : $(TOPDIR)/openj9/runtime/include/jvmti.h
+$(INCLUDE_TARGET_DIR)/jvmti.h : $(OUTPUTDIR)/vm/include/jvmti.h
 	$(call install-file)
 
 $(INCLUDE_TARGET_DIR)/ibmjvmti.h : $(TOPDIR)/openj9/runtime/include/ibmjvmti.h


### PR DESCRIPTION
Add dependency in Main.mk to support the generation of jvmti.h

Generating jvmti.h before initialization of macros in Main.mk.

There are some additional information:
- The related issue is https://github.com/eclipse/openj9/issues/2368
- Add dependency in Main.mk to support the generation of jvmti.h before it starts to build openj9

Signed-off-by: MarkQingGuo <Qing.Guo@ibm.com>