### PR TITLE
Update configure scripts for RISC-V (make)

### DIFF
--- a/make/autoconf/build-aux/autoconf-config.guess
+++ b/make/autoconf/build-aux/autoconf-config.guess
@@ -61,6 +61,10 @@ timestamp='2012-02-10'
 # You can get the latest version of this script from:
 # http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD
 
+# ===========================================================================
+# (c) Copyright IBM Corp. 2019, 2019 All Rights Reserved
+# ===========================================================================
+
 me=`echo "$0" | sed -e 's,.*/,,'`
 
 usage="\
@@ -999,6 +1003,9 @@ EOF
 	exit ;;
     ppc:Linux:*:*)
 	echo powerpc-unknown-linux-gnu
+	exit ;;
+    riscv64:Linux:*:*)
+	echo ${UNAME_MACHINE}-unknown-linux-gnu
 	exit ;;
     s390:Linux:*:* | s390x:Linux:*:*)
 	echo ${UNAME_MACHINE}-ibm-linux

--- a/make/autoconf/build-aux/autoconf-config.sub
+++ b/make/autoconf/build-aux/autoconf-config.sub
@@ -80,6 +80,10 @@ timestamp='2008-01-16'
 #	CPU_TYPE-MANUFACTURER-KERNEL-OPERATING_SYSTEM
 # It is wrong to echo any other type of specification.
 
+# ===========================================================================
+# (c) Copyright IBM Corp. 2019, 2019 All Rights Reserved
+# ===========================================================================
+
 me=`echo "$0" | sed -e 's,.*/,,'`
 
 usage="\
@@ -302,6 +306,7 @@ case $basic_machine in
 	| pdp10 | pdp11 | pj | pjl \
 	| powerpc | powerpc64 | powerpc64le | powerpcle | ppcbe \
 	| pyramid \
+	| riscv64 \
 	| score \
 	| sh | sh[1234] | sh[24]a | sh[23]e | sh[34]eb | sheb | shbe | shle | sh[1234]le | sh3ele \
 	| sh64 | sh64le \
@@ -383,6 +388,7 @@ case $basic_machine in
 	| pdp10-* | pdp11-* | pj-* | pjl-* | pn-* | power-* \
 	| powerpc-* | powerpc64-* | powerpc64le-* | powerpcle-* | ppcbe-* \
 	| pyramid-* \
+	| riscv64-* \
 	| romp-* | rs6000-* \
 	| sh-* | sh[1234]-* | sh[24]a-* | sh[23]e-* | sh[34]eb-* | sheb-* | shbe-* \
 	| shle-* | sh[1234]le-* | sh3ele-* | sh64-* | sh64le-* \

--- a/make/autoconf/platform.m4
+++ b/make/autoconf/platform.m4
@@ -23,6 +23,10 @@
 # questions.
 #
 
+# ===========================================================================
+# (c) Copyright IBM Corp. 2019, 2019 All Rights Reserved
+# ===========================================================================
+
 # Support macro for PLATFORM_EXTRACT_TARGET_AND_BUILD.
 # Converts autoconf style CPU name to OpenJDK style, into
 # VAR_CPU, VAR_CPU_ARCH, VAR_CPU_BITS and VAR_CPU_ENDIAN.
@@ -111,6 +115,12 @@ AC_DEFUN([PLATFORM_EXTRACT_VARS_FROM_CPU],
     powerpc64le)
       VAR_CPU=ppc64le
       VAR_CPU_ARCH=ppc
+      VAR_CPU_BITS=64
+      VAR_CPU_ENDIAN=little
+      ;;
+    riscv64)
+      VAR_CPU=riscv64
+      VAR_CPU_ARCH=riscv64
       VAR_CPU_BITS=64
       VAR_CPU_ENDIAN=little
       ;;


### PR DESCRIPTION
The changes are to modify the scripts in the
make directory to enable RISC-V from the 
configuration perspective.

Issue: ibmruntimes#218

Signed-off-by: Cheng Jin <jincheng@ca.ibm.com>