### PR TITLE
Stop staging jcl and sourcetools folders

### DIFF
--- a/closed/OpenJ9.gmk
+++ b/closed/OpenJ9.gmk
@@ -68,6 +68,8 @@ ifeq (false,$(WARNINGS_AS_ERRORS_OPENJ9))
 endif
 
 ifeq (windows,$(OPENJDK_TARGET_OS))
+  # convert unix path to windows path
+  FixPath = $(shell $(CYGPATH) -m $1)
   # set Visual Studio environment
   # wrap PATH in quotes as it contains spaces (unix path)
   # INCLUDE, LIB are already wrapped in quotes (windows paths)
@@ -75,6 +77,7 @@ ifeq (windows,$(OPENJDK_TARGET_OS))
   # set the output directory for shared libraries
   OPENJ9_BIN_OR_LIB_DIR := bin
 else
+  FixPath = $1
   EXPORT_MSVS_ENV_VARS :=
   OPENJ9_BIN_OR_LIB_DIR := lib
 endif
@@ -84,12 +87,12 @@ endif
 	build-openj9-tools \
 	clean-j9 \
 	clean-j9-dist \
+	clean-openj9-thirdparty-binaries \
 	create_build_jdk \
 	generate-j9jcl-sources \
 	openj9_build_jdk \
 	run-preprocessors-j9 \
 	stage-j9 \
-	stage-openj9-tools \
 	#
 
 # openj9_copy_tree
@@ -394,19 +397,18 @@ $(foreach file, \
 	$(notdir $(wildcard $(OPENJ9_TOPDIR)/buildspecs/*)), \
 	$(eval $(call openj9_stage_buildspec_file,$(file))))
 
-stage-openj9-tools :
-	@$(ECHO) Staging OpenJ9 sourcetools in $(OUTPUTDIR)/vm
-	$(call openj9_copy_tree,$(OUTPUTDIR)/vm/sourcetools,$(OPENJ9_TOPDIR)/sourcetools)
+J9TOOLS_DIR := $(SUPPORT_OUTPUTDIR)/j9tools
+JPP_JAR     := $(J9TOOLS_DIR)/jpp.jar
 
-build-openj9-tools : stage-openj9-tools
-	@$(ECHO) Building OpenJ9 tools
-	$(MAKE) -C $(OUTPUTDIR)/vm/sourcetools $(MAKEFLAGS) -f buildj9tools.mk \
-		JAVA_HOME=$(BOOT_JDK) lib/jpp.jar
+build-openj9-tools :
+	@$(ECHO) Building OpenJ9 Java Preprocessor
+	@$(MKDIR) -p $(J9TOOLS_DIR)
+	$(MAKE) -C $(OPENJ9_TOPDIR)/sourcetools $(MAKEFLAGS) -f buildj9tools.mk \
+		DEST_DIR=$(call FixPath,$(J9TOOLS_DIR)) \
+		JAVA_HOME=$(BOOT_JDK) \
+		$(call FixPath,$(JPP_JAR))
 
-stage-j9 : stage-openj9-tools
-	@$(ECHO) Staging OpenJ9 jcl in $(OUTPUTDIR)/vm
-	$(call openj9_copy_tree,$(OUTPUTDIR)/vm/jcl,$(OPENJ9_TOPDIR)/jcl)
-
+stage-j9 :
 	@$(ECHO) Staging OpenJ9 runtime in $(OUTPUTDIR)/vm
 	$(call openj9_copy_tree,$(OUTPUTDIR)/vm,$(OPENJ9_TOPDIR)/runtime)
 
@@ -542,14 +544,15 @@ run-preprocessors-j9 : stage-j9
 	@$(ECHO) Running OpenJ9 preprocessors with OPENJ9_BUILDSPEC: $(OPENJ9_BUILDSPEC)
 	export BOOT_JDK=$(BOOT_JDK) $(EXPORT_MSVS_ENV_VARS) \
 		OPENJDK_VERSION_NUMBER_FOUR_POSITIONS=$(VERSION_NUMBER_FOUR_POSITIONS) \
-		&& $(MAKE) -C $(OUTPUTDIR)/vm $(MAKEFLAGS) -f buildtools.mk \
+		&& $(MAKE) -C $(OUTPUTDIR)/vm $(MAKEFLAGS) -f $(OPENJ9_TOPDIR)/runtime/buildtools.mk \
 			BUILD_ID=$(BUILD_ID) \
+			DEST_DIR=$(call FixPath,$(J9TOOLS_DIR)) \
 			EXTRA_CONFIGURE_ARGS=$(OMR_EXTRA_CONFIGURE_ARGS) \
 			FREEMARKER_JAR="$(FREEMARKER_JAR)" \
 			J9VM_SHA=$(OPENJ9_SHA) \
 			JAVA_HOME=$(BOOT_JDK) \
 			OMR_DIR=$(OUTPUTDIR)/vm/omr \
-			OPENJ9_BUILD=true \
+			SOURCETOOLS_DIR=$(call FixPath,$(OPENJ9_TOPDIR))/sourcetools \
 			SPEC=$(OPENJ9_BUILDSPEC) \
 			UMA_OPTIONS_EXTRA="-buildDate $(shell date +'%Y%m%d')" \
 			VERSION_MAJOR=$(VERSION_FEATURE) \
@@ -597,23 +600,20 @@ J9JCL_SOURCES_DONEFILE := $(MAKESUPPORT_OUTPUTDIR)/j9jcl_sources.done
 recur_wildcard = $(foreach dir,$(wildcard $1/*),$(call recur_wildcard,$(dir),$2) $(filter $(subst *,%,$2),$(dir)))
 AllJclSource   = $(call recur_wildcard,$(OPENJ9_TOPDIR)/jcl/src,*.java)
 
-JPP_BASE_DIR := $(call FixPath,$(OPENJ9_TOPDIR))
-JPP_DEST     := $(call FixPath,$(SUPPORT_OUTPUTDIR)/j9jcl_sources)
-JPP_JAR      := $(call FixPath,$(OUTPUTDIR)/vm/sourcetools/lib/jpp.jar)
+JPP_DEST := $(SUPPORT_OUTPUTDIR)/j9jcl_sources
 
 $(J9JCL_SOURCES_DONEFILE) : $(AllJclSource)
 	@$(ECHO) Generating J9JCL sources
-	@$(MKDIR) -p $(SUPPORT_OUTPUTDIR)/j9jcl_sources
 	@$(BOOT_JDK)/bin/java \
-		-cp "$(JPP_JAR)" \
+		-cp "$(call FixPath,$(JPP_JAR))" \
 		-Dfile.encoding=US-ASCII \
 		com.ibm.jpp.commandline.CommandlineBuilder \
 			-verdict \
-			-baseDir "$(JPP_BASE_DIR)/" \
+			-baseDir "$(call FixPath,$(OPENJ9_TOPDIR))/" \
 			-config JAVA11 \
 			-srcRoot jcl/ \
 			-xml jpp_configuration.xml \
-			-dest "$(JPP_DEST)" \
+			-dest "$(call FixPath,$(JPP_DEST))" \
 			-macro:define "com.ibm.oti.vm.library.version=29" \
 			-tag:define "PLATFORM-$(OPENJ9_PLATFORM_CODE)"
 	@$(MKDIR) -p $(@D)


### PR DESCRIPTION
* staged jcl folder was not used
* build tools directly from unstaged sourcetools folder
* add missing PHONY declaration for clean-openj9-thirdparty-binaries
* don't assume CUDA is disabled by default
* remove unnecessary definition of OPENJ9_BUILD

Enabled by eclipse/openj9#8246: improves build performance.