### PR TITLE
Sign bundled crypto libraries

### DIFF
--- a/closed/OpenJ9.gmk
+++ b/closed/OpenJ9.gmk
@@ -126,12 +126,7 @@ openj9_install_copy = $(call install-file)
 
 define openj9_install_copy_and_sign
 	$(openj9_install_copy)
-	$(if $(CODESIGN),$(CODESIGN) \
-		--sign "$(MACOSX_CODESIGN_IDENTITY)" \
-		--timestamp \
-		--options runtime \
-		--entitlements $(TOPDIR)/make/data/macosxsigning/entitlements.plist \
-		"$@")
+	$(call CodesignFile,"$@")
 endef
 
 # openj9_install_rule

--- a/closed/autoconf/custom-spec.gmk.in
+++ b/closed/autoconf/custom-spec.gmk.in
@@ -1,11 +1,11 @@
 # ===========================================================================
-# (c) Copyright IBM Corp. 2017, 2019 All Rights Reserved
+# (c) Copyright IBM Corp. 2017, 2020 All Rights Reserved
 # ===========================================================================
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
 # published by the Free Software Foundation.
 #
-# IBM designates this particular file as subject to the "Classpath" exception 
+# IBM designates this particular file as subject to the "Classpath" exception
 # as provided by IBM in the LICENSE file that accompanied this code.
 #
 # This code is distributed in the hope that it will be useful, but WITHOUT
@@ -67,13 +67,13 @@ OPENJDK_SHA             := @OPENJDK_SHA@
 
 include $(TOPDIR)/closed/openjdk-tag.gmk
 
-# J9JDK_EXT_VERSION       := ${VERSION_NUMBER_FOUR_POSITIONS}
+J9JDK_EXT_VERSION       := ${VERSION_NUMBER_FOUR_POSITIONS}
 J9JDK_EXT_VERSION       := HEAD
 J9JDK_EXT_NAME          := Extensions for OpenJDK for Eclipse OpenJ9
 
 # required by CMake
-export CMAKE                := @CMAKE@
-export OPENJ9_ENABLE_CMAKE  := @OPENJ9_ENABLE_CMAKE@
+export CMAKE               := @CMAKE@
+export OPENJ9_ENABLE_CMAKE := @OPENJ9_ENABLE_CMAKE@
 
 # required by UMA
 FREEMARKER_JAR          := @FREEMARKER_JAR@
@@ -112,12 +112,23 @@ ifeq ($(OPENJDK_BUILD_OS), macosx)
   LDFLAGS_JDKEXE += -pagezero_size 0x1000
 endif
 
+# Usage: $(call CodesignFile, files ...)
+ifeq (,$(CODESIGN))
+  CodesignFile =
+else
+  CodesignFile = $(CODESIGN) --sign "$(MACOSX_CODESIGN_IDENTITY)" \
+	--entitlements $(TOPDIR)/make/data/macosxsigning/entitlements.plist \
+	--options runtime \
+	--timestamp \
+	$1
+endif
+
 # OPENSSL
-BUILD_OPENSSL:=@BUILD_OPENSSL@
-OPENSSL_BUNDLE_LIB_PATH:=@OPENSSL_BUNDLE_LIB_PATH@
-OPENSSL_CFLAGS:=@OPENSSL_CFLAGS@
-OPENSSL_DIR:=@OPENSSL_DIR@
-WITH_OPENSSL:=@WITH_OPENSSL@
+BUILD_OPENSSL           := @BUILD_OPENSSL@
+OPENSSL_BUNDLE_LIB_PATH := @OPENSSL_BUNDLE_LIB_PATH@
+OPENSSL_CFLAGS          := @OPENSSL_CFLAGS@
+OPENSSL_DIR             := @OPENSSL_DIR@
+WITH_OPENSSL            := @WITH_OPENSSL@
 
 ifeq (true,$(OPENJ9_ENABLE_CMAKE))
   OPENJ9_VM_BUILD_DIR := $(OUTPUTDIR)/vm/runtime

--- a/closed/make/copy/Copy-java.base.gmk
+++ b/closed/make/copy/Copy-java.base.gmk
@@ -1,5 +1,5 @@
 # ===========================================================================
