### PR TITLE
Stop adding j9jit29 when the target CPU is aarch64

### DIFF
--- a/closed/OpenJ9.gmk
+++ b/closed/OpenJ9.gmk
@@ -198,7 +198,6 @@ $(call openj9_add_jdk_shlibs, java.base, \
 	j9gc29 \
 	j9gcchk29 \
 	j9hookable29 \
-	j9jit29 \
 	j9jnichk29 \
 	j9jvmti29 \
 	j9prt29 \
@@ -211,6 +210,10 @@ $(call openj9_add_jdk_shlibs, java.base, \
 	jclse11_29 \
 	omrsig \
 	)
+
+ifneq (aarch64,$(OPENJDK_TARGET_CPU))
+  $(call openj9_add_jdk_shlibs, java.base, j9jit29)
+endif
 
 ifeq (windows,$(OPENJDK_TARGET_OS))
   $(call openj9_add_jdk_lib, java.base, lib/$(call STATIC_LIBRARY,jsig))


### PR DESCRIPTION
This commit stops adding j9jit29 to java.base shlibs when the target
CPU is aarch64.
This is a temporary change until the JIT library for aarch64 becomes
available.

Signed-off-by: knn-k <konno@jp.ibm.com>