### PR TITLE
Add support to the installed cross-compiler for RISCV

### DIFF
--- a/closed/autoconf/custom-spec.gmk.in
+++ b/closed/autoconf/custom-spec.gmk.in
@@ -138,6 +138,11 @@ endif
 ifeq (riscv64,$(OPENJDK_TARGET_CPU))
   ifeq (cross,$(COMPILE_TYPE))
     export SYSROOT_CFLAGS
+    # Change the prefix of the cross toolchain if the corresponding
+    # software package is installed on the host system.
+    ifeq (install,$(RISCV_TOOLCHAIN_TYPE))
+      export RISCV_CROSSTOOLS_PREFIX := riscv64-linux-gnu
+    endif
   else
     JAVA_FLAGS += -DserverStartupTimeout=36000
   endif


### PR DESCRIPTION
The change is to ensure the installed cross-compiler
is correctly set up on the host system from OpenJDK11
perspective by changing the prefix of the cross-toolchain
if users prefer the installed cross-compiler rather than
building a cross-compiler from the source.

Issue: #218

Signed-off-by: Cheng Jin <jincheng@ca.ibm.com>