### PR TITLE
CMake: Update windows toolchain files

### DIFF
--- a/closed/autoconf/toolchain-win.cmake.in
+++ b/closed/autoconf/toolchain-win.cmake.in
@@ -36,11 +36,12 @@ else()
 	set(CMAKE_ASM_MASM_COMPILER "${tool_dir}/ml" CACHE FILEPATH "")
 endif()
 
-set(Java_JAR_EXECUTABLE "${tool_dir}/jar" CACHE FILEPATH "")
-set(Java_JAVA_EXECUTABLE "${tool_dir}/java" CACHE FILEPATH "")
-set(Java_JAVAC_EXECUTABLE "${tool_dir}/javac" CACHE FILEPATH "")
+set(CMAKE_Java_AR "${tool_dir}/jar" CACHE FILEPATH "")
+set(CMAKE_Java_RUNTIME "${tool_dir}/java" CACHE FILEPATH "")
+set(CMAKE_Java_COMPILER "${tool_dir}/javac" CACHE FILEPATH "")
 
-set(OMR_EXE_LAUNCHER "@FIXPATH_BIN@;-c" CACHE STRING "")
+separate_arguments(FIXPATH UNIX_COMMAND "@FIXPATH@")
+set(OMR_EXE_LAUNCHER "${FIXPATH}" CACHE STRING "")
 
 # CMake will test to see if compiler works by getting it to compile files in
 # /usr/lib, which fixpath wont translate


### PR DESCRIPTION
- Set new style java language variables, so that we override internal
openj9 bootjdk detection

- Update OMR_EXE_LAUNCHER to use `FIXPATH` rather than `FIXPATH_BIN`
which is not exported from autoconf

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>