### PR TITLE
Backporting OpenJDK fix JDK-8220782

### DIFF
--- a/src/java.base/share/classes/sun/security/provider/PolicyFile.java
+++ b/src/java.base/share/classes/sun/security/provider/PolicyFile.java
@@ -30,6 +30,7 @@ import java.lang.reflect.*;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URI;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.*;
 import java.security.*;
@@ -37,7 +38,6 @@ import java.security.cert.Certificate;
 import java.security.cert.X509Certificate;
 import javax.security.auth.Subject;
 import javax.security.auth.x500.X500Principal;
-import java.io.FilePermission;
 import java.net.SocketPermission;
 import java.net.NetPermission;
 import java.util.concurrent.ConcurrentHashMap;
@@ -273,23 +273,6 @@ public class PolicyFile extends java.security.Policy {
     private static Set<URL> badPolicyURLs =
         Collections.newSetFromMap(new ConcurrentHashMap<URL,Boolean>());
 
-    // The default.policy file
-    private static final URL DEFAULT_POLICY_URL =
-        AccessController.doPrivileged(new PrivilegedAction<>() {
-            @Override
-            public URL run() {
-                String sep = File.separator;
-                try {
-                    return Path.of(StaticProperty.javaHome(),
-                                     "lib", "security",
-                                     "default.policy").toUri().toURL();
-                } catch (MalformedURLException mue) {
-                    // should not happen
-                    throw new Error("Malformed default.policy URL: " + mue);
-                }
-            }
-        });
-
     /**
      * Initializes the Policy object and reads the default policy
      * configuration file(s) into the Policy object.
@@ -349,13 +332,10 @@ public class PolicyFile extends java.security.Policy {
     private void initPolicyFile(final PolicyInfo newInfo, final URL url) {
 
         // always load default.policy
-        if (debug != null) {
-            debug.println("reading " + DEFAULT_POLICY_URL);
-        }
         AccessController.doPrivileged(new PrivilegedAction<>() {
             @Override
             public Void run() {
-                init(DEFAULT_POLICY_URL, newInfo, true);
+                initDefaultPolicy(newInfo);
                 return null;
             }
         });
@@ -373,7 +353,7 @@ public class PolicyFile extends java.security.Policy {
             AccessController.doPrivileged(new PrivilegedAction<>() {
                 @Override
                 public Void run() {
-                    if (init(url, newInfo, false) == false) {
+                    if (init(url, newInfo) == false) {
                         // use static policy if all else fails
                         initStaticPolicy(newInfo);
                     }
@@ -429,7 +409,7 @@ public class PolicyFile extends java.security.Policy {
                             if (debug != null) {
                                 debug.println("reading "+policyURL);
                             }
-                            if (init(policyURL, newInfo, false)) {
+                            if (init(policyURL, newInfo)) {
                                 loaded_policy = true;
                             }
                         } catch (Exception e) {
@@ -472,7 +452,7 @@ public class PolicyFile extends java.security.Policy {
                         if (debug != null) {
                             debug.println("reading " + policy_url);
                         }
-                        if (init(policy_url, newInfo, false)) {
+                        if (init(policy_url, newInfo)) {
                             loaded_policy = true;
                         }
                     } catch (Exception e) {
@@ -492,11 +472,34 @@ public class PolicyFile extends java.security.Policy {
         return loadedPolicy;
     }
 
+    private void initDefaultPolicy(PolicyInfo newInfo) {
+        Path defaultPolicy = Path.of(StaticProperty.javaHome(),
+                                     "lib",
+                                     "security",
+                                     "default.policy");
+        if (debug != null) {
+            debug.println("reading " + defaultPolicy);
+        }
+        try (BufferedReader br = Files.newBufferedReader(defaultPolicy)) {
+
+            PolicyParser pp = new PolicyParser(expandProperties);
+            pp.read(br);
+
+            Enumeration<PolicyParser.GrantEntry> enum_ = pp.grantElements();
+            while (enum_.hasMoreElements()) {
+                PolicyParser.GrantEntry ge = enum_.nextElement();
+                addGrantEntry(ge, null, newInfo);
+            }
+        } catch (Exception e) {
+            throw new InternalError("Failed to load default.policy", e);
+        }
+    }
+
     /**
      * Reads a policy configuration into the Policy object using a
      * Reader object.
      */
-    private boolean init(URL policy, PolicyInfo newInfo, boolean defPolicy) {
+    private boolean init(URL policy, PolicyInfo newInfo) {
 
         // skip parsing policy file if it has been previously parsed and
         // has syntax errors
@@ -537,9 +540,6 @@ public class PolicyFile extends java.security.Policy {
             }
             return true;
         } catch (PolicyParser.ParsingException pe) {
-            if (defPolicy) {
-                throw new InternalError("Failed to load default.policy", pe);
-            }
             // record bad policy file to avoid later reparsing it
             badPolicyURLs.add(policy);
             Object[] source = {policy, pe.getNonlocalizedMessage()};
@@ -549,9 +549,6 @@ public class PolicyFile extends java.security.Policy {
                 pe.printStackTrace();
             }
         } catch (Exception e) {
-            if (defPolicy) {
-                throw new InternalError("Failed to load default.policy", e);
-            }
             if (debug != null) {
                 debug.println("error parsing "+policy);
                 debug.println(e.toString());


### PR DESCRIPTION
Defined as the fix for "Program fails when using JDK addressed by
UNC path and using Security Manager"

This will be contributed to OpenJDK shortly.

Signed-off-by: Adam Farley <adam.farley@uk.ibm.com>