### PR TITLE
Remove a wrong copyright line from flags.m4

### DIFF
--- a/make/autoconf/flags.m4
+++ b/make/autoconf/flags.m4
@@ -1,6 +1,5 @@
 #
 # Copyright (c) 2011, 2018, Oracle and/or its affiliates. All rights reserved.
-# Copyright (c) 2021, Azul Systems, Inc. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
This commit removes a copyright line from flags.m4 that was added by
mistake in #474.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>