### PR TITLE
Stop ignoring warnings in openj9.sharedclasses

### DIFF
--- a/closed/custom/common/SetupJavaCompilers.gmk
+++ b/closed/custom/common/SetupJavaCompilers.gmk
@@ -1,5 +1,5 @@
 # ===========================================================================
-# (c) Copyright IBM Corp. 2018, 2020 All Rights Reserved
+# (c) Copyright IBM Corp. 2018, 2022 All Rights Reserved
 # ===========================================================================
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
@@ -24,7 +24,6 @@ WARNING_MODULES := \
 	jdk.management \
 	openj9.dtfj \
 	openj9.dtfjview \
-	openj9.sharedclasses \
 	openj9.traceformat \
 	#
 


### PR DESCRIPTION
Depends on eclipse-openj9/openj9#14814.