### PR TITLE
Preprocess source from debugtools/DDR_VM

### DIFF
--- a/closed/DDR.gmk
+++ b/closed/DDR.gmk
@@ -25,7 +25,6 @@
 #     * generate java pointer source files
 #     * generate java structure stub source files
 #     * generate pointer and structure stub class files
-#     * add copy of DDR_VM source to gensrc/openj9.dtfj
 # - compile_check
 #     * compile DDR_VM source with the generated class files from above
 # ===========================================================================
@@ -65,7 +64,6 @@ DDR_GENSRC_DIR := $(SUPPORT_OUTPUTDIR)/gensrc/openj9.dtfj
 DDR_CLASSES_MARKER := $(DDR_SUPPORT_DIR)/classes.done
 DDR_POINTERS_MARKER := $(DDR_SUPPORT_DIR)/gensrc-pointers.done
 DDR_STRUCTURES_MARKER := $(DDR_SUPPORT_DIR)/gensrc-structures.done
-DDR_VM_MARKER := $(DDR_SUPPORT_DIR)/debugtools.done
 
 #############################################################################
 
@@ -139,17 +137,12 @@ $(DDR_STRUCTURES_MARKER) : $(DDR_SUPERSET_FILE) $(DDR_RESTRICT_FILE) $(DDR_COMPA
 		-o $(DDR_GENSRC_DIR)
 	@$(TOUCH) $@
 
-$(DDR_VM_MARKER) : $(call FindFiles,$(DDR_VM_SRC_ROOT))
-	@$(ECHO) Adding DDR_VM source files to openj9.dtfj
-	$(CP) -rf $(DDR_VM_SRC_ROOT)/. $(DDR_GENSRC_DIR)
-	@$(TOUCH) $@
-
 # The occasional build has been seen to fail when $(CP) thinks it must create
 # a directory only to discover that another process (i.e. PointerGenerator
 # or StructureStubGenerator) has already done so:
 #   /usr/bin/cp: cannot create directory 'support/gensrc/openj9.dtfj/com/ibm/j9ddr/vm29': File exists
 # To avoid that problem, we insist that $(CP) runs before the other tasks.
-$(DDR_POINTERS_MARKER) $(DDR_STRUCTURES_MARKER) : $(DDR_VM_MARKER)
+$(DDR_POINTERS_MARKER) $(DDR_STRUCTURES_MARKER) : $(call FindFiles,$(DDR_VM_SRC_ROOT))
 
 generate : $(DDR_CLASSES_MARKER) $(DDR_POINTERS_MARKER) $(DDR_STRUCTURES_MARKER)
 
@@ -160,16 +153,6 @@ generate : $(DDR_CLASSES_MARKER) $(DDR_POINTERS_MARKER) $(DDR_STRUCTURES_MARKER)
 
 ifneq (,$(wildcard $(DDR_GENSRC_DIR)))
 
-# We depend upon class files from these modules.
-DDR_CLASSPATH := \
-	$(addprefix $(JDK_OUTPUTDIR)/modules/, \
-		java.base \
-		java.desktop \
-		openj9.dtfj \
-		openj9.traceformat \
-		$(if $(filter zos,$(OPENJDK_TARGET_OS)),ibm.jzos) \
-	)
-
 # Packages to be excluded from compilation.
 DDR_SRC_EXCLUDES := com/ibm/j9ddr/tools/ant
 
@@ -178,10 +161,13 @@ DDR_SRC_EXCLUDES := com/ibm/j9ddr/tools/ant
 $(eval $(call SetupJavaCompilation,BUILD_J9DDR_TEST_CLASSES, \
 	SETUP := GENERATE_JDKBYTECODE, \
 	DEPENDS := $(DDR_CLASSES_MARKER), \
-	ADD_JAVAC_FLAGS := --upgrade-module-path $(JDK_OUTPUTDIR)/modules --system none, \
+	ADD_JAVAC_FLAGS := \
+		--patch-module openj9.dtfj=$(DDR_CLASSES_BIN) \
+		--upgrade-module-path $(JDK_OUTPUTDIR)/modules \
+		--system none, \
 	BIN := $(DDR_TEST_BIN), \
-	CLASSPATH := $(DDR_CLASSES_BIN) $(DDR_CLASSPATH), \
-	SRC := $(DDR_VM_SRC_ROOT), \
+	CLASSPATH := $(DDR_CLASSES_BIN), \
+	SRC := $(J9JCL_SOURCES_DIR)/openj9.dtfj/share/classes, \
 	EXCLUDES := $(DDR_SRC_EXCLUDES) \
 	))
 

--- a/closed/GensrcJ9JCL.gmk
+++ b/closed/GensrcJ9JCL.gmk
@@ -31,6 +31,12 @@ JPP_JAR     := $(J9TOOLS_DIR)/jpp.jar
 RecursiveWildcard = $(foreach dir,$(wildcard $1/*),$(call RecursiveWildcard,$(dir),$2) $(filter $(subst *,%,$2),$(dir)))
 AllJclSource = $(call RecursiveWildcard,$(OPENJ9_TOPDIR)/jcl/src,*.java)
 
+ifeq (true,$(OPENJ9_ENABLE_DDR))
+  AllDdrSource = $(call RecursiveWildcard,$(OPENJ9_TOPDIR)/debugtools/DDR_VM/src,*.java)
+else
+  AllDdrSource =
+endif # OPENJ9_ENABLE_DDR
+
 JPP_TAGS := PLATFORM-$(OPENJ9_PLATFORM_CODE)
 
 ifeq (true,$(OPENJ9_ENABLE_CRIU_SUPPORT))
@@ -41,7 +47,7 @@ ifeq (true,$(OPENJ9_ENABLE_OPENJDK_METHODHANDLES))
   JPP_TAGS += OPENJDK_METHODHANDLES
 endif # OPENJ9_ENABLE_OPENJDK_METHODHANDLES
 
-$(J9JCL_SOURCES_DONEFILE) : $(AllJclSource)
+$(J9JCL_SOURCES_DONEFILE) : $(AllJclSource) $(AllDdrSource)
 	@$(ECHO) Building OpenJ9 Java Preprocessor
 	@$(MKDIR) -p $(J9TOOLS_DIR)
 	$(MAKE) $(MAKE_ARGS) -C $(OPENJ9_TOPDIR)/sourcetools -f buildj9tools.mk \
@@ -61,6 +67,23 @@ $(J9JCL_SOURCES_DONEFILE) : $(AllJclSource)
 			-xml jpp_configuration.xml \
 			-dest "$(call FixPath,$(J9JCL_SOURCES_DIR))" \
 			-tag:define "$(subst $(SPACE),;,$(sort $(JPP_TAGS)))"
+  ifeq (true,$(OPENJ9_ENABLE_DDR))
+	@$(ECHO) Generating DDR_VM sources
+	@$(BOOT_JDK)/bin/java \
+		-cp "$(call FixPath,$(JPP_JAR))" \
+		-Dfile.encoding=US-ASCII \
+		com.ibm.jpp.commandline.CommandlineBuilder \
+			-includeIfUnsure \
+			-noWarnIncludeIf \
+			-verdict \
+			-baseDir "$(call FixPath,$(OPENJ9_TOPDIR)/debugtools)/" \
+			-config DDR_VM \
+			-srcRoot DDR_VM/ \
+			-xml "$(call FixPath,$(OPENJ9_TOPDIR)/jcl/jpp_configuration.xml)/" \
+			-dest "$(call FixPath,$(J9JCL_SOURCES_DIR)/openj9.dtfj/share/classes)" \
+			-macro:define "JAVA_SPEC_VERSION=$(VERSION_FEATURE)" \
+			-tag:define "$(subst $(SPACE),;,$(sort $(JPP_TAGS)))"
+  endif # OPENJ9_ENABLE_DDR
 	@$(MKDIR) -p $(@D)
 	@$(TOUCH) $@
 


### PR DESCRIPTION
* use preprocessor on source from `debugtools/DDR_VM`
* adjust compilation for `BUILD_J9DDR_TEST_CLASSES`

Depends on eclipse-openj9/openj9#13040.