### PR TITLE
WIP: Check the correct message in ERR_RECEIVED when JITServer is enabled

### DIFF
--- a/test/jdk/java/lang/ProcessBuilder/InheritIO/InheritIO.sh
+++ b/test/jdk/java/lang/ProcessBuilder/InheritIO/InheritIO.sh
@@ -74,7 +74,7 @@ do
     fi
 
     ERR_EXPECTED='exit value: 0'
-    ERR_RECEIVED=`cat stderr.txt`
+    ERR_RECEIVED=`tail -n 1 stderr.txt`
     if [ "x${ERR_RECEIVED}" != "x${ERR_EXPECTED}" ]; then
         echo "FAIL: unexpected '${ERR_RECEIVED}' in stderr"
         exit 1


### PR DESCRIPTION
`InheritIO.sh` fails the test if `stderr.txt` is not equal to `"exit value: 0"`. With JITServer is enabled, the first message in `stderr.txt` is `"JITServer is currently a technology preview. Its use is not yet supported"` before the second message `"exit value: 0"`. Updated `ERR_RECEIVED` to retrieve the correct message when JITServer is enabled.

Related to eclipse/openj9#9169

Signed-off-by: Annabelle Huo <Annabelle.Huo@ibm.com>