-# (c) Copyright IBM Corp. 2017, 2019 All Rights Reserved
+# (c) Copyright IBM Corp. 2017, 2020 All Rights Reserved
 # ===========================================================================
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
@@ -34,78 +34,54 @@ $(INCLUDE_TARGET_DIR)/ibmjvmti.h : $(TOPDIR)/openj9/runtime/include/ibmjvmti.h
 # To bundle first search for openssl 1.1.x library, if not found, search for 1.0.x
 ifneq ($(OPENSSL_BUNDLE_LIB_PATH), )
   ifeq ($(OPENJDK_TARGET_OS), linux)
-    OPENSSL_LIB_NAME = libcrypto.so.1.1
-    ifeq ("$(wildcard $(OPENSSL_BUNDLE_LIB_PATH)/$(OPENSSL_LIB_NAME))", "")
-      OPENSSL_LIB_NAME = libcrypto.so.1.0.0
-    endif
+    LIBCRYPTO_NAMES := libcrypto.so.1.1 libcrypto.so.1.0.0
   else ifeq ($(OPENJDK_TARGET_OS), macosx)
-    OPENSSL_LIB_NAME = libcrypto.1.1.dylib
-    ifeq ("$(wildcard $(OPENSSL_BUNDLE_LIB_PATH)/$(OPENSSL_LIB_NAME))", "")
-      OPENSSL_LIB_NAME = libcrypto.1.0.0.dylib
-    endif
+    LIBCRYPTO_NAMES := libcrypto.1.1.dylib libcrypto.1.0.0.dylib
   else ifeq ($(OPENJDK_TARGET_OS), windows)
     ifeq ($(OPENJDK_TARGET_CPU_BITS), 64)
-      OPENSSL_LIB_NAME = libcrypto-1_1-x64.dll
+      LIBCRYPTO_NAMES := libcrypto-1_1-x64.dll
     else
-      OPENSSL_LIB_NAME = libcrypto-1_1.dll
+      LIBCRYPTO_NAMES := libcrypto-1_1.dll
     endif
-    ifeq ("$(wildcard $(OPENSSL_BUNDLE_LIB_PATH)/$(OPENSSL_LIB_NAME))", "")
-      OPENSSL_LIB_NAME = libeay32.dll
-    endif
+    LIBCRYPTO_NAMES += libeay32.dll
   else ifeq ($(OPENJDK_TARGET_OS), aix)
     # OpenSSL 1.1.1 on AIX has switched to use archive library files (natural way)
     # instead of 'libcrypto.so' files.
     # For reference, corresponding OpenSSL PR is
     #     https://github.com/openssl/openssl/pull/6487
-    # For OpenSSL v1.0.0, bundle libcrypto.so.1.0.0 library with JDK
-    OPENSSL_LIB_NAME = libcrypto.so.1.0.0
-    ifeq ("$(wildcard $(OPENSSL_BUNDLE_LIB_PATH)/$(OPENSSL_LIB_NAME))", "")
-      # For OpenSSL v1.1.0, bundle libcrypto.so.1.1 library with JDK
-      OPENSSL_LIB_NAME = libcrypto.so.1.1
-      ifeq ("$(wildcard $(OPENSSL_BUNDLE_LIB_PATH)/$(OPENSSL_LIB_NAME))", "")
-        # For OpenSSL v1.1.1, bundle libcrypto.a library with JDK
-        OPENSSL_LIB_NAME = libcrypto.a
-      endif
-    endif
+    LIBCRYPTO_NAMES := libcrypto.so.1.1 libcrypto.so.1.0.0 libcrypto.a
   else
-    OPENSSL_LIB_NAME = libcrypto.so
+    LIBCRYPTO_NAMES := libcrypto.so
+  endif
+  LIBCRYPTO_PATH := $(firstword $(wildcard $(addprefix $(OPENSSL_BUNDLE_LIB_PATH)/, $(LIBCRYPTO_NAMES))))
+  ifeq ($(LIBCRYPTO_PATH), )
+    $(error Cannot bundle OpenSSL - none of $(LIBCRYPTO_NAMES) are present in $(OPENSSL_BUNDLE_LIB_PATH))
   endif
 
