### PR TITLE
Default jdk11 to build mixedrefs, unless cross compiling 

### DIFF
--- a/closed/autoconf/custom-hook.m4
+++ b/closed/autoconf/custom-hook.m4
@@ -1,5 +1,5 @@
 # ===========================================================================
-# (c) Copyright IBM Corp. 2017, 2020 All Rights Reserved
+# (c) Copyright IBM Corp. 2017, 2021 All Rights Reserved
 # ===========================================================================
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
@@ -358,23 +358,25 @@ AC_DEFUN([OPENJ9_PLATFORM_SETUP],
   # Default OPENJ9_BUILD_OS=OPENJDK_BUILD_OS, but override with OpenJ9 equivalent as appropriate
   OPENJ9_BUILD_OS="${OPENJDK_BUILD_OS}"
 
-  OMR_MIXED_REFERENCES_MODE=off
-  if test "x$with_mixedrefs" != x -a "x$with_mixedrefs" != xno; then
-    if test "x$with_mixedrefs" = xyes -o "x$with_mixedrefs" = xstatic; then
+  if test "x$with_noncompressedrefs" = xyes -o "x$with_mixedrefs" = xno -o "x$COMPILE_TYPE" = xcross ; then
+    OMR_MIXED_REFERENCES_MODE=off
+    if test "x$with_noncompressedrefs" = xyes ; then
+      OPENJ9_BUILD_MODE_ARCH="${OPENJ9_CPU}"
+      OPENJ9_LIBS_SUBDIR=default
+    else
+      OPENJ9_BUILD_MODE_ARCH="${OPENJ9_CPU}_cmprssptrs"
+      OPENJ9_LIBS_SUBDIR=compressedrefs
+    fi
+  else
+    if test "x$with_mixedrefs" = x -o "x$with_mixedrefs" = xyes -o "x$with_mixedrefs" = xstatic ; then
       OMR_MIXED_REFERENCES_MODE=static
-    elif test "x$with_mixedrefs" = xdynamic; then
+    elif test "x$with_mixedrefs" = xdynamic ; then
       OMR_MIXED_REFERENCES_MODE=dynamic
     else
       AC_MSG_ERROR([OpenJ9 supports --with-mixedrefs=static and --with-mixedrefs=dynamic])
     fi
     OPENJ9_BUILD_MODE_ARCH="${OPENJ9_CPU}_mxdptrs"
     OPENJ9_LIBS_SUBDIR=default
-  elif test "x$with_noncompressedrefs" = xyes ; then
-    OPENJ9_BUILD_MODE_ARCH="${OPENJ9_CPU}"
-    OPENJ9_LIBS_SUBDIR=default
-  else
-    OPENJ9_BUILD_MODE_ARCH="${OPENJ9_CPU}_cmprssptrs"
-    OPENJ9_LIBS_SUBDIR=compressedrefs
   fi
 
   if test "x$OPENJ9_CPU" = xx86-64 ; then


### PR DESCRIPTION
Prepare for switching jdk11 to build mixedrefs by default. This is dependent on https://github.com/AdoptOpenJDK/TKG/pull/155 being merged first.