### PR TITLE
Use bundled freetype on AIX

### DIFF
--- a/make/autoconf/lib-freetype.m4
+++ b/make/autoconf/lib-freetype.m4
@@ -92,7 +92,7 @@ AC_DEFUN_ONCE([LIB_SETUP_FREETYPE],
 
   # This setup is to verify access to system installed freetype header and libraries.
   # On Windows and MacOS this does not apply and using these options will report an error.
-  # On other platforms (Linux, Solaris, and perhaps AIX), they will default to using
+  # On other platforms (Linux, Solaris), they will default to using
   # the system libraries. If they are found automatically, nothing need be done.
   # If they are not found, the configure "--with-freetype-*" options may be used to fix that.
   # If the preference is to bundle on these platforms then use --with-freetype=bundled
@@ -106,7 +106,8 @@ AC_DEFUN_ONCE([LIB_SETUP_FREETYPE],
   fi
 
   FREETYPE_TO_USE=bundled
-  if (test "x$OPENJDK_TARGET_OS" != "xwindows" && test "x$OPENJDK_TARGET_OS" != "xmacosx"); then
+  if (test "x$OPENJDK_TARGET_OS" != "xwindows" && test "x$OPENJDK_TARGET_OS" != "xmacosx" \
+      && test "x$OPENJDK_TARGET_OS" != "xaix"); then
     FREETYPE_TO_USE=system
   fi
   if (test "x$with_freetype" != "x"); then


### PR DESCRIPTION
Backport https://github.com/ibmruntimes/openj9-openjdk-jdk17/commit/1e90c2e078

When libfreetype.so is bundled, users don't need to install it in order
to load libfontmanager.so

Signed-off-by: Peter Shipton <Peter_Shipton@ca.ibm.com>