### PR TITLE
Omit inappropriate man pages

### DIFF
--- a/closed/custom/Images-post.gmk
+++ b/closed/custom/Images-post.gmk
@@ -1,0 +1,36 @@
+# ===========================================================================
+# (c) Copyright IBM Corp. 2020, 2020 All Rights Reserved
+# ===========================================================================
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.
+#
+# IBM designates this particular file as subject to the "Classpath" exception
+# as provided by IBM in the LICENSE file that accompanied this code.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, see <http://www.gnu.org/licenses/>.
+# ===========================================================================
+
+# Omit man pages for launchers not provided by OpenJ9 or that describe
+# behavior that differs from the OpenJ9 implementation.
+OPENJ9_UNWANTED_MAN_PAGES := \
+	jcmd \
+	jhat \
+	jinfo \
+	jps \
+	jstack \
+	jstat \
+	jstatd \
+	#
+
+OPENJ9_MAN_PAGE_FILTER := $(foreach page,$(OPENJ9_UNWANTED_MAN_PAGES),%/$(page).1)
+
+$(foreach var, JDK_TARGETS JRE_TARGETS, \
+	$(eval $(var) := $$(filter-out $(OPENJ9_MAN_PAGE_FILTER), $($(var)))))


### PR DESCRIPTION
Don't include man pages:
* for launchers not implemented by OpenJ9
* that describe behavior that differs from the OpenJ9 implementation

See eclipse/openj9#8732.