### PR TITLE
Move copying in OpenJ9.gmk to module-specific makefiles

### DIFF
--- a/closed/CopySupport.gmk
+++ b/closed/CopySupport.gmk
@@ -1,0 +1,73 @@
+# ===========================================================================
+# (c) Copyright IBM Corp. 2020, 2020 All Rights Reserved
+# ===========================================================================
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.
+#
+# IBM designates this particular file as subject to the "Classpath" exception
+# as provided by IBM in the LICENSE file that accompanied this code.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, see <http://www.gnu.org/licenses/>.
+# ===========================================================================
+
+ifeq ($(origin LIB_DST_DIR),undefined)
+include CopyCommon.gmk
+endif
+
+EXE_DST_DIR := $(call FindExecutableDirForModule, $(MODULE))
+
+define openj9_copy_only
+	$(call install-file)
+endef
+
+define openj9_copy_and_sign
+	$(openj9_copy_only)
+	$(call CodesignFile,"$@")
+endef
+
+# openj9_copy_rule
+# ----------------
+# $1 - suffix of install action macro ('only' or 'and_sign')
+# $2 - source file path
+# $3 - target file path
+define openj9_copy_rule
+  TARGETS += $2
+  $3 : $2
+	$$(openj9_copy_$1)
+endef
+
+# openj9_copy_files
+# -----------------
+# $1 - suffix of install action macro ('only' or 'and_sign'; default is 'only')
+# $2 - sequence of file paths
+openj9_copy_files = \
+	$(eval $(call openj9_copy_rule,$(if $1,$(strip $1),only),$(word 1,$2),$(word 2,$2))) \
+	$(if $(word 2,$2),$(call openj9_copy_files,,$(wordlist 2,$(words $2),$2)))
+
+# openj9_copy_exes
+# ----------------
+# $1 = list of executable names without $(EXE_SUFFIX)
+openj9_copy_exes = \
+	$(foreach file, $1, \
+		$(call openj9_copy_files,and_sign, \
+			$(addsuffix /$(file)$(EXE_SUFFIX), \
+				$(OPENJ9_VM_BUILD_DIR) \
+				$(EXE_DST_DIR))))
+
+# openj9_copy_shlibs
+# ------------------
+# $1 = list of shared library names without $(LIBRARY_PREFIX) or $(SHARED_LIBRARY_SUFFIX)
+openj9_copy_shlibs = \
+	$(foreach name, $1, \
+		$(call openj9_copy_files,and_sign, \
+			$(addsuffix /$(call SHARED_LIBRARY,$(name)), \
+				$(OPENJ9_VM_BUILD_DIR) \
+				$(LIB_DST_DIR)/$(OPENJ9_LIBS_SUBDIR))))

--- a/closed/OpenJ9.gmk
+++ b/closed/OpenJ9.gmk
@@ -88,9 +88,7 @@ endif
 	clean-j9 \
 	clean-j9-dist \
 	clean-openj9-thirdparty-binaries \
-	create_build_jdk \
 	generate-j9jcl-sources \
-	openj9_build_jdk \
 	run-preprocessors-j9 \
 	stage-j9 \
 	#
@@ -111,181 +109,6 @@ define openj9_copy_tree_impl
 	@$(TOUCH) $1/$(OPENJ9_MARKER_FILE)
 endef
 
