### PR TITLE
Fix @Stable annotation in MethodHandleImpl

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/MethodHandleImpl.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandleImpl.java
@@ -23,6 +23,12 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2022, 2022 All Rights Reserved
+ * ===========================================================================
+ */
+
 package java.lang.invoke;
 
 import jdk.internal.misc.JavaLangInvokeAccess;
@@ -490,7 +496,7 @@ import static jdk.internal.org.objectweb.asm.Opcodes.*;
     private static final class AsVarargsCollector extends DelegatingMethodHandle {
         private final MethodHandle target;
         private final Class<?> arrayType;
-        private @Stable MethodHandle asCollectorCache;
+        private MethodHandle asCollectorCache;
 
         AsVarargsCollector(MethodHandle target, Class<?> arrayType) {
             this(target.type(), target, arrayType);


### PR DESCRIPTION
This is a back-port of ibmruntimes/openj9-openjdk-jdk17#81, required when `--enable-openjdk-methodhandles` is used at configuration time.