### PR TITLE
Improve integration of OpenJ9 JCL code generation

### DIFF
--- a/closed/OpenJ9.gmk
+++ b/closed/OpenJ9.gmk
@@ -404,6 +404,7 @@ build-openj9-tools :
 	@$(ECHO) Building OpenJ9 Java Preprocessor
 	@$(MKDIR) -p $(J9TOOLS_DIR)
 	$(MAKE) -C $(OPENJ9_TOPDIR)/sourcetools $(MAKEFLAGS) -f buildj9tools.mk \
+		BOOT_JDK=$(BOOT_JDK) \
 		DEST_DIR=$(call FixPath,$(J9TOOLS_DIR)) \
 		JAVA_HOME=$(BOOT_JDK) \
 		$(call FixPath,$(JPP_JAR))

--- a/closed/make/Main.gmk
+++ b/closed/make/Main.gmk
@@ -1,5 +1,5 @@
 # ===========================================================================
-# (c) Copyright IBM Corp. 2017, 2019 All Rights Reserved
+# (c) Copyright IBM Corp. 2017, 2020 All Rights Reserved
 # ===========================================================================
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
@@ -22,6 +22,7 @@ CLEAN_DIRS += vm
 
 .PHONY : \
 	j9vm-build \
+	openj9-create-main-targets-include \
 	openssl-build \
 	test-image-openj9 \
 	#
@@ -36,6 +37,18 @@ PHASE_MAKEDIRS := $(TOPDIR)/closed/make/closed_make $(PHASE_MAKEDIRS)
 
 OPENJ9_MAKE := $(MAKE) -f $(TOPDIR)/closed/OpenJ9.gmk SPEC=$(SPEC)
 OPENSSL_MAKE := $(MAKE) -f $(TOPDIR)/closed/openssl.gmk SPEC=$(SPEC)
+
+# An early part of the build process involves computing the list of main targets.
+# Those targets include {module}-java, {module}-jmod, etc. which requires that the
+# set of module names be known. We must build and run the preprocessor to ensure the
+# modules specific to OpenJ9 will be found and included in that set. The next two
+# rules make that happen.
+
+create-main-targets-include : openj9-create-main-targets-include
+
+openj9-create-main-targets-include :
+	+$(OPENJ9_MAKE) build-openj9-tools
+	+$(OPENJ9_MAKE) generate-j9jcl-sources
 
 openssl-build : buildtools-langtools
 	+$(OPENSSL_MAKE)

--- a/closed/make/common/Modules.gmk
+++ b/closed/make/common/Modules.gmk
@@ -1,11 +1,11 @@
 # ===========================================================================
-# (c) Copyright IBM Corp. 2017, 2019 All Rights Reserved
+# (c) Copyright IBM Corp. 2017, 2020 All Rights Reserved
 # ===========================================================================
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
 # published by the Free Software Foundation.
 #
-# IBM designates this particular file as subject to the "Classpath" exception 
+# IBM designates this particular file as subject to the "Classpath" exception
 # as provided by IBM in the LICENSE file that accompanied this code.
 #
 # This code is distributed in the hope that it will be useful, but WITHOUT
@@ -19,8 +19,8 @@
 # ===========================================================================
 
 BOOT_MODULES += \
-    openj9.sharedclasses \
     openj9.jvm \
+    openj9.sharedclasses \
     #
 
 MODULES_FILTER += \
@@ -38,13 +38,3 @@ TOP_SRC_DIRS += \
     $(TOPDIR)/closed/src \
     $(SUPPORT_OUTPUTDIR)/j9jcl_sources \
     #
-
-# An early part of the build process involves computing the list of main targets.
-# Those targets include {module}-java, {module}-jmod, etc. which requires that the
-# set of module names be known. We must build and run the preprocessor to ensure the
-# modules specific to OpenJ9 will be found and included in that set.
-
-ifneq (,$(findstring create-main-targets-include,$(MAKECMDGOALS)))
-BUILD_OPENJ9_TOOLS     := $(shell $(MAKE) -C $(TOPDIR)/closed -f OpenJ9.gmk SPEC=$(SPEC) BOOT_JDK=$(BOOT_JDK) build-openj9-tools)
-GENERATE_J9JCL_SOURCES := $(shell $(MAKE) -C $(TOPDIR)/closed -f OpenJ9.gmk SPEC=$(SPEC) generate-j9jcl-sources)
-endif


### PR DESCRIPTION
Generation of J9JCL code was connected to the build system in an unusual manner that triggered the work at least twice and hid all diagnostics from the build log. This adds a new target that is a prerequisite of `create-main-targets-include` which operates as a normal make rule.