### PR TITLE
Add support for installing libssl.so.3

### DIFF
--- a/closed/custom/copy/Copy-java.base.gmk
+++ b/closed/custom/copy/Copy-java.base.gmk
@@ -220,7 +220,7 @@ ifneq ($(OPENSSL_BUNDLE_LIB_PATH), )
 
   ifeq (true,$(OPENJ9_ENABLE_JITSERVER))
     ifeq (linux,$(OPENJDK_TARGET_OS))
-      LIBSSL_NAMES := libssl.so.1.1 libssl.so.1.0.0
+      LIBSSL_NAMES := libssl.so.3 libssl.so.1.1 libssl.so.1.0.0
       LIBSSL_PATH := $(firstword $(wildcard $(addprefix $(OPENSSL_BUNDLE_LIB_PATH)/, $(LIBSSL_NAMES))))
 
       ifneq ($(LIBSSL_PATH), )


### PR DESCRIPTION
See also https://github.com/ibmruntimes/openj9-openjdk-jdk11/pull/500

Signed-off-by: Peter Shipton <Peter_Shipton@ca.ibm.com>