### PR TITLE
Update configure scripts for RISC-V (closed)

### DIFF
--- a/closed/OpenJ9.gmk
+++ b/closed/OpenJ9.gmk
@@ -196,7 +196,6 @@ $(call openj9_add_jdk_shlibs, java.base, \
 	j9gc29 \
 	j9gcchk29 \
 	j9hookable29 \
-	j9jit29 \
 	j9jnichk29 \
 	j9jvmti29 \
 	j9prt29 \
@@ -210,6 +209,10 @@ $(call openj9_add_jdk_shlibs, java.base, \
 	jvm \
 	omrsig \
 	)
+
+ifneq (riscv64, $(OPENJDK_TARGET_CPU))
+  $(call openj9_add_jdk_shlibs, java.base, j9jit29)
+endif
 
 ifeq (windows,$(OPENJDK_TARGET_OS))
   $(call openj9_add_jdk_lib, java.base, lib/$(call STATIC_LIBRARY,jsig))

--- a/closed/autoconf/custom-hook.m4
+++ b/closed/autoconf/custom-hook.m4
@@ -226,7 +226,7 @@ AC_DEFUN([OPENJ9_CONFIGURE_DDR],
     OPENJ9_ENABLE_DDR=false
   elif test "x$enable_ddr" = x ; then
     case "$OPENJ9_PLATFORM_CODE" in
-      ap64|oa64|wa64|xa64|xl64|xz64)
+      ap64|oa64|rv64|wa64|xa64|xl64|xz64)
         AC_MSG_RESULT([yes (default for $OPENJ9_PLATFORM_CODE)])
         OPENJ9_ENABLE_DDR=true
         ;;
@@ -263,6 +263,9 @@ AC_DEFUN([OPENJ9_PLATFORM_EXTRACT_VARS_FROM_CPU],
       ;;
     aarch64)
       OPENJ9_CPU=aarch64
+      ;;
+    riscv64)
+      OPENJ9_CPU=riscv64
       ;;
     *)
       AC_MSG_ERROR([unsupported OpenJ9 cpu $1])
@@ -325,6 +328,11 @@ AC_DEFUN_ONCE([OPENJ9_PLATFORM_SETUP],
     OPENJ9_LIBS_SUBDIR=default
   elif test "x$OPENJ9_CPU" = xaarch64 ; then
     OPENJ9_PLATFORM_CODE=xr64
+    if test "x$COMPILE_TYPE" = xcross ; then
+      OPENJ9_BUILDSPEC="${OPENJ9_BUILDSPEC}_cross"
+    fi
+  elif test "x$OPENJ9_CPU" = xriscv64 ; then
+    OPENJ9_PLATFORM_CODE=rv64
     if test "x$COMPILE_TYPE" = xcross ; then
       OPENJ9_BUILDSPEC="${OPENJ9_BUILDSPEC}_cross"
     fi
@@ -549,6 +557,22 @@ AC_DEFUN([CONFIGURE_OPENSSL],
                 OPENSSL_BUNDLE_LIB_PATH="${LOCAL_CRYPTO}"
               else
                 OPENSSL_BUNDLE_LIB_PATH="${OPENSSL_DIR}/lib"
+              fi
+            fi
+          elif test -s "$OPENSSL_DIR/lib64/${LIBRARY_PREFIX}crypto${SHARED_LIBRARY_SUFFIX}" ; then
+            OPENSSL_CFLAGS="-I${OPENSSL_DIR}/include"
+            if test "x$BUNDLE_OPENSSL" = xyes ; then
+              # On Mac OSX, create local copy of the crypto library to update @rpath
+              # as the default is /usr/local/lib.
+              if test "x$OPENJDK_BUILD_OS" = xmacosx ; then
+                LOCAL_CRYPTO="$TOPDIR/openssl"
+                $MKDIR -p "${LOCAL_CRYPTO}"
+                $CP "${OPENSSL_DIR}/lib64/libcrypto.1.1.dylib" "${LOCAL_CRYPTO}"
+                $CP "${OPENSSL_DIR}/lib64/libcrypto.1.0.0.dylib" "${LOCAL_CRYPTO}"
+                $CP -a "${OPENSSL_DIR}/lib64/libcrypto.dylib" "${LOCAL_CRYPTO}"
+                OPENSSL_BUNDLE_LIB_PATH="${LOCAL_CRYPTO}"
+              else
+                OPENSSL_BUNDLE_LIB_PATH="${OPENSSL_DIR}/lib64"
               fi
             fi
           elif test -s "$OPENSSL_DIR/${LIBRARY_PREFIX}crypto${SHARED_LIBRARY_SUFFIX}" ; then

--- a/closed/autoconf/custom-spec.gmk.in
+++ b/closed/autoconf/custom-spec.gmk.in
@@ -121,3 +121,11 @@ ifeq (true,$(OPENJ9_ENABLE_CMAKE))
 else
   OPENJ9_VM_BUILD_DIR := $(OUTPUTDIR)/vm
 endif
+
+ifeq (riscv64,$(OPENJDK_TARGET_CPU))
+  ifeq (cross,$(COMPILE_TYPE))
+    export SYSROOT_CFLAGS
+  else
+    JAVA_FLAGS += -DserverStartupTimeout=36000
+  endif
+endif


### PR DESCRIPTION
The changes are to modify the scripts intended
for OpenJ9 to enable RISC-V from the configuration
perspective.

Issue: ibmruntimes#218

Signed-off-by: Cheng Jin <jincheng@ca.ibm.com>