### PR TITLE
Remove -Xlog:all=warning from ProcessBuilder/Basic test

### DIFF
--- a/test/jdk/java/lang/ProcessBuilder/Basic.java
+++ b/test/jdk/java/lang/ProcessBuilder/Basic.java
@@ -2125,12 +2125,10 @@ public class Basic {
                     switch (action & 0x1) {
                         case 0:
                             childArgs.set(1, "-XX:+DisplayVMOutputToStderr");
-                            childArgs.add(2, "-Xlog:all=warning:stderr");
                             pb.redirectError(INHERIT);
                             break;
                         case 1:
                             childArgs.set(1, "-XX:+DisplayVMOutputToStdout");
-                            childArgs.add(2, "-Xlog:all=warning:stdout");
                             pb.redirectOutput(INHERIT);
                             break;
                         default:


### PR DESCRIPTION
It was added by
https://github.com/ibmruntimes/openj9-openjdk-jdk11/commit/87d3be4e45
but causes https://github.com/eclipse-openj9/openj9/issues/13865 which is blocking OpenJDK11 acceptance.

Resolves https://github.com/eclipse-openj9/openj9/issues/13865

Tested via grinder https://openj9-jenkins.osuosl.org/view/Test/job/Grinder/349/