### PR TITLE
Remove management shared lib. Correct management_ext shared lib module.

### DIFF
--- a/closed/custom/Main.gmk
+++ b/closed/custom/Main.gmk
@@ -59,7 +59,7 @@ j9vm-build : openssl-build
 # Modules with content created by j9vm-build:
 OPENJ9_VM_MODULES := \
 	java.base \
-	java.management \
+	jdk.management \
 	openj9.cuda \
 	openj9.dtfj \
 	openj9.sharedclasses \

--- a/closed/make/copy/Copy-jdk.management.gmk
+++ b/closed/make/copy/Copy-jdk.management.gmk
@@ -20,4 +20,4 @@
 
 include $(TOPDIR)/closed/CopySupport.gmk
 
-$(call openj9_copy_shlibs, management management_ext)
+$(call openj9_copy_shlibs, management_ext)


### PR DESCRIPTION
Remove the OpenJ9 management shared lib, OpenJ9 is modified not
to supply it. It's not needed for JDK11+, FileSystemImpl natives are
found in the management_agent shared library.

The management_ext shared lib belongs in the jdk.management module, not
the java.management module.

Related to https://github.com/eclipse/openj9/pull/8631