### PR TITLE
Enable JIT on AArch64 macOS

### DIFF
--- a/closed/custom/copy/Copy-java.base.gmk
+++ b/closed/custom/copy/Copy-java.base.gmk
@@ -1,5 +1,5 @@
 # ===========================================================================
-# (c) Copyright IBM Corp. 2017, 2021 All Rights Reserved
+# (c) Copyright IBM Corp. 2017, 2022 All Rights Reserved
 # ===========================================================================
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
@@ -73,7 +73,7 @@ $(call openj9_copy_files_and_debuginfos, \
 		$(addprefix $(LIB_DST_DIR), / /j9vm/ /server/)))
 
 # Target platforms without JIT support.
-NO_JIT_PLATFORMS := linux_riscv64 macosx_aarch64
+NO_JIT_PLATFORMS := linux_riscv64
 TARGET_PLATFORM := $(OPENJDK_TARGET_OS)_$(OPENJDK_TARGET_CPU)
 
 $(call openj9_copy_shlibs, \

--- a/make/autoconf/flags.m4
+++ b/make/autoconf/flags.m4
@@ -1,5 +1,6 @@
 #
 # Copyright (c) 2011, 2018, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2021, Azul Systems, Inc. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -22,6 +23,10 @@
 # or visit www.oracle.com if you need additional information or have any
 # questions.
 #
+
+# ===========================================================================
+# (c) Copyright IBM Corp. 2022, 2022 All Rights Reserved
+# ===========================================================================
 
 m4_include([flags-cflags.m4])
 m4_include([flags-ldflags.m4])
@@ -116,7 +121,11 @@ AC_DEFUN([FLAGS_SETUP_MACOSX_VERSION],
     # of the OS. It currently has a hard coded value. Setting this also limits
     # exposure to API changes in header files. Bumping this is likely to
     # require code changes to build.
-    MACOSX_VERSION_MIN=10.9.0
+    if test "x$OPENJDK_TARGET_CPU_ARCH" = xaarch64; then
+      MACOSX_VERSION_MIN=11.00.00
+    else
+      MACOSX_VERSION_MIN=10.9.0
+    fi
     MACOSX_VERSION_MIN_NODOTS=${MACOSX_VERSION_MIN//\./}
 
     AC_SUBST(MACOSX_VERSION_MIN)


### PR DESCRIPTION
This commit enables JIT on AArch64 macOS.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>