### PR TITLE
Include StructureAliases29.dat when building DDR tools

### DIFF
--- a/closed/DDR.gmk
+++ b/closed/DDR.gmk
@@ -75,9 +75,11 @@ $(eval $(call SetupJavaCompilation,BUILD_DDR_TOOLS, \
 	BIN := $(DDR_TOOLS_BIN), \
 	CLASSPATH := $(JDK_OUTPUTDIR)/modules/java.base, \
 	SRC := $(DDR_VM_SRC_ROOT), \
+	COPY := StructureAliases29.dat, \
 	INCLUDE_FILES := \
 		com/ibm/j9ddr/BytecodeGenerator.java \
 		com/ibm/j9ddr/CTypeParser.java \
+		com/ibm/j9ddr/StructureAliases29.dat \
 		com/ibm/j9ddr/StructureHeader.java \
 		com/ibm/j9ddr/StructureReader.java \
 		com/ibm/j9ddr/StructureTypeManager.java \


### PR DESCRIPTION
This restores the ability to use Java 10 as the bootjdk.

Tested on Linux x64 using both these as the bootjdk:
```
$ jdk-10.0.2+13-openj9-0.9.0/bin/java -version
openjdk version "10.0.2-adoptopenjdk" 2018-07-17
OpenJDK Runtime Environment (build 10.0.2-adoptopenjdk+13)
Eclipse OpenJ9 VM (build openj9-0.9.0, JRE 10 Linux amd64-64-Bit Compressed References 20180813_102 (JIT enabled, AOT enabled)
OpenJ9   - 24e53631
OMR      - fad6bf6e
JCL      - 7db90eda56 based on jdk-10.0.2+13)

$ jdk-11.0.9+11-openj9-0.23.0/bin/java -version
openjdk version "11.0.9" 2020-10-20
OpenJDK Runtime Environment AdoptOpenJDK (build 11.0.9+11)
Eclipse OpenJ9 VM AdoptOpenJDK (build openj9-0.23.0, JRE 11 Linux amd64-64-Bit Compressed References 20201022_810 (JIT enabled, AOT enabled)
OpenJ9   - 0394ef754
OMR      - 582366ae5
JCL      - 3b09cfd7e9 based on jdk-11.0.9+11)
```
Fixes eclipse/openj9#12249.