### PR TITLE
Buffer CRIU RNG

### DIFF
--- a/closed/src/java.base/share/classes/openj9/internal/criu/CRIUSECProvider.java
+++ b/closed/src/java.base/share/classes/openj9/internal/criu/CRIUSECProvider.java
@@ -57,7 +57,8 @@ public final class CRIUSECProvider extends Provider {
     /**
      * Resets the security digests.
      */
-    public static void resetDigests() {
+    public static void resetCRIUSEC() {
+        NativePRNG.clearRNGBuffers();
         DigestBase.resetDigests();
     }
 }


### PR DESCRIPTION
Signed-off-by: Alon Shalev Housfater <alonsh@ca.ibm.com>

Changes to the CRIU Random Number Generator
1. Added a buffering scheme similar to the default OpenJDK NativeRNG where we have a 256B buffer that reads /dev/random. These buffered bytes will become stale after 0.1 ms as per previous implementation. This is done as a performance enhancement.
2. renamed  resetDigests() that is called via CRIU hook during post-snapshot to clear digest state to be a generic resetCRIUSEC() as this method now resets the digest contexts and also clears out the rng buffer.