### PR TITLE
Fix bug when building with cmake and ccache enabled

### DIFF
--- a/closed/OpenJ9.gmk
+++ b/closed/OpenJ9.gmk
@@ -454,14 +454,47 @@ ifneq (,$(OPENJ9_DEVELOPER_DIR))
 endif
 
 ifeq (true,$(OPENJ9_ENABLE_CMAKE))
+CMAKE_ARGS :=
+
+# We grab the C/C++ compilers detected by autoconf or provided by user, not
+# the CC/CXX variables defined by the makefiles, which potentially include
+# the ccache command which will throw off cmake.
+ifneq (,$(OPENJ9_CC))
+  CMAKE_ARGS += "-DCMAKE_C_COMPILER=$(OPENJ9_CC)"
+else
+  CMAKE_ARGS += "-DCMAKE_C_COMPILER=$(ac_cv_prog_CC)"
+endif
+
+ifneq (,$(OPENJ9_CXX))
+  CMAKE_ARGS += "-DCMAKE_CXX_COMPILER=$(OPENJ9_CXX)"
+else
+  CMAKE_ARGS += "-DCMAKE_CXX_COMPILER=$(ac_cv_prog_CXX)"
+endif
+
+ifneq (,$(CCACHE))
+  # openjdk makefiles adds a bunch of environemnt variables to the ccache command.
+  # CMake will not parse this properly, so we wrap the whole thing in the env command.
+  # We also need to add semicolons between arguments or else cmake will treat the whole
+  # thing as one long command name.
+
+  # Note: we remove the CCACHE_COMPRESS option that openjdk adds, because it significantly
+  # slows down the build (to the point of erasing any gains from using ccache).
+  CCACHE_NOCOMPRESS := $(filter-out CCACHE_COMPRESS=1,$(CCACHE))
+  ESCAPED_CCACHE := env$(subst $(SPACE),,$(addprefix ;,$(CCACHE_NOCOMPRESS)))
+
+  CMAKE_ARGS += "-DCMAKE_CXX_COMPILER_LAUNCHER=$(ESCAPED_CCACHE)"
+  CMAKE_ARGS += "-DCMAKE_C_COMPILER_LAUNCHER=$(ESCAPED_CCACHE)"
+endif
 $(OUTPUTDIR)/vm/cmake.stamp :
 	cd $(OUTPUTDIR)/vm && \
 	$(CMAKE) \
-	  -C $(OPENJ9_TOPDIR)/runtime/cmake/caches/$(OPENJ9_BUILDSPEC).cmake \
+		-C $(OPENJ9_TOPDIR)/runtime/cmake/caches/$(OPENJ9_BUILDSPEC).cmake \
+		$(CMAKE_ARGS) \
 		-DJ9VM_OMR_DIR=$(OPENJ9OMR_TOPDIR) \
 		-DBUILD_ID=$(BUILD_ID) \
 		-DJAVA_SPEC_VERSION=$(VERSION_MAJOR) \
 		-DOPENJ9_BUILD=true \
+		$(EXTRA_CMAKE_ARGS) \
 		$(OPENJ9_TOPDIR)
 	touch $(OUTPUTDIR)/vm/cmake.stamp
 


### PR DESCRIPTION
This is a direct port of the fix for the same issue that was applied in
openj9 to buildtools.mk. However since cmake builds no longer go through
buildtools.mk it needs to be moved up here

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>