### PR TITLE
Improve backward compatibility of openj9.dtfj

### DIFF
--- a/closed/DDR.gmk
+++ b/closed/DDR.gmk
@@ -65,7 +65,6 @@ DDR_GENSRC_DIR := $(SUPPORT_OUTPUTDIR)/gensrc/openj9.dtfj
 DDR_CLASSES_MARKER := $(DDR_SUPPORT_DIR)/classes.done
 DDR_POINTERS_MARKER := $(DDR_SUPPORT_DIR)/gensrc-pointers.done
 DDR_STRUCTURES_MARKER := $(DDR_SUPPORT_DIR)/gensrc-structures.done
-DDR_TOOLS_MARKER := $(DDR_SUPPORT_DIR)/tools.done
 DDR_VM_MARKER := $(DDR_SUPPORT_DIR)/debugtools.done
 
 #############################################################################
@@ -115,12 +114,19 @@ $(DDR_POINTERS_MARKER) : $(DDR_SUPERSET_FILE) $(BUILD_DDR_TOOLS)
 		-o $(DDR_GENSRC_DIR)
 	@$(TOUCH) $@
 
-$(DDR_STRUCTURES_MARKER) : $(DDR_SUPERSET_FILE) $(BUILD_DDR_TOOLS)
+# Any new references to constants must be paired with additions to the compatibility
+# list unless those constants were defined long ago.
+DDR_COMPATIBILITY_FILE := $(DDR_VM_SRC_ROOT)/com/ibm/j9ddr/CompatibilityConstants29.dat
+DDR_RESTRICT_FILE := $(OPENJ9_TOPDIR)/debugtools/DDR_VM/data/superset-constants.dat
+
+$(DDR_STRUCTURES_MARKER) : $(DDR_SUPERSET_FILE) $(DDR_RESTRICT_FILE) $(DDR_COMPATIBILITY_FILE) $(BUILD_DDR_TOOLS)
 	@$(ECHO) Generating DDR structure stub source files
 	@$(JAVA) -cp $(DDR_TOOLS_BIN) com.ibm.j9ddr.tools.StructureStubGenerator \
 		-f $(dir $(DDR_SUPERSET_FILE)) \
 		-s $(notdir $(DDR_SUPERSET_FILE)) \
 		-p com.ibm.j9ddr.vm29.structure \
+		-r $(DDR_RESTRICT_FILE) \
+		-c $(DDR_COMPATIBILITY_FILE) \
 		-o $(DDR_GENSRC_DIR)
 	@$(TOUCH) $@
 

--- a/closed/custom/CompileJavaModules.gmk
+++ b/closed/custom/CompileJavaModules.gmk
@@ -22,7 +22,7 @@ java.base_COPY += ExternalMessages.properties
 
 jdk.jcmd_EXCLUDES += sun
 
-openj9.dtfj_COPY     += StructureAliases29.dat StructureAliases29-edg.dat
+openj9.dtfj_COPY     += CompatibilityConstants29.dat StructureAliases29.dat StructureAliases29-edg.dat
 openj9.dtfj_EXCLUDES += com/ibm/j9ddr/tools/ant
 
 openj9.gpu_COPY += ibm_gpu_thresholds.properties


### PR DESCRIPTION
This is part of the solution to eclipse/openj9#12182; it depends on eclipse/openj9#12210.

* compile using only those constants guaranteed to be available
* include `CompatibilityConstants29.dat` in `openj9.dtfj` module