### PR TITLE
Remove record class from test java/nio/file/Files/probeContentType/Basic

### DIFF
--- a/test/jdk/java/nio/file/Files/probeContentType/Basic.java
+++ b/test/jdk/java/nio/file/Files/probeContentType/Basic.java
@@ -21,6 +21,12 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2022, 2022 All Rights Reserved
+ * ===========================================================================
+ */
+
 /* @test
  * @bug 4313887 8129632 8129633 8162624 8146215 8162745 8273655
  * @summary Unit test for probeContentType method
@@ -193,5 +199,18 @@ public class Basic {
         }
     }
 
-    record ExType(String extension, List<String> expectedTypes) { }
+    static class ExType {
+        String extension;
+        List<String> expectedTypes;
+        ExType(String ext, List<String> expTypes) {
+            extension = ext;
+            expectedTypes = expTypes;
+        }
+        String extension() {
+                return extension;
+        }
+        List<String> expectedTypes() {
+                return expectedTypes;
+        }
+    }
 }


### PR DESCRIPTION
The test java/nio/file/Files/probeContentType/Basic is defining a record
in jdk11 when records are only applicable to jdk17+.

Fixes https://github.com/eclipse-openj9/openj9/issues/15105

Tested via grinder https://openj9-jenkins.osuosl.org/view/Test/job/Grinder/820 which passed.

Signed-off-by: Peter Shipton <Peter_Shipton@ca.ibm.com>