### PR TITLE
Stop ignoring warnings from openj9.dataaccess and openj9.jvm

### DIFF
--- a/closed/custom/common/SetupJavaCompilers.gmk
+++ b/closed/custom/common/SetupJavaCompilers.gmk
@@ -22,10 +22,8 @@
 WARNING_MODULES := \
 	java.base \
 	jdk.management \
-	openj9.dataaccess \
 	openj9.dtfj \
 	openj9.dtfjview \
-	openj9.jvm \
 	openj9.sharedclasses \
 	openj9.traceformat \
 	#


### PR DESCRIPTION
There will be no warnings in openj9.dataaccess or openj9.jvm to be ignored after eclipse/openj9#10270 and eclipse/openj9#10271 are merged: this will contribute to ensuring it stays that way.