### PR TITLE
Add runtime permission getClassLoader for jdk.crypto.cryptoki

### DIFF
--- a/src/java.base/share/lib/security/default.policy
+++ b/src/java.base/share/lib/security/default.policy
@@ -144,6 +144,7 @@ grant codeBase "jrt:/jdk.crypto.cryptoki" {
                    "accessClassInPackage.sun.security.*";
     permission java.lang.RuntimePermission "accessClassInPackage.sun.nio.ch";
     permission java.lang.RuntimePermission "loadLibrary.j2pkcs11";
+    permission java.lang.RuntimePermission "getClassLoader";
     permission java.util.PropertyPermission "sun.security.pkcs11.allowSingleThreadedModules", "read";
     permission java.util.PropertyPermission "sun.security.pkcs11.disableKeyExtraction", "read";
     permission java.util.PropertyPermission "os.name", "read";


### PR DESCRIPTION
Signed-off-by: Tao Liu <tao.liu@ibm.com>

This PR is for the issue https://github.com/ibmruntimes/openj9-openjdk-jdk11/issues/526

When running the cleaner thread creation in the security provider "SunPKCS11" of module "jdk.crypto.cryptoki", and meanwhile the security manager is enabled. The access denied error "Caused by: java.security.AccessControlException: Access denied ("java.lang.RuntimePermission" "getClassLoader")" happens.