### PR TITLE
CMake: fix path when getting the redirector import lib on windows

### DIFF
--- a/closed/OpenJ9.gmk
+++ b/closed/OpenJ9.gmk
@@ -218,7 +218,7 @@ ifeq (windows,$(OPENJDK_TARGET_OS))
   $(call openj9_add_jdk_lib, java.base, lib/$(call STATIC_LIBRARY,jsig))
   $(eval $(call openj9_add_jdk_rules, \
 	$(call FindLibDirForModule, java.base)/$(call STATIC_LIBRARY,jvm), \
-	$(OUTPUTDIR)/vm/redirector/$(call STATIC_LIBRARY,redirector_jvm)))
+	$(OPENJ9_VM_BUILD_DIR)/redirector/$(call STATIC_LIBRARY,redirector_jvm)))
 endif
 
 $(call openj9_add_jdk_lib, java.base, \


### PR DESCRIPTION
Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>