### PR TITLE
(v0.14.2) Disable openssl native crypto for MessageDigest

### DIFF
--- a/src/java.base/share/classes/sun/security/provider/SunEntries.java
+++ b/src/java.base/share/classes/sun/security/provider/SunEntries.java
@@ -89,12 +89,13 @@ final class SunEntries {
 
     /*
      * Check whether native crypto is enabled with property.
-     * By default, the native crypto is enabled  and uses native library crypto.
-     * The property 'jdk.nativeDigest' is used to disable Native digest alone
-     * and 'jdk.nativeCrypto' is used to disable all native cryptos (Digest,
+     * By default, the native crypto is enabled and uses native library crypto.
+     * The native crypto for MessageDigest is disabled until
+     * https://github.com/eclipse/openj9/issues/5611 can be resolved.
+     * The property 'jdk.nativeCrypto' is used to disable all native cryptos (Digest,
      * CBC, GCM, and RSA).
      */
-    private static boolean useNativeDigest = true;
+    private static boolean useNativeDigest = false;
 
     private SunEntries() {
         // empty


### PR DESCRIPTION
Avoid problems such as https://github.com/eclipse/openj9/issues/5611

Doc issue https://github.com/eclipse/openj9-docs/issues/269

Signed-off-by: Peter Shipton <Peter_Shipton@ca.ibm.com>