-openj9_build_jdk : build-j9
-	+$(MAKE) -f $(TOPDIR)/closed/OpenJ9.gmk create_build_jdk
-
-# openj9_joinall
-# --------------
-# yields all possible concatenations taking one word from each of up to 4 lists
-# e.g. $(call openj9_joinall, A B, 1 2) = A1 A2 B1 B2
-openj9_joinall = \
-	$(if $(firstword $5),$(error openj9_joinall handles at most 4 lists),$(strip \
-	$(if $(firstword $2),$(foreach word, $1,$(addprefix $(word), $(call openj9_joinall,$2,$3,$4))),$1)))
-
-openj9_install_copy = $(call install-file)
-
-define openj9_install_copy_and_sign
-	$(openj9_install_copy)
-	$(call CodesignFile,"$@")
-endef
-
-# openj9_install_rule
-# -------------------
-# $1 - suffix of install action macro (copy or copy_and_sign)
-# $2 - source file path
-# $3 - target file path
-define openj9_install_rule
-$3 : $2
-	$$(openj9_install_$1)
-endef
-
-# openj9_install_files
-# --------------------
-# $1 - suffix of install action macro (copy or copy_and_sign; default is copy)
-# $2 - sequence of file paths
-openj9_install_files = \
-	$(if $(word 2,$2), \
-		$(eval $(call openj9_install_rule,$(if $1,$(strip $1),copy),$(word 1,$2),$(word 2,$2))) \
-		$(call openj9_install_files,,$(wordlist 2,$(words $2),$2)), \
-		$(eval create_build_jdk : $2) \
-	)
-
-# openj9_install_exes
-# -------------------
-# $1 = module name
-# $2 = list of executable names without $(EXE_SUFFIX)
-openj9_install_exes = \
-	$(foreach file, $(addsuffix $(EXE_SUFFIX), $2), \
-		$(call openj9_install_files,copy_and_sign, \
-			$(addsuffix /$(file), \
-				$(OPENJ9_VM_BUILD_DIR) \
-				$(call FindExecutableDirForModule, $1) \
-				$(JDK_OUTPUTDIR)/bin)))
-
-# openj9_install_shlibs
-# ---------------------
-# $1 = module name
-# $2 = list of shared library names without $(LIBRARY_PREFIX) or $(SHARED_LIBRARY_SUFFIX)
-openj9_install_shlibs = \
-	$(foreach file, $(foreach name, $2, $(call SHARED_LIBRARY,$(name))), \
-		$(call openj9_install_files,copy_and_sign, \
-			$(addsuffix /$(file), \
-				$(OPENJ9_VM_BUILD_DIR) \
-				$(call FindLibDirForModule, $1)/$(OPENJ9_LIBS_SUBDIR) \
-				$(JDK_OUTPUTDIR)/$(OPENJ9_BIN_OR_LIB_DIR)/$(OPENJ9_LIBS_SUBDIR))))
-
-# jitserver
-
-ifeq (true,$(OPENJ9_ENABLE_JITSERVER))
-  $(call openj9_install_exes, java.base, jitserver)
-endif
-
-# redirector
-
-$(call openj9_install_files,copy_and_sign, \
-	$(addsuffix /$(call SHARED_LIBRARY,jvm), \
-		$(OPENJ9_VM_BUILD_DIR)/redirector \
-		$(call openj9_joinall, \
-			$(call FindLibDirForModule, java.base) $(JDK_OUTPUTDIR)/$(OPENJ9_BIN_OR_LIB_DIR), \
-			/j9vm /server)))
-
-# jsig
-
-$(call openj9_install_files,copy_and_sign, \
-	$(addsuffix $(call SHARED_LIBRARY,jsig), \
-		$(OPENJ9_VM_BUILD_DIR)/ \
-		$(call openj9_joinall, \
-			$(call FindLibDirForModule, java.base) $(JDK_OUTPUTDIR)/$(OPENJ9_BIN_OR_LIB_DIR), \
-			/ /j9vm/ /server/)))
-
-# CPU targets without JIT support.
-NO_JIT_CPUS := riscv64
-
-# java.base
-
-$(call openj9_install_shlibs, java.base, \
-	j9dmp29 \
-	j9gc29 \
-	j9gcchk29 \
-	j9hookable29 \
-	$(if $(filter $(NO_JIT_CPUS),$(OPENJDK_TARGET_CPU)),,j9jit29) \
-	j9jnichk29 \
-	j9jvmti29 \
-	j9prt29 \
-	j9thr29 \
-	j9trc29 \
-	j9vm29 \
-	j9vmchk29 \
-	j9vrb29 \
-	j9zlib29 \
-	jclse29 \
-	jvm \
-	omrsig \
-	)
-
-ifeq (windows,$(OPENJDK_TARGET_OS))
-  $(call openj9_install_files,, \
-	$(addsuffix /$(call STATIC_LIBRARY,jsig), \
-		$(OPENJ9_VM_BUILD_DIR)/lib \
-		$(call FindLibDirForModule, java.base) \
-		$(JDK_OUTPUTDIR)/lib))
-
-  $(call openj9_install_files,, \
-	$(OPENJ9_VM_BUILD_DIR)/redirector/$(call STATIC_LIBRARY,redirector_jvm) \
-	$(addsuffix /$(call STATIC_LIBRARY,jvm), \
-		$(call FindLibDirForModule, java.base) \
-		$(JDK_OUTPUTDIR)/lib))
-endif # windows
-
-$(foreach file, \
-		$(notdir $(wildcard $(OPENJ9_VM_BUILD_DIR)/java*.properties)) \
-		options.default, \
-	$(call openj9_install_files,, \
-		$(addsuffix /$(file), \
-			$(OPENJ9_VM_BUILD_DIR) \
-			$(call FindLibDirForModule, java.base) \
-			$(JDK_OUTPUTDIR)/lib)))
-
-ifeq (true,$(OPENJ9_ENABLE_DDR))
-
-$(call openj9_install_files,, \
-	$(addsuffix /j9ddr.dat, \
-		$(OPENJ9_VM_BUILD_DIR) \
-		$(addsuffix /$(OPENJ9_LIBS_SUBDIR), \
-			$(call FindLibDirForModule, java.base) \
-			$(JDK_OUTPUTDIR)/lib)))
-
-.PHONY : run-ddrgen
-
-$(OPENJ9_VM_BUILD_DIR)/j9ddr.dat : run-ddrgen
-
-run-ddrgen :
-  ifeq (true,$(OPENJ9_ENABLE_CMAKE))
-	$(MAKE) -C $(OPENJ9_VM_BUILD_DIR) j9ddr
-  else # OPENJ9_ENABLE_CMAKE
-	export CC="$(CC)" CXX="$(CXX)" $(EXPORT_MSVS_ENV_VARS) \
-		&& $(MAKE) -C $(OUTPUTDIR)/vm/ddr -f run_omrddrgen.mk
-  endif # OPENJ9_ENABLE_CMAKE
-
-endif # OPENJ9_ENABLE_DDR
-
-$(call openj9_install_files,, \
-	$(OPENJ9_TOPDIR)/longabout.html \
-	$(call FindLibDirForModule, java.base)/openj9-notices.html)
-
-# contributions to other modules
-$(call openj9_install_shlibs, java.management, management management_ext)
-$(call openj9_install_shlibs, openj9.cuda, cuda4j29)
-$(call openj9_install_shlibs, openj9.dtfj, j9jextract)
-$(call openj9_install_shlibs, openj9.sharedclasses, j9shr29)
-
-$(foreach file, J9TraceFormat.dat OMRTraceFormat.dat, \
-	$(call openj9_install_files,, \
-		$(addsuffix /$(file), \
-			$(OPENJ9_VM_BUILD_DIR) \
-			$(call FindLibDirForModule, openj9.traceformat) \
-			$(JDK_OUTPUTDIR)/lib)))
-
 # openj9_test_image_rules
 # -----------------------
 # $1 = absolute library path
