### PR TITLE
Include nativevmargs test executable for ignoring blank options

### DIFF
--- a/closed/OpenJ9.gmk
+++ b/closed/OpenJ9.gmk
@@ -268,6 +268,7 @@ $(foreach file, \
 		glaunch \
 		invtest \
 		jsigjnitest \
+		nativevmargs \
 		pltest \
 		propstest \
 		shrtest \


### PR DESCRIPTION
Extensions change for PR: https://github.com/eclipse/openj9/pull/6090

Signed-off-by: Sharon Wang <sharon-wang-cpsc@outlook.com>