### PR TITLE
Create thread in SystemThreadGroup and not inherit ThreadLocals

### DIFF
--- a/closed/src/java.base/share/classes/java/io/ClassCache.java
+++ b/closed/src/java.base/share/classes/java/io/ClassCache.java
@@ -1,6 +1,6 @@
 /*
 * ===========================================================================
-* (c) Copyright IBM Corp. 2017, 2018 All Rights Reserved
+* (c) Copyright IBM Corp. 2017, 2019 All Rights Reserved
 * ===========================================================================
  * 
  * This code is free software; you can redistribute it and/or modify it
@@ -209,25 +209,24 @@ final class ClassCache {
         }
 
         public Thread run() {
-            return new Reaper(cache, queue);
+            Reaper reaper = new Reaper(cache, queue);
+            return com.ibm.oti.vm.VM.getVMLangAccess().createThread(reaper, "ClassCache Reaper", true, false, true, null);
         }
     }
 
-    private static final class Reaper extends Thread {
+    private static final class Reaper implements Runnable {
         private final WeakReference<ClassCache> cacheRef;
         private final ReferenceQueue<Object> queue;
 
         Reaper(ClassCache cache, ReferenceQueue<Object> queue) {
-            super("ClassCache Reaper");
             this.queue = queue;
             cacheRef = new WeakReference<ClassCache>(cache, queue);
-            setDaemon(true);
-            setContextClassLoader(null);
         }
-/*
- * Blocks on remove() on queur reference and calls processStaleRef() when any loader is removed.(non-Javadoc)
- * @see java.lang.Thread#run()
- */
+
+        /*
+         * Blocks on remove() on queur reference and calls processStaleRef() when any loader is removed.(non-Javadoc)
+         * @see java.lang.Thread#run()
+         */
         public void run() {
             Object staleRef = null;
             do {

--- a/src/java.base/share/classes/java/io/ObjectInputStream.java
+++ b/src/java.base/share/classes/java/io/ObjectInputStream.java
@@ -25,7 +25,7 @@
 
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2018,2018 All Rights Reserved
+ * (c) Copyright IBM Corp. 2018, 2019 All Rights Reserved
  * ===========================================================================
  */
 
@@ -327,12 +327,11 @@ public class ObjectInputStream
      */
 
       /* ClassCache Entry for caching class.forName results upon enableClassCaching */
-     private static final ClassCache classCache;
+     private static ClassCache classCache = null;
      private static final boolean isClassCachingEnabled;
      static {
           isClassCachingEnabled =
              AccessController.doPrivileged(new GetClassCachingSettingAction());
-         classCache = (isClassCachingEnabled ? new ClassCache() : null);
      }
   
 
@@ -793,10 +792,19 @@ public class ObjectInputStream
     {
         String name = desc.getName();
         try {
-        	return ((classCache == null) ?
-        	        Class.forName(name, false, latestUserDefinedLoader()) :
-        	        classCache.get(name, cachedLudcl));
-           	
+        	Class<?> clzRet;
+        	if (isClassCachingEnabled) {
+        		if (classCache == null) {
+        			/* In case there are multiple threads attempting to create ClassCache,
+        			 * the class created last stays and others are discarded.
+        			 */
+        			classCache = new ClassCache();
+        		}
+        		clzRet = classCache.get(name, cachedLudcl);
+        	} else {
+        		clzRet = Class.forName(name, false, latestUserDefinedLoader());
+        	}
+        	return clzRet;
         } catch (ClassNotFoundException ex) {
             Class<?> cl = primClasses.get(name);
             if (cl != null) {


### PR DESCRIPTION
Create thread in `SystemThreadGroup` and not inherit `ThreadLocals`

Created the thread via `com.ibm.oti.vm.VM.getVMLangAccess().createThread()`.
This thread is expected to be alive along with `JVM` hence belongs to the system thread group.
This thread doesn't need inherit `ThreadLocals` and avoid copying `ThreadLocals` which causes `NPE` in some use scenarios.

Verified that this fixes https://github.com/eclipse/openj9/issues/5726.

Depends on: https://github.com/eclipse/openj9/pull/5778
issue: https://github.com/eclipse/openj9/issues/5726

Note: will create PRs for `Java 8/12/13` if this is approved.

Reviewer: @pshipton 
FYI: @DanHeidinga 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>