### PR TITLE
NativeDigest context free via Cleaner API

### DIFF
--- a/closed/src/java.base/share/classes/sun/security/provider/NativeDigest.java
+++ b/closed/src/java.base/share/classes/sun/security/provider/NativeDigest.java
@@ -38,6 +38,8 @@ import java.security.ProviderException;
 import static sun.security.provider.ByteArrayAccess.*;
 
 import jdk.crypto.jniprovider.NativeCrypto;
+import jdk.internal.ref.CleanerFactory;
+import java.lang.ref.Cleaner;
 
 abstract class NativeDigest extends MessageDigestSpi implements Cloneable {
 
@@ -55,10 +57,25 @@ abstract class NativeDigest extends MessageDigestSpi implements Cloneable {
     //  0: is already reset
     private long bytesProcessed;
 
-    private static NativeCrypto nativeCrypto;
+    private static final NativeCrypto nativeCrypto;
+    private static final Cleaner digestCleaner;
 
     static {
         nativeCrypto = NativeCrypto.getNativeCrypto();
+        digestCleaner = CleanerFactory.cleaner();
+    }
+
+    private static final class DigestCleanerRunnable implements Runnable {
+        private final long digestCtx;
+        
+        public DigestCleanerRunnable(long context) {
+            this.digestCtx = context;
+        }
+        
+        @Override
+        public void run() {
+            nativeCrypto.DigestDestroyContext(digestCtx);
+        }
     }
 
     /**
@@ -70,10 +87,12 @@ abstract class NativeDigest extends MessageDigestSpi implements Cloneable {
         this.digestLength = digestLength;
         this.algIndx = algIndx;
         this.context = nativeCrypto.DigestCreateContext(0, algIndx);
+
         if (this.context == -1) {
             throw new ProviderException("Error in Native Digest");
         }
 
+        digestCleaner.register(this, new DigestCleanerRunnable(this.context));
     }
 
     // return digest length. See JCA doc.
@@ -161,18 +180,13 @@ abstract class NativeDigest extends MessageDigestSpi implements Cloneable {
 
     synchronized public Object clone() throws CloneNotSupportedException {
         NativeDigest copy = (NativeDigest) super.clone();
-        copy.context    = nativeCrypto.DigestCreateContext(context, algIndx);
+        copy.context = nativeCrypto.DigestCreateContext(context, algIndx);
+
         if (copy.context == -1) {
             throw new ProviderException("Error in Native Digest");
         }
-        return copy;
-    }
 
-    /*
-     * Finalize method to release the Digest contexts.
-     */
-    @Override
-    public void finalize() {
-        nativeCrypto.DigestDestroyContext(context);
+        digestCleaner.register(copy, new DigestCleanerRunnable(copy.context));
+        return copy;
     }
 }

--- a/src/java.base/share/classes/sun/security/provider/SunEntries.java
+++ b/src/java.base/share/classes/sun/security/provider/SunEntries.java
@@ -90,12 +90,11 @@ final class SunEntries {
     /*
      * Check whether native crypto is enabled with property.
      * By default, the native crypto is enabled and uses native library crypto.
-     * The native crypto for MessageDigest is disabled until
-     * https://github.com/eclipse/openj9/issues/5611 can be resolved.
-     * The property 'jdk.nativeCrypto' is used to disable all native cryptos (Digest,
+     * The property 'jdk.nativeDigest' is used to disable Native digest alone
+     * and 'jdk.nativeCrypto' is used to disable all native cryptos (Digest,
      * CBC, GCM, RSA, and ChaCha20).
      */
-    private static boolean useNativeDigest = false;
+    private static boolean useNativeDigest = true;
 
     private SunEntries() {
         // empty


### PR DESCRIPTION
due to issues such as eclipse/openj9#5611 removed the native context de-allocation via a finalizer. Introduced the use of PhantomReferences to control when the native digest context can be de-allocated.

The cleanup stage happens when the reference array is fully used, at which point there is an attempted clean-up by examining the ReferenceQueue which will de-allocate the native contexts and also free up space in the reference array.

Signed-off-by: Alon Shalev Housfater <alonsh@ca.ibm.com>