### PR TITLE
Revert "Enable DDR by default on z/OS"

### DIFF
--- a/closed/autoconf/custom-hook.m4
+++ b/closed/autoconf/custom-hook.m4
@@ -226,7 +226,7 @@ AC_DEFUN([OPENJ9_CONFIGURE_DDR],
     OPENJ9_ENABLE_DDR=false
   elif test "x$enable_ddr" = x ; then
     case "$OPENJ9_PLATFORM_CODE" in
-      ap64|mz64|oa64|wa64|xa64|xl64|xz64)
+      ap64|oa64|wa64|xa64|xl64|xz64)
         AC_MSG_RESULT([yes (default for $OPENJ9_PLATFORM_CODE)])
         OPENJ9_ENABLE_DDR=true
         ;;


### PR DESCRIPTION
Reverts ibmruntimes/openj9-openjdk-jdk11#229

Enabling DDR caused some build errors, reverting until these are resolved.
```
22:25:12  /home/jenkins/workspace/Build_JDK11_s390x_zos_Nightly/build/zos-s390x-normal-server-release/support/ddr/gensrc/com/ibm/j9ddr/vm29/structure/GC_CheckElement.java:42: error: variable type_class is already defined in class GC_CheckElement
22:25:12  	public static final long type_class;
22:25:12  	                         ^
22:25:12  /home/jenkins/workspace/Build_JDK11_s390x_zos_Nightly/build/zos-s390x-normal-server-release/support/ddr/gensrc/com/ibm/j9ddr/vm29/structure/GC_CheckElement.java:44: error: variable type_none is already defined in class GC_CheckElement
22:25:12  	public static final long type_none;
22:25:12  	                         ^
22:25:12  /home/jenkins/workspace/Build_JDK11_s390x_zos_Nightly/build/zos-s390x-normal-server-release/support/ddr/gensrc/com/ibm/j9ddr/vm29/structure/GC_CheckElement.java:46: error: variable type_object is already defined in class GC_CheckElement
22:25:12  	public static final long type_object;
22:25:12  	                         ^
```