### PR TITLE
In test, increase deflate buffer size for zlinux Ubuntu 20

### DIFF
--- a/test/jdk/java/util/zip/DeInflate.java
+++ b/test/jdk/java/util/zip/DeInflate.java
@@ -20,6 +20,11 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2021, 2021 All Rights Reserved
+ * ===========================================================================
+ */
 
 /**
  * @test
@@ -268,7 +273,7 @@ public class DeInflate {
 
         byte[] dataIn = new byte[1024 * 512];
         rnd.nextBytes(dataIn);
-        byte[] dataOut1 = new byte[dataIn.length + 1024];
+        byte[] dataOut1 = new byte[dataIn.length + (32 * 1024)]; // See https://github.com/eclipse-openj9/openj9/issues/12740
         byte[] dataOut2 = new byte[dataIn.length];
 
         Deflater defNotWrap = new Deflater(Deflater.DEFAULT_COMPRESSION, false);


### PR DESCRIPTION
test/jdk/java/util/zip/DeInflate.java

Issue https://github.com/eclipse-openj9/openj9/issues/12740

Tested via https://ci.eclipse.org/openj9/view/Test/job/Grinder/1836/ - passed

Note using a smaller size of + 16K isn't big enough.
https://ci.eclipse.org/openj9/view/Test/job/Grinder/1835/
```
12:15:58  m=540672, n=512675, len=524288, eq=false
12:15:58  STDERR:
12:15:58  java.lang.RuntimeException: De/inflater failed:java.util.zip.Deflater@a9ab8748
12:15:58  	at DeInflate.check(DeInflate.java:146)
12:15:58  	at DeInflate.main(DeInflate.java:295)
```