### PR TITLE
healthcenter: don't make jdk.internal.jvmstat a platform module

### DIFF
--- a/closed/custom/common/Modules.gmk
+++ b/closed/custom/common/Modules.gmk
@@ -38,7 +38,7 @@ else
   PLATFORM_MODULES += \
 	ibm.healthcenter \
 	jdk.attach \
-	jdk.internal.jvmstat
+	#
 endif
 
 MODULES_FILTER += \

--- a/closed/src/jdk.attach/aix/classes/sun/tools/attach/AttachProviderImpl.java
+++ b/closed/src/jdk.attach/aix/classes/sun/tools/attach/AttachProviderImpl.java
@@ -1,0 +1,21 @@
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2022, 2022 All Rights Reserved
+ * ===========================================================================
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * IBM designates this particular file as subject to the "Classpath" exception
+ * as provided by IBM in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, see <http://www.gnu.org/licenses/>.
+ * ===========================================================================
+ */

--- a/closed/src/jdk.attach/linux/classes/sun/tools/attach/AttachProviderImpl.java
+++ b/closed/src/jdk.attach/linux/classes/sun/tools/attach/AttachProviderImpl.java
@@ -1,0 +1,21 @@
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2022, 2022 All Rights Reserved
+ * ===========================================================================
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * IBM designates this particular file as subject to the "Classpath" exception
+ * as provided by IBM in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, see <http://www.gnu.org/licenses/>.
+ * ===========================================================================
+ */

--- a/closed/src/jdk.attach/macosx/classes/sun/tools/attach/AttachProviderImpl.java
+++ b/closed/src/jdk.attach/macosx/classes/sun/tools/attach/AttachProviderImpl.java
@@ -1,0 +1,21 @@
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2022, 2022 All Rights Reserved
+ * ===========================================================================
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * IBM designates this particular file as subject to the "Classpath" exception
+ * as provided by IBM in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, see <http://www.gnu.org/licenses/>.
+ * ===========================================================================
+ */

--- a/closed/src/jdk.attach/share/classes/sun/tools/attach/HotSpotAttachProvider.java
+++ b/closed/src/jdk.attach/share/classes/sun/tools/attach/HotSpotAttachProvider.java
@@ -1,0 +1,21 @@
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2022, 2022 All Rights Reserved
+ * ===========================================================================
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * IBM designates this particular file as subject to the "Classpath" exception
+ * as provided by IBM in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, see <http://www.gnu.org/licenses/>.
+ * ===========================================================================
+ */

--- a/closed/src/jdk.attach/solaris/classes/sun/tools/attach/AttachProviderImpl.java
+++ b/closed/src/jdk.attach/solaris/classes/sun/tools/attach/AttachProviderImpl.java
@@ -1,0 +1,21 @@
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2022, 2022 All Rights Reserved
+ * ===========================================================================
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * IBM designates this particular file as subject to the "Classpath" exception
+ * as provided by IBM in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, see <http://www.gnu.org/licenses/>.
+ * ===========================================================================
+ */

--- a/closed/src/jdk.attach/windows/classes/sun/tools/attach/AttachProviderImpl.java
+++ b/closed/src/jdk.attach/windows/classes/sun/tools/attach/AttachProviderImpl.java
@@ -1,0 +1,21 @@
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2022, 2022 All Rights Reserved
+ * ===========================================================================
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * IBM designates this particular file as subject to the "Classpath" exception
+ * as provided by IBM in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, see <http://www.gnu.org/licenses/>.
+ * ===========================================================================
+ */

--- a/src/java.base/share/lib/security/default.policy
+++ b/src/java.base/share/lib/security/default.policy
@@ -105,6 +105,8 @@ grant codeBase "jrt:/jdk.accessibility" {
 
 grant codeBase "jrt:/jdk.attach" {
     permission java.lang.RuntimePermission "accessClassInPackage.com.ibm.oti.util";
+    permission java.lang.RuntimePermission "accessClassInPackage.com.ibm.oti.vm";
+    permission java.lang.RuntimePermission "accessClassInPackage.jdk.internal.misc";
     permission java.lang.RuntimePermission "accessClassInPackage.openj9.internal.tools.attach.target";
     permission java.lang.RuntimePermission "accessClassInPackage.openj9.internal.tools.attach.diagnostics.base";
     permission java.util.PropertyPermission "com.ibm.tools.attach.*", "read";

--- a/src/jdk.attach/share/classes/module-info.java
+++ b/src/jdk.attach/share/classes/module-info.java
@@ -22,9 +22,10 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2018, 2018 All Rights Reserved
+ * (c) Copyright IBM Corp. 2018, 2022 All Rights Reserved
  * ===========================================================================
  */
 
@@ -37,8 +38,6 @@
  * @since 9
  */
 module jdk.attach {
-    requires jdk.internal.jvmstat;
-
     exports com.sun.tools.attach;
     exports com.sun.tools.attach.spi;
 


### PR DESCRIPTION
A build configured with `--with-healthcenter` requires that `ibm.healthcenter`, and the modules it requires, be platform modules.

- update the default security policy with permissions required when `jdk.attach` is a platform module
  - fixes a test failure in `CheckAccessClassInPackagePermissions`
- remove the dependency on `jdk.internal.jvmstat` so it need not be a platform module
- add stubs in `jdk.attach` for classes that used to depend on `jdk.internal.jvmstat`