@@ -293,7 +116,8 @@ define openj9_test_image_rules
   openj9_test_image : $(TEST_IMAGE_DIR)/openj9/$(notdir $(strip $1))
 
   $(TEST_IMAGE_DIR)/openj9/$(notdir $(strip $1)) : $(strip $1)
-	$$(openj9_install_copy_and_sign)
+	$$(call install-file)
+	$$(call CodesignFile,"$$@")
 endef
 
 $(foreach file, \
@@ -617,11 +441,21 @@ ifeq (true,$(OPENJ9_ENABLE_JITSERVER))
   endif # OPENJ9_ENABLE_CMAKE
 endif # OPENJ9_ENABLE_JITSERVER
 
+ifneq (true,$(OPENJ9_ENABLE_DDR))
+  DDR_COMMAND :=
+else ifeq (true,$(OPENJ9_ENABLE_CMAKE))
+  DDR_COMMAND := $(MAKE) -C $(OPENJ9_VM_BUILD_DIR) j9ddr
+else
+  DDR_COMMAND := export CC="$(CC)" CXX="$(CXX)" $(EXPORT_MSVS_ENV_VARS) \
+	&& $(MAKE) -C $(OUTPUTDIR)/vm/ddr -f run_omrddrgen.mk
+endif # OPENJ9_ENABLE_DDR
+
 build-j9 : run-preprocessors-j9
 	@$(ECHO) Compiling OpenJ9 in $(OUTPUTDIR)/vm
 	export OPENJ9_BUILD=true $(EXPORT_MSVS_ENV_VARS) $(CUSTOM_COMPILER_ENV_VARS) \
 		&& $(MAKE) -C $(OUTPUTDIR)/vm $(MAKEFLAGS) all
 	@$(ECHO) OpenJ9 compile complete
+	$(DDR_COMMAND)
 
 J9JCL_SOURCES_DONEFILE := $(MAKESUPPORT_OUTPUTDIR)/j9jcl_sources.done
 

--- a/closed/custom/Main.gmk
+++ b/closed/custom/Main.gmk
@@ -54,9 +54,19 @@ openssl-build : buildtools-langtools
 	+$(OPENSSL_MAKE)
 
 j9vm-build : openssl-build
-	+$(OPENJ9_MAKE) openj9_build_jdk
+	+$(OPENJ9_MAKE) build-j9
 
-java.base-copy : j9vm-build
+# Modules with content created by j9vm-build:
+OPENJ9_VM_MODULES := \
+	java.base \
+	java.management \
+	openj9.cuda \
+	openj9.dtfj \
+	openj9.sharedclasses \
+	openj9.traceformat \
+	#
+
+$(addsuffix -copy, $(OPENJ9_VM_MODULES)) : j9vm-build
 
 java.base-libs : java.base-copy
 

--- a/closed/custom/copy/Copy-java.base.gmk
+++ b/closed/custom/copy/Copy-java.base.gmk
@@ -18,16 +18,98 @@
 # 2 along with this work; if not, see <http://www.gnu.org/licenses/>.
 # ===========================================================================
 
-TARGETS += \
-	$(INCLUDE_TARGET_DIR)/jvmti.h \
-	$(INCLUDE_TARGET_DIR)/ibmjvmti.h \
-	#
+include $(TOPDIR)/closed/CopySupport.gmk
 
-$(INCLUDE_TARGET_DIR)/jvmti.h : $(OPENJ9_VM_BUILD_DIR)/include/jvmti.h
-	$(call install-file)
+# header files
 
-$(INCLUDE_TARGET_DIR)/ibmjvmti.h : $(TOPDIR)/openj9/runtime/include/ibmjvmti.h
-	$(call install-file)
+$(call openj9_copy_files,, \
+	$(OPENJ9_TOPDIR)/runtime/include/ibmjvmti.h \
+	$(INCLUDE_TARGET_DIR)/ibmjvmti.h)
+
+$(call openj9_copy_files,, \
+	$(OPENJ9_VM_BUILD_DIR)/include/jvmti.h \
+	$(INCLUDE_TARGET_DIR)/jvmti.h)
+
+# jitserver
+
+ifeq (true,$(OPENJ9_ENABLE_JITSERVER))
+$(call openj9_copy_exes, jitserver)
+endif
+
+# redirector
+
+$(call openj9_copy_files,and_sign, \
+	$(addsuffix $(call SHARED_LIBRARY,jvm), \
+		$(OPENJ9_VM_BUILD_DIR)/redirector/ \
+		$(addprefix $(LIB_DST_DIR), /j9vm/ /server/)))
+
+# jsig
+
+$(call openj9_copy_files,and_sign, \
+	$(addsuffix $(call SHARED_LIBRARY,jsig), \
+		$(OPENJ9_VM_BUILD_DIR)/ \
+		$(addprefix $(LIB_DST_DIR), / /j9vm/ /server/)))
+
+# CPU targets without JIT support.
+NO_JIT_CPUS := riscv64
+
+$(call openj9_copy_shlibs, \
+	j9dmp29 \
+	j9gc29 \
+	j9gcchk29 \
+	j9hookable29 \
+	$(if $(filter $(NO_JIT_CPUS),$(OPENJDK_TARGET_CPU)),,j9jit29) \
+	j9jnichk29 \
+	j9jvmti29 \
+	j9prt29 \
+	j9thr29 \
+	j9trc29 \
+	j9vm29 \
+	j9vmchk29 \
+	j9vrb29 \
+	j9zlib29 \
+	jclse29 \
+	jvm \
+	omrsig \
+	)
+
+# static libraries that are needed on some platforms
+
+ifneq (,$(filter windows zos,$(OPENJDK_TARGET_OS)))
+
+$(call openj9_copy_files,, \
+	$(addsuffix /$(call STATIC_LIBRARY,jsig), \
+		$(OPENJ9_VM_BUILD_DIR)/lib \
+		$(LIB_DST_DIR)))
+
+$(call openj9_copy_files,, \
+	$(OPENJ9_VM_BUILD_DIR)/redirector/$(call STATIC_LIBRARY,redirector_jvm) \
+	$(LIB_DST_DIR)/$(call STATIC_LIBRARY,jvm))
+
+endif # OPENJDK_TARGET_OS
+
+# properties files, etc.
+
+$(foreach file, \
+		$(notdir $(wildcard $(OPENJ9_VM_BUILD_DIR)/java*.properties)) \
+		options.default, \
+	$(call openj9_copy_files,, \
+		$(addsuffix /$(file), \
+			$(OPENJ9_VM_BUILD_DIR) \
+			$(LIB_DST_DIR))))
+
+$(call openj9_copy_files,, \
+	$(OPENJ9_TOPDIR)/longabout.html \
+	$(LEGAL_DST_DIR)/openj9-notices.html)
+
+ifeq (true,$(OPENJ9_ENABLE_DDR))
+
+$(call openj9_copy_files,, \
+	$(addsuffix /j9ddr.dat, \
+		$(OPENJ9_VM_BUILD_DIR) \
+		$(LIB_DST_DIR)/$(OPENJ9_LIBS_SUBDIR)))
+
+endif # OPENJ9_ENABLE_DDR
 
 ##########################################################################################
 # Optionally copy OpenSSL Crypto Lbrary
@@ -47,8 +129,7 @@ ifneq ($(OPENSSL_BUNDLE_LIB_PATH), )
   else ifeq ($(OPENJDK_TARGET_OS), aix)
     # OpenSSL 1.1.1 on AIX has switched to use archive library files (natural way)
     # instead of 'libcrypto.so' files.
-    # For reference, corresponding OpenSSL PR is
-    #     https://github.com/openssl/openssl/pull/6487
+    # See https://github.com/openssl/openssl/pull/6487.
     LIBCRYPTO_NAMES := libcrypto.so.1.1 libcrypto.so.1.0.0 libcrypto.a
   else
     LIBCRYPTO_NAMES := libcrypto.so

--- a/closed/make/copy/Copy-java.management.gmk
+++ b/closed/make/copy/Copy-java.management.gmk
@@ -1,0 +1,23 @@
+# ===========================================================================
+# (c) Copyright IBM Corp. 2020, 2020 All Rights Reserved
+# ===========================================================================
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.
+#
+# IBM designates this particular file as subject to the "Classpath" exception
+# as provided by IBM in the LICENSE file that accompanied this code.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, see <http://www.gnu.org/licenses/>.
+# ===========================================================================
+
+include $(TOPDIR)/closed/CopySupport.gmk
+
+$(call openj9_copy_shlibs, management management_ext)

--- a/closed/make/copy/Copy-openj9.cuda.gmk
+++ b/closed/make/copy/Copy-openj9.cuda.gmk
@@ -1,0 +1,23 @@
+# ===========================================================================
+# (c) Copyright IBM Corp. 2020, 2020 All Rights Reserved
+# ===========================================================================
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.
+#
+# IBM designates this particular file as subject to the "Classpath" exception
+# as provided by IBM in the LICENSE file that accompanied this code.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, see <http://www.gnu.org/licenses/>.
+# ===========================================================================
+
+include $(TOPDIR)/closed/CopySupport.gmk
+
+$(call openj9_copy_shlibs, cuda4j29)

--- a/closed/make/copy/Copy-openj9.dtfj.gmk
+++ b/closed/make/copy/Copy-openj9.dtfj.gmk
@@ -1,0 +1,23 @@
+# ===========================================================================
+# (c) Copyright IBM Corp. 2020, 2020 All Rights Reserved
+# ===========================================================================
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.
+#
+# IBM designates this particular file as subject to the "Classpath" exception
+# as provided by IBM in the LICENSE file that accompanied this code.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, see <http://www.gnu.org/licenses/>.
+# ===========================================================================
+
+include $(TOPDIR)/closed/CopySupport.gmk
+
+$(call openj9_copy_shlibs, j9jextract)

--- a/closed/make/copy/Copy-openj9.sharedclasses.gmk
+++ b/closed/make/copy/Copy-openj9.sharedclasses.gmk
@@ -1,0 +1,23 @@
+# ===========================================================================
+# (c) Copyright IBM Corp. 2020, 2020 All Rights Reserved
+# ===========================================================================
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.
+#
+# IBM designates this particular file as subject to the "Classpath" exception
+# as provided by IBM in the LICENSE file that accompanied this code.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, see <http://www.gnu.org/licenses/>.
+# ===========================================================================
+
+include $(TOPDIR)/closed/CopySupport.gmk
+
+$(call openj9_copy_shlibs, j9shr29)

--- a/closed/make/copy/Copy-openj9.traceformat.gmk
+++ b/closed/make/copy/Copy-openj9.traceformat.gmk
@@ -1,0 +1,27 @@
+# ===========================================================================
+# (c) Copyright IBM Corp. 2020, 2020 All Rights Reserved
+# ===========================================================================
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.
+#
+# IBM designates this particular file as subject to the "Classpath" exception
+# as provided by IBM in the LICENSE file that accompanied this code.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, see <http://www.gnu.org/licenses/>.
+# ===========================================================================
+
+include $(TOPDIR)/closed/CopySupport.gmk
+
+$(foreach file, J9TraceFormat.dat OMRTraceFormat.dat, \
+	$(call openj9_copy_files,, \
+		$(addsuffix /$(file), \
+			$(OPENJ9_VM_BUILD_DIR) \
+			$(LIB_DST_DIR))))


### PR DESCRIPTION
Integrates better with openjdk makefiles, lays the groundwork for collecting debuginfo files.