### PR TITLE
Added special case for EngineAEADDec in NativeChaCha20Cipher.engineUpdate

### DIFF
--- a/closed/src/java.base/share/classes/com/sun/crypto/provider/NativeChaCha20Cipher.java
+++ b/closed/src/java.base/share/classes/com/sun/crypto/provider/NativeChaCha20Cipher.java
@@ -636,7 +636,12 @@ abstract class NativeChaCha20Cipher extends CipherSpi {
     protected byte[] engineUpdate(byte[] in, int inOfs, int inLen) {
         byte[] out = new byte[inLen];
         try {
-            engine.doUpdate(in, inOfs, inLen, out, 0);
+            int size = engine.doUpdate(in, inOfs, inLen, out, 0);
+            // Special case for EngineAEADDec, doUpdate only buffers the input
+            // So the output array must be empty since no encryption happened yet
+            if (size == 0) {
+                return new byte[0];
+            }
         } catch (ShortBufferException | KeyException exc) {
             throw new RuntimeException(exc);
         }


### PR DESCRIPTION
Fixing [OpenJ9 Issue #9429](https://github.com/eclipse/openj9/issues/9429).

I added a special case in the ChaCha20 update function: when the size returned by the `doUpdate` is zero, the function must return a new zero-sized array since the input was only buffered and nothing was encrypted.

Signed-off-by: Samer AL Masri <samasri@ibm.com>