### PR TITLE
Remove exclusions for removed ant tasks

### DIFF
--- a/closed/DDR.gmk
+++ b/closed/DDR.gmk
@@ -153,9 +153,6 @@ generate : $(DDR_CLASSES_MARKER) $(DDR_POINTERS_MARKER) $(DDR_STRUCTURES_MARKER)
 
 ifneq (,$(wildcard $(DDR_GENSRC_DIR)))
 
-# Packages to be excluded from compilation.
-DDR_SRC_EXCLUDES := com/ibm/j9ddr/tools/ant
-
 # Compile DDR code again, to ensure compatibility with class files
 # as they would be dynamically generated from the blob.
 $(eval $(call SetupJavaCompilation,BUILD_J9DDR_TEST_CLASSES, \
@@ -167,8 +164,7 @@ $(eval $(call SetupJavaCompilation,BUILD_J9DDR_TEST_CLASSES, \
 		--system none, \
 	BIN := $(DDR_TEST_BIN), \
 	CLASSPATH := $(DDR_CLASSES_BIN), \
-	SRC := $(J9JCL_SOURCES_DIR)/openj9.dtfj/share/classes, \
-	EXCLUDES := $(DDR_SRC_EXCLUDES) \
+	SRC := $(J9JCL_SOURCES_DIR)/openj9.dtfj/share/classes \
 	))
 
 .PHONY : compile_check

--- a/closed/custom/CompileJavaModules.gmk
+++ b/closed/custom/CompileJavaModules.gmk
@@ -23,6 +23,5 @@ java.base_COPY += ExternalMessages.properties
 jdk.jcmd_EXCLUDES += sun
 
 openj9.dtfj_COPY += .dat
-openj9.dtfj_EXCLUDES += com/ibm/j9ddr/tools/ant
 
 openj9.gpu_COPY += ibm_gpu_thresholds.properties


### PR DESCRIPTION
The files were removed by eclipse-openj9/openj9#13045.