### PR TITLE
Stop ignoring warnings in jdk.management

### DIFF
--- a/closed/custom/common/SetupJavaCompilers.gmk
+++ b/closed/custom/common/SetupJavaCompilers.gmk
@@ -21,7 +21,6 @@
 # OpenJ9 requires more lenient javac warnings for these modules.
 WARNING_MODULES := \
 	java.base \
-	jdk.management \
 	openj9.dtfj \
 	openj9.dtfjview \
 	openj9.traceformat \


### PR DESCRIPTION
Depends on eclipse-openj9/openj9#14973.