-  # On Mac OS, update the crypto library path to @rpath as the default is /usr/local/lib/
+  LIBCRYPTO_TARGET_LIB := $(LIB_DST_DIR)/$(notdir $(LIBCRYPTO_PATH))
+  TARGETS += $(LIBCRYPTO_TARGET_LIB)
+  $(LIBCRYPTO_TARGET_LIB) : $(LIBCRYPTO_PATH)
+	$(call install-file)
   ifeq ($(OPENJDK_BUILD_OS), macosx)
-    .PHONY : RPATH_CRYPTO_LIB
-    TARGETS += RPATH_CRYPTO_LIB
-    RPATH_CRYPTO_LIB :
-	install_name_tool -id "@rpath/$(OPENSSL_LIB_NAME)" "$(OPENSSL_BUNDLE_LIB_PATH)/$(OPENSSL_LIB_NAME)"
-  endif
-
-  OPENSSL_TARGET_LIB = $(LIB_DST_DIR)/$(OPENSSL_LIB_NAME)
-  TARGETS += $(OPENSSL_TARGET_LIB)
-  $(OPENSSL_TARGET_LIB) : $(OPENSSL_BUNDLE_LIB_PATH)/$(OPENSSL_LIB_NAME)
-	@$(MKDIR) -p $(@D)
-	$(CP) $< $@
-  ifeq ($(OPENJDK_BUILD_OS), windows)
+    # update @rpath of the crypto library as the default is /usr/local/lib/
+	install_name_tool -id "@rpath/$(@F)" $@
+  else ifeq ($(OPENJDK_BUILD_OS), windows)
 	$(CHMOD) a+rx $@
   endif
+	$(call CodesignFile,"$@")
 
   ifeq (true,$(OPENJ9_ENABLE_JITSERVER))
-    # Copy OpenSSL SSL Lbrary
-    # To bundle first search for libssl 1.1.x library, if not found, search for 1.0.x
     ifeq ($(OPENJDK_TARGET_OS), linux)
-      OPENSSL_SSL_LIB_NAME = libssl.so.1.1
-      ifeq ("$(wildcard $(OPENSSL_BUNDLE_LIB_PATH)/$(OPENSSL_SSL_LIB_NAME))", "")
-        OPENSSL_SSL_LIB_NAME = libssl.so.1.0.0
-        ifeq ("$(wildcard $(OPENSSL_BUNDLE_LIB_PATH)/$(OPENSSL_SSL_LIB_NAME))", "")
-          OPENSSL_SSL_LIB_NAME =
-        endif
-      endif
+      LIBSSL_NAMES := libssl.so.1.1 libssl.so.1.0.0
+      LIBSSL_PATH := $(firstword $(wildcard $(addprefix $(OPENSSL_BUNDLE_LIB_PATH)/, $(LIBSSL_NAMES))))
 
-      ifneq ($(OPENSSL_SSL_LIB_NAME), )
-        OPENSSL_SSL_TARGET_LIB = $(LIB_DST_DIR)/$(OPENSSL_SSL_LIB_NAME)
-        TARGETS += $(OPENSSL_SSL_TARGET_LIB)
-        $(OPENSSL_SSL_TARGET_LIB) : $(OPENSSL_BUNDLE_LIB_PATH)/$(OPENSSL_SSL_LIB_NAME)
+      ifneq ($(LIBSSL_PATH), )
+        LIBSSL_TARGET_LIB = $(LIB_DST_DIR)/$(notdir $(LIBSSL_PATH))
+        TARGETS += $(LIBSSL_TARGET_LIB)
+        $(LIBSSL_TARGET_LIB) : $(LIBSSL_PATH)
 			$(call install-file)
-      endif # OPENSSL_SSL_LIB_NAME
+			$(call CodesignFile,"$@")
+      endif # LIBSSL_PATH
     endif # OPENJDK_TARGET_OS
   endif # OPENJ9_ENABLE_JITSERVER
 endif # OPENSSL_BUNDLE_LIB_PATH


### PR DESCRIPTION
When libcrypto.dylib or libssl.dylib are bundled in a jdk on OSX, they must also be signed.

* define CodesignFile in custom-spec.gmk and use in OpenJ9.gmk, Copy-java.base.gmk
* change AIX search order for libcrypto to match jdk8

Issue: eclipse/openj9#8389