### PR TITLE
Add accelerated zlibNX to LIBPATH for AIX P9 or newer systems

### DIFF
--- a/src/java.base/unix/native/libjli/java_md_solinux.h
+++ b/src/java.base/unix/native/libjli/java_md_solinux.h
@@ -23,6 +23,12 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2021, 2021 All Rights Reserved
+ * ===========================================================================
+ */
+
 #ifndef JAVA_MD_SOLINUX_H
 #define JAVA_MD_SOLINUX_H
 
@@ -59,5 +65,30 @@ static const char *user_dir     = "/java";
 #else
 #include <pthread.h>
 #endif
+
+#ifdef AIX
+#define ZLIBNX_PATH "/usr/opt/zlibNX/lib"
+
+#ifndef POWER_9
+#define POWER_9 0x20000 /* 9 class CPU */
+#endif
+
+#ifndef POWER_10
+#define POWER_10 0x40000 /* 10 class CPU */
+#endif
+
+#define power_9_andup() ((POWER_9  == _system_configuration.implementation) \
+                        || (POWER_10 == _system_configuration.implementation))
+
+#ifndef SC_NX_CAP
+#define SC_NX_CAP 60
+#endif
+
+#ifndef NX_GZIP_PRESENT
+#define NX_GZIP_PRESENT 0x00000001
+#endif
+
+#define power_nx_gzip() (0 != ((long)getsystemcfg(SC_NX_CAP) & NX_GZIP_PRESENT))
+#endif /* AIX */
 
 #endif /* JAVA_MD_SOLINUX_H */


### PR DESCRIPTION
`zlibNX` is an accelerated replacement for `zlib`, it make use of the NX accelerator in P9 and newer systems.
This PR enable the use of `zlibNX` for AIX systems by adding it to the `LIBPATH` if the system is P9 or newer and has the NX accelerator enabled.

Signed-off-by: Abdulrahman Alattas <rmnattas@gmail.com>