### PR TITLE
Downgrade NASM requirement to version 2.11 on x86

### DIFF
--- a/closed/autoconf/custom-hook.m4
+++ b/closed/autoconf/custom-hook.m4
@@ -323,13 +323,14 @@ AC_DEFUN_ONCE([OPENJ9_CHECK_NASM_VERSION],
     if test "x$NASM_INSTALLED" = xyes ; then
       AC_MSG_CHECKING([whether nasm version requirement is met])
       
-      # Require NASM v2.13+. This is checked by trying to build conftest.c
-      # containing an AVX512 instruction that is supported in v2.13+
-      AC_LANG_CONFTEST([AC_LANG_SOURCE([vinserti32x8 zmm0, ymm1, 1;])])
+      # Require NASM v2.11+. This is checked by trying to build conftest.c
+      # containing an instruction that makes use of zmm registers that are
+      # supported on NASM v2.11+
+      AC_LANG_CONFTEST([AC_LANG_SOURCE([vdivpd zmm0, zmm1, zmm3;])])
 
       # the following hack is needed because conftest.c contains C preprocessor
       # directives defined in confdefs.h that would cause nasm to error out
-      $SED -i -e '/vinsert/!d' conftest.c
+      $SED -i -e '/vdivpd/!d' conftest.c
 
       if nasm -f elf64 conftest.c 2> /dev/null ; then
         AC_MSG_RESULT([yes])
@@ -343,7 +344,7 @@ AC_DEFUN_ONCE([OPENJ9_CHECK_NASM_VERSION],
         # NASM_VERSION is set within square brackets so that the sed expression would not
         # require quadrigraps to represent square brackets
         [NASM_VERSION=`nasm -v | $SED -e 's/^.* \([2-9]\.[0-9][0-9]\.[0-9][0-9]\).*$/\1/'`]
-        AC_MSG_ERROR([nasm version detected: $NASM_VERSION; required version 2.13+])
+        AC_MSG_ERROR([nasm version detected: $NASM_VERSION; required version 2.11+])
       fi
     else
       AC_MSG_ERROR([nasm not found])


### PR DESCRIPTION
This is done to continue supporting building using NASM v2.11. #163 Set the requirement to NASM 2.13+, which is not necessary as AVX512 instructions are not being used at this time.

Signed-off-by: Nazim Uddin Bhuiyan <Nazim.Uddin.Bhuiyan@ibm.com>