### PR TITLE
Add permissions required by module jdk.attach

### DIFF
--- a/src/java.base/share/lib/security/default.policy
+++ b/src/java.base/share/lib/security/default.policy
@@ -103,6 +103,19 @@ grant codeBase "jrt:/jdk.accessibility" {
     permission java.lang.RuntimePermission "accessClassInPackage.sun.awt";
 };
 
+grant codeBase "jrt:/jdk.attach" {
+    permission java.lang.RuntimePermission "accessClassInPackage.com.ibm.oti.util";
+    permission java.lang.RuntimePermission "accessClassInPackage.com.ibm.tools.attach.target";
+    permission java.lang.RuntimePermission "accessClassInPackage.openj9.tools.attach.diagnostics.base";
+    permission java.util.PropertyPermission "com.ibm.tools.attach.*", "read";
+    // required by com.ibm.tools.attach.attacher.OpenJ9AttachProvider.listVirtualMachinesImp():commonDir.exists(),
+    // com.ibm.tools.attach.target.Reply.writeReply():new RandomAccessFile(replyFile, "rw"),
+    // and com.ibm.tools.attach.target.Reply.deleteReply():replyFile.delete()
+    permission java.io.FilePermission "<<ALL FILES>>", "read,write,delete";
+    // required by com.ibm.tools.attach.attacher.OpenJ9VirtualMachine.tryAttachTarget():targetServer.accept()
+    permission java.net.SocketPermission "localhost:1024-", "accept,resolve";
+};
+
 grant codeBase "jrt:/jdk.charsets" {
     permission java.util.PropertyPermission "os.name", "read";
     permission java.util.PropertyPermission "sun.nio.cs.map", "read";


### PR DESCRIPTION
#### Add permissions required by module jdk.attach ####

Added following permissions:
```
    permission java.lang.RuntimePermission "accessClassInPackage.com.ibm.tools.attach.target";
    permission java.lang.RuntimePermission "accessClassInPackage.com.ibm.oti.util";
    permission java.util.PropertyPermission "com.ibm.tools.attach.*", "read";
    permission java.io.FilePermission "<<ALL FILES>>", "read,write,delete";
    permission java.net.SocketPermission "127.0.0.1", "accept,resolve";
```
Note: will port this to later JDK level extensions if this is approved.

Related: https://github.com/eclipse/openj9/pull/6263

Reviewer: @pshipton 
FYI: @DanHeidinga 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>