### PR TITLE
Put AArch64 j9jit29 back in java.base

### DIFF
--- a/closed/OpenJ9.gmk
+++ b/closed/OpenJ9.gmk
@@ -197,6 +197,7 @@ $(call openj9_add_jdk_shlibs, java.base, \
 	j9gc29 \
 	j9gcchk29 \
 	j9hookable29 \
+	j9jit29 \
 	j9jnichk29 \
 	j9jvmti29 \
 	j9prt29 \
@@ -210,10 +211,6 @@ $(call openj9_add_jdk_shlibs, java.base, \
 	jvm \
 	omrsig \
 	)
-
-ifneq (aarch64,$(OPENJDK_TARGET_CPU))
-  $(call openj9_add_jdk_shlibs, java.base, j9jit29)
-endif
 
 ifeq (windows,$(OPENJDK_TARGET_OS))
   $(call openj9_add_jdk_lib, java.base, lib/$(call STATIC_LIBRARY,jsig))


### PR DESCRIPTION
This commit stops excluding j9jit29 in java.base when the target CPU is
aarch64.  It is to revert the temporary change in #126.

Signed-off-by: knn-k <konno@jp.ibm.com>