### PR TITLE
Express dependency of test-image on test-image-openj9 consistently

### DIFF
--- a/closed/custom/Main.gmk
+++ b/closed/custom/Main.gmk
@@ -30,7 +30,7 @@ JVM_MAIN_LIB_TARGETS := j9vm-build
 JVM_MAIN_TARGETS := j9vm-build
 JVM_TOOLS_TARGETS :=
 JVM_DOCS_TARGETS :=
-JVM_TEST_IMAGE_TARGETS :=
+JVM_TEST_IMAGE_TARGETS := test-image-openj9
 DEFAULT_JMOD_DEPS := j9vm-build
 PHASE_MAKEDIRS := $(TOPDIR)/closed/make $(PHASE_MAKEDIRS)
 
@@ -71,8 +71,6 @@ debug-image : exploded-image
 all-images : debug-image
 
 ALL_TARGETS += debug-image
-
-test-image : test-image-openj9
 
 # If not cross-compiling, capture 'java -version' output.
 test-image-openj9 : exploded-image


### PR DESCRIPTION
Use macro `JVM_TEST_IMAGE_TARGETS` like later jdk versions.