### PR TITLE
(0.32) Add openssl version 3.0+ support for Linux platforms

### DIFF
--- a/closed/src/java.base/aix/native/libjncrypto/NativeCrypto_md.c
+++ b/closed/src/java.base/aix/native/libjncrypto/NativeCrypto_md.c
@@ -1,6 +1,6 @@
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2019, 2019 All Rights Reserved
+ * (c) Copyright IBM Corp. 2019, 2022 All Rights Reserved
  * ===========================================================================
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,7 +30,7 @@
 #include "NativeCrypto_md.h"
 
 /* Load the crypto library (return NULL on error) */
-void * load_crypto_library() {
+void * load_crypto_library(jboolean traceEnabled) {
     void * result = NULL;
     const char *libname111 = "libcrypto.a(libcrypto64.so.1.1)";
     const char *libname110 = "libcrypto.so.1.1";

--- a/closed/src/java.base/macosx/native/libjncrypto/NativeCrypto_md.c
+++ b/closed/src/java.base/macosx/native/libjncrypto/NativeCrypto_md.c
@@ -1,6 +1,6 @@
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2019, 2019 All Rights Reserved
+ * (c) Copyright IBM Corp. 2019, 2022 All Rights Reserved
  * ===========================================================================
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,7 +30,7 @@
 #include "NativeCrypto_md.h"
 
 /* Load the crypto library (return NULL on error) */
-void * load_crypto_library() {
+void * load_crypto_library(jboolean traceEnabled) {
     void * result = NULL;
     
     const char *libname = "libcrypto.1.1.dylib";

--- a/closed/src/java.base/share/classes/jdk/crypto/jniprovider/NativeCrypto.java
+++ b/closed/src/java.base/share/classes/jdk/crypto/jniprovider/NativeCrypto.java
@@ -1,6 +1,6 @@
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2018, 2019 All Rights Reserved
+ * (c) Copyright IBM Corp. 2018, 2022 All Rights Reserved
  * ===========================================================================
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,15 +36,20 @@ public class NativeCrypto {
     //ossl_ver:
     // -1 : library load failed
     //  0 : openssl 1.0.x
-    //  1 : openssl 1.1.x
+    //  1 : openssl 1.1.x or newer
     private static final int ossl_ver = AccessController.doPrivileged(
             (PrivilegedAction<Integer>) () -> {
                 int ossl_ver = -1;
+                boolean traceEnabled = Boolean.getBoolean("jdk.nativeCryptoTrace");
+
                 try {
                     System.loadLibrary("jncrypto"); // check for native library
                     // load OpenSSL crypto library dynamically.
-                    ossl_ver = loadCrypto();
+                    ossl_ver = loadCrypto(traceEnabled);
                 } catch (UnsatisfiedLinkError usle) {
+                    if (traceEnabled) {
+                        System.err.println("UnsatisfiedLinkError: Failure attempting to load jncrypto JNI library");
+                    }
                     // Return that ossl_ver is -1 (default set above)
                 }
 
@@ -77,7 +82,7 @@ public class NativeCrypto {
     }
 
     /* Native digest interfaces */
-    static final native int loadCrypto();
+    private static final native int loadCrypto(boolean traceEnabled);
 
     public final native long DigestCreateContext(long nativeBuffer,
                                                  int algoIndex);

--- a/closed/src/java.base/share/native/libjncrypto/NativeCrypto_md.h
+++ b/closed/src/java.base/share/native/libjncrypto/NativeCrypto_md.h
@@ -1,6 +1,6 @@
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2019, 2019 All Rights Reserved
+ * (c) Copyright IBM Corp. 2019, 2022 All Rights Reserved
  * ===========================================================================
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,9 @@
 #ifndef NATIVECRYPTO_MD_H
 #define NATIVECRYPTO_MD_H
 
-void * load_crypto_library();
+#include <jni.h>
+
+void * load_crypto_library(jboolean traceEnabled);
 void   unload_crypto_library(void *handle);
 void * find_crypto_symbol(void *handle, const char *symname);
 

--- a/closed/src/java.base/unix/native/libjncrypto/NativeCrypto_md.c
+++ b/closed/src/java.base/unix/native/libjncrypto/NativeCrypto_md.c
@@ -1,6 +1,6 @@
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2019, 2019 All Rights Reserved
+ * (c) Copyright IBM Corp. 2019, 2022 All Rights Reserved
  * ===========================================================================
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,6 +22,7 @@
  * ===========================================================================
  */
 
+#include <link.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -30,12 +31,14 @@
 #include "NativeCrypto_md.h"
 
 /* Load the crypto library (return NULL on error) */
-void * load_crypto_library() {
+void * load_crypto_library(jboolean traceEnabled)
+{
     void * result = NULL;
     size_t i = 0;
     
-    // Library names for OpenSSL 1.1.1, 1.1.0, 1.0.2 and symbolic links
+    // Library names for OpenSSL 3.x, 1.1.1, 1.1.0, 1.0.2 and symbolic links
     static const char * const libNames[] = {
+        "libcrypto.so.3",     // 3.x   library name
         "libcrypto.so.1.1",   // 1.1.x library name
         "libcrypto.so.1.0.0", // 1.0.x library name
         "libcrypto.so.10",    // 1.0.x library name on RHEL
@@ -50,6 +53,12 @@ void * load_crypto_library() {
         result = dlopen (libName,  RTLD_NOW);
     }
 
+    if (traceEnabled && (NULL != result)) {
+        struct link_map *map = NULL;
+        dlinfo(result, RTLD_DI_LINKMAP, &map);
+        fprintf(stderr, "Attempt to load OpenSSL %s\n", map->l_name);
+        fflush(stderr);
+    }
     return result;
 }
 

--- a/closed/src/java.base/windows/native/libjncrypto/NativeCrypto_md.c
+++ b/closed/src/java.base/windows/native/libjncrypto/NativeCrypto_md.c
@@ -1,6 +1,6 @@
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2019, 2019 All Rights Reserved
+ * (c) Copyright IBM Corp. 2019, 2022 All Rights Reserved
  * ===========================================================================
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,7 @@
 #include "NativeCrypto_md.h"
 
 /* Load the crypto library (return NULL on error) */
-void * load_crypto_library() {
+void * load_crypto_library(jboolean traceEnabled) {
     void * result = NULL;
     const char *libname = "libcrypto-1_1-x64.dll";
     const char *oldname = "libeay32.dll";

--- a/test/jdk/com/sun/crypto/provider/Cipher/AEAD/GCMParameterSpecTest.java
+++ b/test/jdk/com/sun/crypto/provider/Cipher/AEAD/GCMParameterSpecTest.java
@@ -21,6 +21,12 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2022, 2022 All Rights Reserved
+ * ===========================================================================
+ */
+
 import java.security.NoSuchAlgorithmException;
 import java.security.NoSuchProviderException;
 import java.util.Arrays;
@@ -36,7 +42,15 @@ import javax.crypto.spec.GCMParameterSpec;
  */
 public class GCMParameterSpecTest {
 
-    private static final int[] IV_LENGTHS = { 96, 8, 1024 };
+    /*
+     * OpenSSL3 only supports IV lengths up to 16 bytes.
+     * When the IV length is set to be larger than 16 bytes, an error is thrown.
+     * According to the OpenSSL docs([1]), in OpenSSL1.1.1 and older, there is
+     * no error thrown but unpredictable behavior will happen for large IV sizes.
+     *
+     * [1] https://www.openssl.org/docs/man1.1.1/man3/EVP_CIPHER_CTX_block_size.html
+     */
+    private static final int[] IV_LENGTHS = { 96, 8 };
     private static final int[] KEY_LENGTHS = { 128, 192, 256 };
     private static final int[] DATA_LENGTHS = { 0, 128, 1024 };
     private static final int[] AAD_LENGTHS = { 0, 128, 1024 };


### PR DESCRIPTION
Cherry pick of https://github.com/ibmruntimes/openj9-openjdk-jdk11/pull/499 for the 0.32 release.

Signed-off-by: Jinhang Zhang <Jinhang.Zhang@ibm.com>