### PR TITLE
Enable cmake by default on aarch64

### DIFF
--- a/closed/autoconf/custom-hook.m4
+++ b/closed/autoconf/custom-hook.m4
@@ -60,7 +60,7 @@ AC_DEFUN([OPENJ9_CONFIGURE_CMAKE],
     ],
     [
       case "$OPENJ9_PLATFORM_CODE" in
-        oa64|xa64|xl64|xz64)
+        oa64|xa64|xl64|xr64|xz64)
           with_cmake=cmake
           ;;
         *)


### PR DESCRIPTION
Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>