### PR TITLE
Revert change to libjdwp/export/sys.h

### DIFF
--- a/src/jdk.jdwp.agent/share/native/libjdwp/export/sys.h
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/export/sys.h
@@ -23,12 +23,6 @@
  * questions.
  */
 
-/*
- * ===========================================================================
- * (c) Copyright IBM Corp. 2019, 2019 All Rights Reserved
- * ===========================================================================
- */
-
 #ifndef JDWP_SYS_H
 #define JDWP_SYS_H
 
@@ -43,7 +37,7 @@
 
 /* Implemented in linker_md.c */
 
-void    dbgsysBuildLibName(char *, size_t, const char *, const char *);
+void    dbgsysBuildLibName(char *, int, const char *, const char *);
 void *  dbgsysLoadLibrary(const char *, char *err_buf, int err_buflen);
 void    dbgsysUnloadLibrary(void *);
 void *  dbgsysFindLibraryEntry(void *, const char *);


### PR DESCRIPTION
Otherwise it is inconsistent with:
* 8229378: jdwp library loader in linker_md.c quietly truncates on buffer overflow

The result is a compile error on Windows: https://ci.eclipse.org/openj9/job/Build_JDK11_x86-64_windows_OpenJDK11/67.

Note: this targets the openj9-staging branch.