### PR TITLE
Fix help for '--with-openssl'

### DIFF
--- a/closed/autoconf/custom-hook.m4
+++ b/closed/autoconf/custom-hook.m4
@@ -535,7 +535,7 @@ AC_DEFUN_ONCE([CUSTOM_LATE_HOOK],
 AC_DEFUN([CONFIGURE_OPENSSL],
 [
   AC_ARG_WITH(openssl, [AS_HELP_STRING([--with-openssl],
-    [Use either fetched | system | <path to openssl 1.0.2 (and above)])])
+    [Use either fetched | system | <path to openssl version 1.0.2 or later>])])
   AC_ARG_ENABLE(openssl-bundling, [AS_HELP_STRING([--enable-openssl-bundling],
     [enable bundling of the openssl crypto library with the jdk build])])
   WITH_OPENSSL=yes


### PR DESCRIPTION
A repeat of ibmruntimes/openj9-openjdk-jdk#289 for Java 11.