### PR TITLE
AIX with xlc 16 must set -std=c99

### DIFF
--- a/make/autoconf/flags-cflags.m4
+++ b/make/autoconf/flags-cflags.m4
@@ -23,6 +23,10 @@
 # questions.
 #
 
+# ===========================================================================
+# (c) Copyright IBM Corp. 2022, 2022 All Rights Reserved
+# ===========================================================================
+
 ################################################################################
 #
 # Setup flags for C/C++ compiler
@@ -541,6 +545,15 @@ AC_DEFUN([FLAGS_SETUP_CFLAGS_HELPER],
     TOOLCHAIN_CFLAGS_JVM="-nologo -MD -MP"
     TOOLCHAIN_CFLAGS_JDK="-nologo -MD -Zc:wchar_t-"
   fi
+
+  # -std=c99 is required on AIX with xlc 16
+  if test "x$TOOLCHAIN_TYPE" = xxlc; then
+    # Explicitly set C99.
+    LANGSTD_CFLAGS="-std=c99"
+  else
+    LANGSTD_CFLAGS=""
+  fi
+  TOOLCHAIN_CFLAGS_JDK_CONLY="$LANGSTD_CFLAGS $TOOLCHAIN_CFLAGS_JDK_CONLY"
 
   # CFLAGS WARNINGS STUFF
   # Set JVM_CFLAGS warning handling


### PR DESCRIPTION
Otherwise there is an error '-std=gnu++0x' not allowed with 'C/ObjC'

See https://github.com/eclipse-openj9/openj9/pull/15007

Signed-off-by: Peter Shipton <Peter_Shipton@ca.ibm.com>