### PR TITLE
CMake: Fix race creating $(OUTPUTDIR)/vm

### DIFF
--- a/closed/OpenJ9.gmk
+++ b/closed/OpenJ9.gmk
@@ -533,6 +533,7 @@ ifeq (true,$(OPENJ9_ENABLE_CMAKE))
   endif # OPENJ9_ENABLE_CUDA
 
 $(OUTPUTDIR)/vm/cmake.stamp :
+	@$(MKDIR) -p $(@D)
 	cd $(@D) && $(CMAKE_CUDA_ENV) $(CMAKE) $(CMAKE_ARGS) $(OPENJ9_TOPDIR)
 	$(TOUCH) $@
 


### PR DESCRIPTION
There was a race in `OpenJ9.gmk` that apparently since #254 is now more likely to go wrong. That file has these dependencies:
```
run-preprocessors-j9 : $(OUTPUT_ROOT)/vm/cmake.stamp
run-preprocessors-j9 : generate-j9-version-headers
```
A side-effect of `generate-j9-version-headers` is the creation of the directory needed by `$(OUTPUT_ROOT)/vm/cmake.stamp`. This removes the dependency on that ordering.