### PR TITLE
Add OpenSSL related settings to CUSTOM_COMPILER_ENV_VARS

### DIFF
--- a/closed/OpenJ9.gmk
+++ b/closed/OpenJ9.gmk
@@ -496,9 +496,21 @@ ifeq (true,$(OPENJ9_ENABLE_CMAKE))
 
   ifeq (true,$(OPENJ9_ENABLE_JITSERVER))
     CMAKE_ARGS += -DJITSERVER_SUPPORT=ON
+
+    ifneq (,$(OPENSSL_CFLAGS))
+      CMAKE_ARGS += -DOPENSSL_CFLAGS="$(OPENSSL_CFLAGS)"
+    endif
+
+    ifneq (,$(OPENSSL_DIR))
+      CMAKE_ARGS += -DOPENSSL_DIR="$(OPENSSL_DIR)"
+    endif
+
+    ifneq (,$(OPENSSL_BUNDLE_LIB_PATH))
+      CMAKE_ARGS += -DOPENSSL_BUNDLE_LIB_PATH="$(OPENSSL_BUNDLE_LIB_PATH)"
+    endif
   else
     CMAKE_ARGS += -DJITSERVER_SUPPORT=OFF
-  endif
+  endif # OPENJ9_ENABLE_JITSERVER
 
   CMAKE_ARGS += $(EXTRA_CMAKE_ARGS)
 
@@ -550,8 +562,20 @@ endif
 ifeq (true,$(OPENJ9_ENABLE_JITSERVER))
   ifneq (true,$(OPENJ9_ENABLE_CMAKE))
     CUSTOM_COMPILER_ENV_VARS += JITSERVER_SUPPORT=1
-  endif
-endif
+
+    ifneq (,$(OPENSSL_CFLAGS))
+      CUSTOM_COMPILER_ENV_VARS += OPENSSL_CFLAGS="$(OPENSSL_CFLAGS)"
+    endif
+
+    ifneq (,$(OPENSSL_DIR))
+      CUSTOM_COMPILER_ENV_VARS += OPENSSL_DIR="$(OPENSSL_DIR)"
+    endif
+
+    ifneq (,$(OPENSSL_BUNDLE_LIB_PATH))
+      CUSTOM_COMPILER_ENV_VARS += OPENSSL_BUNDLE_LIB_PATH="$(OPENSSL_BUNDLE_LIB_PATH)"
+    endif
+  endif # OPENJ9_ENABLE_CMAKE
+endif # OPENJ9_ENABLE_JITSERVER
 
 build-j9 : run-preprocessors-j9
 	@$(ECHO) Compiling OpenJ9 in $(OUTPUTDIR)/vm

--- a/closed/autoconf/custom-hook.m4
+++ b/closed/autoconf/custom-hook.m4
@@ -653,6 +653,20 @@ AC_DEFUN([CONFIGURE_OPENSSL],
 
     AC_MSG_CHECKING([if we should bundle openssl])
     AC_MSG_RESULT([$BUNDLE_OPENSSL])
+
+    if test "x$OPENJ9_ENABLE_JITSERVER" = xtrue ; then
+      if test "x$OPENJDK_TARGET_OS" = xlinux ; then
+        if test "x$OPENSSL_DIR" != x ; then
+          AC_MSG_CHECKING([if the required OPENSSL API exists for JITServer in $OPENSSL_DIR])
+          if $GREP -q -w SSL_CTX_set_ecdh_auto "$OPENSSL_DIR/include/openssl/ssl.h" 2> /dev/null ; then
+            AC_MSG_RESULT([yes])
+          else
+            AC_MSG_RESULT([no])
+            AC_MSG_ERROR([SSL_CTX_set_ecdh_auto is required by JITServer])
+          fi
+        fi
+      fi
+    fi
   fi
 
   AC_SUBST(OPENSSL_BUNDLE_LIB_PATH)

--- a/closed/make/copy/Copy-java.base.gmk
+++ b/closed/make/copy/Copy-java.base.gmk
@@ -87,5 +87,26 @@ ifneq ($(OPENSSL_BUNDLE_LIB_PATH), )
   ifeq ($(OPENJDK_BUILD_OS), windows)
 	$(CHMOD) a+rx $@
   endif
-endif
+
+  ifeq (true,$(OPENJ9_ENABLE_JITSERVER))
+    # Copy OpenSSL SSL Lbrary
+    # To bundle first search for libssl 1.1.x library, if not found, search for 1.0.x
+    ifeq ($(OPENJDK_TARGET_OS), linux)
+      OPENSSL_SSL_LIB_NAME = libssl.so.1.1
+      ifeq ("$(wildcard $(OPENSSL_BUNDLE_LIB_PATH)/$(OPENSSL_SSL_LIB_NAME))", "")
+        OPENSSL_SSL_LIB_NAME = libssl.so.1.0.0
+        ifeq ("$(wildcard $(OPENSSL_BUNDLE_LIB_PATH)/$(OPENSSL_SSL_LIB_NAME))", "")
+          OPENSSL_SSL_LIB_NAME =
+        endif
+      endif
+
+      ifneq ($(OPENSSL_SSL_LIB_NAME), )
+        OPENSSL_SSL_TARGET_LIB = $(LIB_DST_DIR)/$(OPENSSL_SSL_LIB_NAME)
+        TARGETS += $(OPENSSL_SSL_TARGET_LIB)
+        $(OPENSSL_SSL_TARGET_LIB) : $(OPENSSL_BUNDLE_LIB_PATH)/$(OPENSSL_SSL_LIB_NAME)
+			$(call install-file)
+      endif # OPENSSL_SSL_LIB_NAME
+    endif # OPENJDK_TARGET_OS
+  endif # OPENJ9_ENABLE_JITSERVER
+endif # OPENSSL_BUNDLE_LIB_PATH
 ################################################################################


### PR DESCRIPTION
`
JITServer` needs to be built with `libssl`. By default, it
is built against the `OpenSSL` installed on the build machine.
The same as when `--enable-jitserver --with-openssl=system`
is specified.

This change passes the `OpenSSL` build flags from OpenJDK to
JIT build environment.
- Add `OPENSSL_DIR`, `OPENSSL_CFLAGS`, and `OPENSSL_BUNDLE_LIB_PATH`
  to `CUSTOM_COMPILER_ENV_VARS` and `CMAKE_ARGS`.
- Bundle `libssl` if `--with-openssl=fetched --enable-openssl-bundling`
  is set.

Examples on the supported flags:
--enable-jitserver --with-openssl=fetched
--enable-jitserver --with-openssl=fetched --enable-openssl-bundling
--enable-jitserver --with-openssl=system

The JIT build change is addressed in:
eclipse/openj9#5789, eclipse/openj9#7846

This is a similar change as ibmruntimes/openj9-openjdk-jdk8#303.

Issue: eclipse/openj9#5720

Signed-off-by: Annabelle Huo <Annabelle.Huo@ibm.com>