### PR TITLE
Set default load address for launchers on s390x

### DIFF
--- a/make/launcher/LauncherCommon.gmk
+++ b/make/launcher/LauncherCommon.gmk
@@ -23,6 +23,11 @@
 # questions.
 #
 
+# ===========================================================================
+# (c) Copyright IBM Corp. 2019, 2019 All Rights Reserved
+# ===========================================================================
+#
+
 include JdkNativeCompilation.gmk
 
 ORIGIN_ARG := $(call SET_EXECUTABLE_ORIGIN,/../lib/jli)
@@ -93,6 +98,16 @@ JAVA_MANIFEST := $(TOPDIR)/src/java.base/windows/native/launcher/java.manifest
 SetupBuildLauncher = $(NamedParamsMacroTemplate)
 define SetupBuildLauncherBody
   # Setup default values (unless overridden)
+  
+  ifeq ($(OPENJDK_TARGET_OS), linux)
+  # Set the image base address for zLinux 64 to 0x60000 for launchers,
+  # allows compressedRefsShift to be 0 when -Xmx is set to 2040m or more.
+  # / RTC PR 100052
+    ifeq ($(OPENJDK_TARGET_CPU), s390x)
+      $1_LDFLAGS += -Wl,-Ttext-segment=0x60000
+    endif
+  endif
+
   ifeq ($$($1_OPTIMIZATION), )
     $1_OPTIMIZATION := LOW
   endif


### PR DESCRIPTION
Sets the load address of the launchers to 0x60000 on zlinux 64 systems. This enables compressed references  with shift 0 with heaps larger then 1.8GB

**Before:**
```
80000000-80001000 r-xp 00000000 fd:01 12058817                           /root/jdk-11.0.4+11/bin/java
80002000-80003000 r--p 00001000 fd:01 12058817                           /root/jdk-11.0.4+11/bin/java
80003000-80004000 rw-p 00002000 fd:01 12058817                           /root/jdk-11.0.4+11/bin/java
```
<img width="1310" alt="Screenshot 2019-11-15 at 15 19 14" src="https://user-images.githubusercontent.com/25231953/68954156-53893080-07bb-11ea-8f9b-21125e1a310e.png">

**After:**
```
00060000-00062000 r-xp 00000000 fd:01 3171696                            /root/SharedDocker/openj9-openjdk-jdk11/build/linux-s390x-normal-server-release/images/jdk/bin/java
00062000-00063000 r--p 00001000 fd:01 3171696                            /root/SharedDocker/openj9-openjdk-jdk11/build/linux-s390x-normal-server-release/images/jdk/bin/java
00063000-00064000 rw-p 00002000 fd:01 3171696                            /root/SharedDocker/openj9-openjdk-jdk11/build/linux-s390x-normal-server-release/images/jdk/bin/java
```
<img width="1310" alt="Screenshot 2019-11-15 at 15 20 40" src="https://user-images.githubusercontent.com/25231953/68954228-816e7500-07bb-11ea-9d2a-2d40d1ba49f5.png">

Issue: eclipse/openj9#7115

Signed-off-by: Morgan Davies <morgan.davies@ibm.com>