### PR TITLE
(0.20.0) AIX: create .debuginfo files

### DIFF
--- a/make/autoconf/jdk-options.m4
+++ b/make/autoconf/jdk-options.m4
@@ -23,6 +23,10 @@
 # questions.
 #
 
+# ===========================================================================
+# (c) Copyright IBM Corp. 2020, 2020 All Rights Reserved
+# ===========================================================================
+
 ###############################################################################
 # Check which variant of the JDK that we want to build.
 # Currently we have:
@@ -291,15 +295,9 @@ AC_DEFUN_ONCE([JDKOPT_SETUP_DEBUG_SYMBOLS],
       [AS_HELP_STRING([--with-native-debug-symbols],
       [set the native debug symbol configuration (none, internal, external, zipped) @<:@varying@:>@])],
       [
-        if test "x$OPENJDK_TARGET_OS" = xaix; then
-          if test "x$withval" = xexternal || test "x$withval" = xzipped; then
-            AC_MSG_ERROR([AIX only supports the parameters 'none' and 'internal' for --with-native-debug-symbols])
-          fi
-        else
-          if test "x$OPENJDK_TARGET_OS" = xwindows; then
-            if test "x$withval" = xinternal; then
-              AC_MSG_ERROR([Windows does not support the parameter 'internal' for --with-native-debug-symbols])
-            fi
+        if test "x$OPENJDK_TARGET_OS" = xwindows; then
+          if test "x$withval" = xinternal; then
+            AC_MSG_ERROR([Windows does not support the parameter 'internal' for --with-native-debug-symbols])
           fi
         fi
       ],
@@ -307,12 +305,7 @@ AC_DEFUN_ONCE([JDKOPT_SETUP_DEBUG_SYMBOLS],
         if test "x$STATIC_BUILD" = xtrue; then
           with_native_debug_symbols="none"
         else
-          if test "x$OPENJDK_TARGET_OS" = xaix; then
-            # AIX doesn't support 'external' so use 'internal' as default
-            with_native_debug_symbols="internal"
-          else
-            with_native_debug_symbols="external"
-          fi
+          with_native_debug_symbols="external"
         fi
       ])
   NATIVE_DEBUG_SYMBOLS=$with_native_debug_symbols

--- a/make/common/NativeCompilation.gmk
+++ b/make/common/NativeCompilation.gmk
@@ -23,6 +23,10 @@
 # questions.
 #
 
+# ===========================================================================
+# (c) Copyright IBM Corp. 2020, 2020 All Rights Reserved
+# ===========================================================================
+
 # When you read this source. Remember that $(sort ...) has the side effect
 # of removing duplicates. It is actually this side effect that is
 # desired whenever sort is used below!
@@ -823,6 +827,9 @@ define SetupNativeCompilationBody
               $$($1_OUTPUT_DIR)/$$($1_BASENAME).dSYM/Contents/Resources/DWARF/$$($1_BASENAME)
           $1_CREATE_DEBUGINFO_CMDS := \
               $(DSYMUTIL) --out $$($1_OUTPUT_DIR)/$$($1_BASENAME).dSYM $$($1_TARGET)
+        else ifeq ($(OPENJDK_TARGET_OS), aix)
+          $1_DEBUGINFO_FILES := $$($1_OUTPUT_DIR)/$$($1_NOSUFFIX).debuginfo
+          $1_CREATE_DEBUGINFO_CMDS := $(CP) -f $$($1_TARGET) $$($1_DEBUGINFO_FILES)
         endif # OPENJDK_TARGET_OS
 
         # Since the link rule creates more than one file that we want to track,


### PR DESCRIPTION
This is a replay of #276 for the 0.20.0 release branch.
See eclipse/openj9#8821.