### PR TITLE
Put z/OS .x side deck files in the proper places

### DIFF
--- a/closed/custom/copy/Copy-java.base.gmk
+++ b/closed/custom/copy/Copy-java.base.gmk
@@ -100,14 +100,14 @@ $(call openj9_copy_files,, \
 else ifeq ($(OPENJDK_TARGET_OS), zos)
 
 $(call openj9_copy_files,, \
-	$(addsuffix /libjsig.x, \
-		$(OPENJ9_VM_BUILD_DIR)/lib \
-		$(LIB_DST_DIR)))
+	$(addsuffix libjsig.x, \
+		$(OPENJ9_VM_BUILD_DIR)/lib/ \
+		$(addprefix $(LIB_DST_DIR), / /j9vm/ /server/)))
 
 $(call openj9_copy_files,, \
-	$(addsuffix /libjvm.x, \
-		$(OPENJ9_VM_BUILD_DIR)/lib/redirector \
-		$(LIB_DST_DIR)))
+	$(addsuffix libjvm.x, \
+		$(OPENJ9_VM_BUILD_DIR)/lib/redirector/ \
+		$(addprefix $(LIB_DST_DIR), /j9vm/ /server/)))
 
 endif # OPENJDK_TARGET_OS
 


### PR DESCRIPTION
Currently `.x` files are found in the `lib` folder:
```
lib/libjsig.x
lib/libjvm.x
```

These files should be next to the corresponding .so files:
* `libjsig.x` should be in `lib`, `lib/j9vm` and `lib/server`
* `libjvm.x` should be in `lib/j9vm` and in `lib/server`