### PR TITLE
Copy jni_convert.h from source tree

### DIFF
--- a/closed/custom/copy/Copy-java.base.gmk
+++ b/closed/custom/copy/Copy-java.base.gmk
@@ -32,7 +32,7 @@ $(call openj9_copy_files,, \
 
 ifeq ($(OPENJDK_TARGET_OS), zos)
 $(call openj9_copy_files,, \
-	$(OPENJ9_VM_BUILD_DIR)/include/jni_convert.h \
+	$(OPENJ9_TOPDIR)/runtime/include/jni_convert.h \
 	$(INCLUDE_TARGET_DIR)/jni_convert.h)
 endif
 


### PR DESCRIPTION
Copy from source tree rather than build tree as the file does not exist
in the build tree for cmake builds.

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>