### PR TITLE
CRIU update TimerTask.nextExecutionTime with checkpointRestoreTimeDelta

### DIFF
--- a/closed/GensrcJ9JCL.gmk
+++ b/closed/GensrcJ9JCL.gmk
@@ -52,6 +52,8 @@ $(eval $(call SetupCopyFiles,COPY_OVERLAY_FILES, \
 	DEST := $(SUPPORT_OUTPUTDIR)/overlay, \
 	FILES := \
 		src/java.base/share/classes/java/security/Security.java \
+		src/java.base/share/classes/java/util/Timer.java \
+		src/java.base/share/classes/java/util/TimerTask.java \
 		src/java.base/unix/classes/java/lang/ProcessEnvironment.java \
 	))
 

--- a/src/java.base/share/classes/java/util/Timer.java
+++ b/src/java.base/share/classes/java/util/Timer.java
@@ -23,9 +23,19 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2022, 2022 All Rights Reserved
+ * ===========================================================================
+ */
+
 package java.util;
 import java.util.Date;
 import java.util.concurrent.atomic.AtomicInteger;
+
+/*[IF CRIU_SUPPORT]*/
+import openj9.internal.criu.InternalCRIUSupport;
+/*[ENDIF] CRIU_SUPPORT*/
 
 /**
  * A facility for threads to schedule tasks for future execution in a
@@ -191,6 +201,12 @@ public class Timer {
     public void schedule(TimerTask task, long delay) {
         if (delay < 0)
             throw new IllegalArgumentException("Negative delay.");
+        /*[IF CRIU_SUPPORT]*/
+        // only tasks scheduled before Checkpoint to be adjusted
+        if (InternalCRIUSupport.getCheckpointRestoreNanoTimeDelta() == 0) {
+            task.criuAdjustRequired = true;
+        }
+        /*[ENDIF] CRIU_SUPPORT*/
         sched(task, System.currentTimeMillis()+delay, 0);
     }
 
@@ -246,6 +262,12 @@ public class Timer {
             throw new IllegalArgumentException("Negative delay.");
         if (period <= 0)
             throw new IllegalArgumentException("Non-positive period.");
+        /*[IF CRIU_SUPPORT]*/
+        // only tasks scheduled before Checkpoint to be adjusted
+        if (InternalCRIUSupport.getCheckpointRestoreNanoTimeDelta() == 0) {
+            task.criuAdjustRequired = true;
+        }
+        /*[ENDIF] CRIU_SUPPORT*/
         sched(task, System.currentTimeMillis()+delay, -period);
     }
 
@@ -326,6 +348,12 @@ public class Timer {
             throw new IllegalArgumentException("Negative delay.");
         if (period <= 0)
             throw new IllegalArgumentException("Non-positive period.");
+        /*[IF CRIU_SUPPORT]*/
+        // only tasks scheduled before Checkpoint to be adjusted
+        if (InternalCRIUSupport.getCheckpointRestoreNanoTimeDelta() == 0) {
+            task.criuAdjustRequired = true;
+        }
+        /*[ENDIF] CRIU_SUPPORT*/
         sched(task, System.currentTimeMillis()+delay, period);
     }
 
@@ -537,6 +565,18 @@ class TimerThread extends Thread {
                             continue;  // No action required, poll queue again
                         }
                         currentTime = System.currentTimeMillis();
+                        /*[IF CRIU_SUPPORT]*/
+                        if (task.criuAdjustRequired) {
+                            long checkpointRestoreTimeDelta = InternalCRIUSupport.getCheckpointRestoreNanoTimeDelta();
+                            // A zero checkpointRestoreTimeDelta value indicates no Checkpoint performed yet,
+                            // it can't be negative, otherwise a RestoreException already was thrown.
+                            if (checkpointRestoreTimeDelta > 0) {
+                                task.nextExecutionTime += (checkpointRestoreTimeDelta / 1000000);
+                                // clear the flag - only one time adjustment required
+                                task.criuAdjustRequired = false;
+                            }
+                        }
+                        /*[ENDIF] CRIU_SUPPORT*/
                         executionTime = task.nextExecutionTime;
                         if (taskFired = (executionTime<=currentTime)) {
                             if (task.period == 0) { // Non-repeating, remove

--- a/src/java.base/share/classes/java/util/TimerTask.java
+++ b/src/java.base/share/classes/java/util/TimerTask.java
@@ -23,6 +23,12 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2022, 2022 All Rights Reserved
+ * ===========================================================================
+ */
+
 package java.util;
 
 /**
@@ -83,6 +89,13 @@ public abstract class TimerTask implements Runnable {
      * A value of 0 indicates a non-repeating task.
      */
     long period = 0;
+
+    /*[IF CRIU_SUPPORT]*/
+    /**
+     * Determine if the nextExecutionTime is to be adjusted.
+     */
+    boolean criuAdjustRequired;
+    /*[ENDIF] CRIU_SUPPORT*/
 
     /**
      * Creates a new timer task.


### PR DESCRIPTION
`TimerTask.nextExecutionTime` is added with `InternalCRIUSupport.getCheckpointRestoreTimeDelta()` to reflect the
elapsed time in milliseconds elapsed between Checkpoint and Restore;
Add `TimerTask.criuAdjustRequired` to determine if the `nextExecutionTime` is to be adjusted.

Depends on https://github.com/eclipse-openj9/openj9/pull/15112

Signed-off-by: Jason Feng <fengj@ca.ibm.com>