### PR TITLE
Set the default class name when compiling XSL templates

### DIFF
--- a/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/compiler/XSLTC.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/compiler/XSLTC.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -58,7 +58,7 @@ import org.xml.sax.XMLReader;
  * @author G. Todd Miller
  * @author Morten Jorgensen
  * @author John Howard (johnh@schemasoft.com)
- * @LastModified: Oct 2017
+ * @LastModified: Nov 2021
  */
 public final class XSLTC {
 
@@ -460,8 +460,11 @@ public final class XSLTC {
                 if (name != null) {
                     setClassName(name);
                 }
-                else if (systemId != null && !systemId.equals("")) {
-                    setClassName(Util.baseName(systemId));
+                else if (systemId != null && !systemId.isEmpty()) {
+                    String clsName = Util.baseName(systemId);
+                    if (clsName != null && !clsName.isEmpty()) {
+                        setClassName(clsName);
+                    }
                 }
 
                 // Ensure we have a non-empty class name at this point


### PR DESCRIPTION
The changes ensure the default class name is always set
to the bytecode so as to address the corner case when
the base name converted from the system ID is null.

Signed-off-by: Cheng Jin <jincheng@ca.ibm.com>