### PR TITLE
Turn off native digest

### DIFF
--- a/src/java.base/share/classes/sun/security/provider/SunEntries.java
+++ b/src/java.base/share/classes/sun/security/provider/SunEntries.java
@@ -94,7 +94,7 @@ final class SunEntries {
      * and 'jdk.nativeCrypto' is used to disable all native cryptos (Digest,
      * CBC, GCM, and RSA).
      */
-    private static boolean useNativeDigest = true;
+    private static boolean useNativeDigest = false;
 
     private SunEntries() {
         // empty


### PR DESCRIPTION
This change will disable OpenSSL based accelerated Digest, it cannot be re-enabled with the command line option. This was done due to a segfault under some conditions when the Digest is invoked. https://github.com/eclipse/openj9/issues/4530
