### PR TITLE
Remove IBM Copyrights as OpenJDK merged fixes

### DIFF
--- a/src/java.base/share/classes/sun/security/ssl/ClientHandshakeContext.java
+++ b/src/java.base/share/classes/sun/security/ssl/ClientHandshakeContext.java
@@ -22,11 +22,6 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-/*
- * ===========================================================================
- * (c) Copyright IBM Corp. 2019, 2019 All Rights Reserved.
- * ===========================================================================
- */
 
 package sun.security.ssl;
 

--- a/src/java.base/share/classes/sun/security/ssl/NewSessionTicket.java
+++ b/src/java.base/share/classes/sun/security/ssl/NewSessionTicket.java
@@ -22,11 +22,6 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-/*
- * ===========================================================================
- * (c) Copyright IBM Corp. 2018, 2018 All Rights Reserved
- * ===========================================================================
- */
 package sun.security.ssl;
 
 import java.io.IOException;

--- a/src/java.base/share/classes/sun/security/ssl/PreSharedKeyExtension.java
+++ b/src/java.base/share/classes/sun/security/ssl/PreSharedKeyExtension.java
@@ -22,11 +22,6 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-/*
- * ===========================================================================
- * (c) Copyright IBM Corp. 2018, 2019 All Rights Reserved
- * ===========================================================================
- */
 package sun.security.ssl;
 
 import java.io.IOException;

--- a/src/java.base/share/classes/sun/security/ssl/SSLSessionImpl.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLSessionImpl.java
@@ -22,11 +22,6 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-/*
- * ===========================================================================
- * (c) Copyright IBM Corp. 2018, 2019 All Rights Reserved
- * ===========================================================================
- */
 package sun.security.ssl;
 
 import java.math.BigInteger;

--- a/test/jdk/sun/security/ssl/SSLSessionImpl/ResumeChecksClient.java
+++ b/test/jdk/sun/security/ssl/SSLSessionImpl/ResumeChecksClient.java
@@ -20,11 +20,6 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-/*
- * ===========================================================================
- * (c) Copyright IBM Corp. 2018, 2018 All Rights Reserved
- * ===========================================================================
- */
 
 /*
  * @test


### PR DESCRIPTION
Remove IBM Copyrights as OpenJDK merged fixes now backported and no patch exists

Signed-off-by: andrew-m-leonard <andrew_m_leonard@uk.ibm.com>