### PR TITLE
Set env var MALLOCOPTIONS=multiheap,considersize on AIX

### DIFF
--- a/src/java.base/unix/native/libjli/java_md_solinux.c
+++ b/src/java.base/unix/native/libjli/java_md_solinux.c
@@ -310,9 +310,9 @@ CreateExecutionEnvironment(int *pargc, char ***pargv,
 
 #ifdef AIX
     const char *mallocOptionsName = "MALLOCOPTIONS";
-    const char *mallocOptionsValue = "multiheap";
+    const char *mallocOptionsValue = "multiheap,considersize";
     if (setenv(mallocOptionsName, mallocOptionsValue, 0) != 0) {
-        fprintf(stderr, "setenv('MALLOCOPTIONS=multiheap') failed: performance may be affected\n");
+        fprintf(stderr, "setenv('MALLOCOPTIONS=multiheap,considersize') failed: performance may be affected\n");
     }
 #endif
 


### PR DESCRIPTION
The previous setting `MALLOCOPTIONS=multiheap` uses too much memory in
some cases.

Issue eclipse/openj9#8842

Signed-off-by: Peter Shipton <Peter_Shipton@ca.ibm.com>