### PR TITLE
Include j9vrb_full library in mixed references builds

### DIFF
--- a/closed/custom/copy/Copy-java.base.gmk
+++ b/closed/custom/copy/Copy-java.base.gmk
@@ -1,5 +1,5 @@
 # ===========================================================================
-# (c) Copyright IBM Corp. 2017, 2020 All Rights Reserved
+# (c) Copyright IBM Corp. 2017, 2021 All Rights Reserved
 # ===========================================================================
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
@@ -77,6 +77,7 @@ $(call openj9_copy_shlibs, \
 	j9vm29 \
 	j9vmchk29 \
 	j9vrb29 \
+	$(if $(filter static,$(OMR_MIXED_REFERENCES_MODE)),j9vrb_full29) \
 	j9zlib29 \
 	jclse29 \
 	jvm \


### PR DESCRIPTION
Includes the j9vrb_full library in the JDK for mixed references builds; depends on https://github.com/eclipse/openj9/pull/11662.

Ports:
- JDK 8: https://github.com/ibmruntimes/openj9-openjdk-jdk8/pull/470
~- JDK 15: https://github.com/ibmruntimes/openj9-openjdk-jdk15/pull/53~ -- not needed
- JDK 16: https://github.com/ibmruntimes/openj9-openjdk-jdk16/pull/7
- JDK Next: https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/269