### PR TITLE
Add Linux AArch64 as DDR platform

### DIFF
--- a/closed/autoconf/custom-hook.m4
+++ b/closed/autoconf/custom-hook.m4
@@ -227,7 +227,7 @@ AC_DEFUN([OPENJ9_CONFIGURE_DDR],
     OPENJ9_ENABLE_DDR=false
   elif test "x$enable_ddr" = x ; then
     case "$OPENJ9_PLATFORM_CODE" in
-      ap64|oa64|rv64|wa64|xa64|xl64|xz64)
+      ap64|oa64|rv64|wa64|xa64|xl64|xr64|xz64)
         AC_MSG_RESULT([yes (default for $OPENJ9_PLATFORM_CODE)])
         OPENJ9_ENABLE_DDR=true
         ;;


### PR DESCRIPTION
This commit adds xr64 to the list of DDR platforms for enabling DDR
on Linux AArch64.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>