### PR TITLE
Support export/import plain keys in FIPS Mode

### DIFF
--- a/src/java.base/share/classes/module-info.java
+++ b/src/java.base/share/classes/module-info.java
@@ -342,6 +342,7 @@ module java.base {
     exports sun.util.resources to
         jdk.localedata;
     exports openj9.internal.security to
+        jdk.crypto.cryptoki,
         jdk.crypto.ec;
 
 

--- a/src/java.base/share/lib/security/default.policy
+++ b/src/java.base/share/lib/security/default.policy
@@ -146,6 +146,8 @@ grant codeBase "jrt:/jdk.crypto.cryptoki" {
                    "accessClassInPackage.sun.security.*";
     permission java.lang.RuntimePermission "accessClassInPackage.sun.nio.ch";
     permission java.lang.RuntimePermission "loadLibrary.j2pkcs11";
+    permission java.lang.RuntimePermission
+                    "accessClassInPackage.openj9.internal.security";
     permission java.util.PropertyPermission "sun.security.pkcs11.allowSingleThreadedModules", "read";
     permission java.util.PropertyPermission "sun.security.pkcs11.disableKeyExtraction", "read";
     permission java.util.PropertyPermission "os.name", "read";

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/SunPKCS11.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/SunPKCS11.java
@@ -23,15 +23,29 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2022, 2022 All Rights Reserved
+ * ===========================================================================
+ */
+
 package sun.security.pkcs11;
 
 import java.io.*;
 import java.util.*;
 
 import java.security.*;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.InvalidKeyException;
 import java.security.interfaces.*;
+import java.util.function.Consumer;
 
+import javax.crypto.BadPaddingException;
+import javax.crypto.Cipher;
+import javax.crypto.IllegalBlockSizeException;
+import javax.crypto.NoSuchPaddingException;
 import javax.crypto.interfaces.*;
+import javax.crypto.spec.IvParameterSpec;
 
 import javax.security.auth.Subject;
 import javax.security.auth.login.LoginException;
@@ -43,12 +57,13 @@ import javax.security.auth.callback.PasswordCallback;
 import com.sun.crypto.provider.ChaCha20Poly1305Parameters;
 
 import jdk.internal.misc.InnocuousThread;
+import openj9.internal.security.FIPSConfigurator;
 import sun.security.util.Debug;
 import sun.security.util.ResourcesMgr;
 import static sun.security.util.SecurityConstants.PROVIDER_VER;
 
 import sun.security.pkcs11.Secmod.*;
-
+import sun.security.pkcs11.TemplateManager;
 import sun.security.pkcs11.wrapper.*;
 import static sun.security.pkcs11.wrapper.PKCS11Constants.*;
 
@@ -86,6 +101,11 @@ public final class SunPKCS11 extends AuthProvider {
     private TokenPoller poller;
 
     static NativeResourceCleaner cleaner;
+
+    // This is the SunPKCS11 provider instance
+    // there can only be a single PKCS11 provider in
+    // FIPS mode.
+    static SunPKCS11 mysunpkcs11;
 
     Token getToken() {
         return token;
@@ -376,6 +396,29 @@ public final class SunPKCS11 extends AuthProvider {
             if (nssModule != null) {
                 nssModule.setProvider(this);
             }
+
+            // When FIPS mode is enabled, configure p11 object to FIPS mode
+            // and pass the parent object so it can callback.
+            if (FIPSConfigurator.enableFips()) {
+                if (debug != null) {
+                    System.out.println("FIPS mode in SunPKCS11");
+                }
+
+                @SuppressWarnings("unchecked")
+                Consumer<SunPKCS11> consumer = (Consumer<SunPKCS11>) p11;
+                consumer.accept(this);
+                mysunpkcs11 = this;
+
+                Session session = null;
+                try {
+                    session = token.getOpSession();
+                    p11.C_Login(session.id(), CKU_USER, new char[] {});
+                } catch (PKCS11Exception e) {
+                    throw e;
+                } finally {
+                    token.releaseSession(session);
+                }
+            }
         } catch (Exception e) {
             if (config.getHandleStartupErrors() == Config.ERR_IGNORE_ALL) {
                 throw new UnsupportedOperationException
@@ -410,6 +453,94 @@ public final class SunPKCS11 extends AuthProvider {
 
     private static String[] s(String ...aliases) {
         return aliases;
+    }
+
+    byte[] exportKey(long hSession, CK_ATTRIBUTE[] attributes, long keyId) throws PKCS11Exception {
+        // Generating the secret key that will be used for wrapping and unwrapping.
+        CK_ATTRIBUTE[] wrapKeyAttributes = token.getAttributes(TemplateManager.O_GENERATE, CKO_SECRET_KEY, CKK_AES, new CK_ATTRIBUTE[] { new CK_ATTRIBUTE(CKA_CLASS, CKO_SECRET_KEY), new CK_ATTRIBUTE(CKA_VALUE_LEN, 256 >> 3) });
+        Session wrapKeyGenSession = token.getObjSession();
+        P11Key wrapKey;
+
+        try {
+            long genKeyId = token.p11.C_GenerateKey(wrapKeyGenSession.id(), new CK_MECHANISM(CKM_AES_KEY_GEN), wrapKeyAttributes);
+            wrapKey = (P11Key)P11Key.secretKey(wrapKeyGenSession, genKeyId, "AES", 256 >> 3, null);
+        } catch (PKCS11Exception e) {
+            throw e;
+        } finally {
+            token.releaseSession(wrapKeyGenSession);
+        }
+
+        // Wrapping the private key inside the PKCS11 device using the generated secret key.
+        CK_MECHANISM wrapMechanism = new CK_MECHANISM(CKM_AES_CBC_PAD, new byte[16]);
+        long wrapKeyId = wrapKey.getKeyID();
+        byte[] wrappedKeyBytes = token.p11.C_WrapKey(hSession, wrapMechanism, wrapKeyId, keyId);
+
+        // Unwrapping to obtain the private key.
+        byte[] unwrappedKeyBytes;
+        try {
+            Cipher unwrapCipher = Cipher.getInstance("AES/CBC/PKCS5Padding");
+            unwrapCipher.init(Cipher.DECRYPT_MODE, wrapKey, new IvParameterSpec((byte[])wrapMechanism.pParameter), null);
+            unwrappedKeyBytes = unwrapCipher.doFinal(wrappedKeyBytes);
+            return unwrappedKeyBytes;
+        } catch (NoSuchPaddingException | NoSuchAlgorithmException | BadPaddingException | InvalidAlgorithmParameterException | InvalidKeyException | IllegalBlockSizeException e) {
+            throw new PKCS11Exception(CKR_GENERAL_ERROR);
+        } finally {
+            wrapKey.releaseKeyID();
+        }
+    }
+
+    long importKey(long hSession, CK_ATTRIBUTE[] attributes) throws PKCS11Exception {
+        long unwrappedKeyId, keyClass = 0, keyType = 0;
+        byte[] keyBytes = null;
+        // Extract key information.
+        for (CK_ATTRIBUTE attr : attributes) {
+            if (attr.type == CKA_CLASS) {
+                keyClass = attr.getLong();
+            }
+            if (attr.type == CKA_KEY_TYPE) {
+                keyType = attr.getLong();
+            }
+            if (attr.type == CKA_VALUE) {
+                keyBytes = attr.getByteArray();
+            }
+        }
+
+        if ((keyClass == CKO_SECRET_KEY) && (keyBytes != null) && (keyBytes.length > 0)) {
+            // Generate key used for wrapping and unwrapping of the secret key.
+            CK_ATTRIBUTE[] wrapKeyAttributes = token.getAttributes(TemplateManager.O_GENERATE, CKO_SECRET_KEY, CKK_AES, new CK_ATTRIBUTE[] { new CK_ATTRIBUTE(CKA_CLASS, CKO_SECRET_KEY), new CK_ATTRIBUTE(CKA_VALUE_LEN, 256 >> 3)});
+            Session wrapKeyGenSession = token.getObjSession();
+            P11Key wrapKey;
+
+            try {
+                long keyId = token.p11.C_GenerateKey(wrapKeyGenSession.id(), new CK_MECHANISM(CKM_AES_KEY_GEN), wrapKeyAttributes);
+                wrapKey = (P11Key)P11Key.secretKey(wrapKeyGenSession, keyId, "AES", 256 >> 3, null);
+            } catch (PKCS11Exception e) {
+                throw e;
+            } finally {
+                token.releaseSession(wrapKeyGenSession);
+            }
+
+            long wrapKeyId = wrapKey.getKeyID();
+            try {
+                // Wrap the external secret key.
+                CK_MECHANISM wrapMechanism = new CK_MECHANISM(CKM_AES_CBC_PAD, new byte[16]);
+                Cipher wrapCipher = Cipher.getInstance("AES/CBC/PKCS5Padding");
+                wrapCipher.init(Cipher.ENCRYPT_MODE, wrapKey, new IvParameterSpec((byte[])wrapMechanism.pParameter), null);
+                byte[] wrappedBytes = wrapCipher.doFinal(keyBytes);
+
+                // Unwrap the secret key.
+                CK_ATTRIBUTE[] unwrapAttributes = token.getAttributes(TemplateManager.O_IMPORT, keyClass, keyType, attributes);
+                unwrappedKeyId = token.p11.C_UnwrapKey(hSession, wrapMechanism, wrapKeyId, wrappedBytes, unwrapAttributes);
+            } catch (PKCS11Exception | NoSuchPaddingException | NoSuchAlgorithmException | BadPaddingException | InvalidAlgorithmParameterException | InvalidKeyException | IllegalBlockSizeException e) {
+                throw new PKCS11Exception(CKR_GENERAL_ERROR);
+            } finally {
+                wrapKey.releaseKeyID();
+            }
+        } else {
+            // Unsupported key type or invalid bytes.
+            throw new PKCS11Exception(CKR_GENERAL_ERROR);
+        }
+        return Long.valueOf(unwrappedKeyId);
     }
 
     private static final class Descriptor {

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/wrapper/PKCS11.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/wrapper/PKCS11.java
@@ -45,16 +45,26 @@
  *  POSSIBILITY  OF SUCH DAMAGE.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2022, 2022 All Rights Reserved
+ * ===========================================================================
+ */
+
 package sun.security.pkcs11.wrapper;
 
 import java.io.File;
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.util.*;
+import java.util.function.Consumer;
 
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 
 import sun.security.util.Debug;
+import sun.security.pkcs11.SunPKCS11;
 
 import static sun.security.pkcs11.wrapper.PKCS11Constants.*;
 
@@ -134,6 +144,48 @@ public class PKCS11 {
     private static final Map<String,PKCS11> moduleMap =
         new HashMap<String,PKCS11>();
 
+    static boolean isKey(CK_ATTRIBUTE[] attrs) {
+        for (CK_ATTRIBUTE attr : attrs) {
+            if ((attr.type == CKA_CLASS) && (attr.getLong() == CKO_SECRET_KEY)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    // This is the SunPKCS11 provider instance
+    // there can only be a single PKCS11 provider in
+    // FIPS mode.
+    private static SunPKCS11 mysunpkcs11;
+
+    private static final class InnerPKCS11 extends PKCS11 implements Consumer<SunPKCS11> {
+        InnerPKCS11(String pkcs11ModulePath, String functionListName) throws IOException {
+            super(pkcs11ModulePath, functionListName);
+        }
+
+        // Set PKCS11 instance to FIPS mode, called by SunPKCS11 provider.
+        @Override
+        public void accept(SunPKCS11 sunpkcs11) {
+            mysunpkcs11 = sunpkcs11;
+        }
+
+        // Overriding the JNI method C_CreateObject so that first check if FIPS mode is on and the object is a
+        // secret key, in which case invoke the importKey method in SunPKCS11 provider to import the secret key
+        // into the PKCS11 device.
+        public synchronized long C_CreateObject(long hSession, CK_ATTRIBUTE[] pTemplate) throws PKCS11Exception {
+            if ((mysunpkcs11 != null) && isKey(pTemplate)) {
+                try {
+                    Method method = mysunpkcs11.getClass().getDeclaredMethod("importKey", long.class, CK_ATTRIBUTE[].class);
+                    method.setAccessible(true);
+                    return (Long)method.invoke(mysunpkcs11, hSession, pTemplate);
+                } catch (InvocationTargetException | NoSuchMethodException | IllegalAccessException e) {
+                    throw new PKCS11Exception(CKR_GENERAL_ERROR);
+                }
+            }
+            return super.C_CreateObject(hSession, pTemplate);
+        }
+    }
+
     /**
      * Connects to the PKCS#11 driver given. The filename must contain the
      * path, if the driver is not in the system's search path.
@@ -157,7 +209,7 @@ public class PKCS11 {
         if (pkcs11 == null) {
             if ((pInitArgs != null)
                     && ((pInitArgs.flags & CKF_OS_LOCKING_OK) != 0)) {
-                pkcs11 = new PKCS11(pkcs11ModulePath, functionList);
+                pkcs11 = new InnerPKCS11(pkcs11ModulePath, functionList);
             } else {
                 pkcs11 = new SynchronizedPKCS11(pkcs11ModulePath, functionList);
             }
@@ -1691,6 +1743,15 @@ static class SynchronizedPKCS11 extends PKCS11 {
 
     public synchronized long C_CreateObject(long hSession,
             CK_ATTRIBUTE[] pTemplate) throws PKCS11Exception {
+        if ((mysunpkcs11 != null) && isKey(pTemplate)) {
+            try {
+                Method method = mysunpkcs11.getClass().getMethod("importKey", long.class, CK_ATTRIBUTE[].class);
+                method.setAccessible(true);
+                return (Long)method.invoke(mysunpkcs11, hSession, pTemplate);
+            } catch (InvocationTargetException | NoSuchMethodException | IllegalAccessException e) {
+                throw new PKCS11Exception(CKR_GENERAL_ERROR);
+            }
+        }
         return super.C_CreateObject(hSession, pTemplate);
     }
 


### PR DESCRIPTION
Signed-off-by: Alon Shalev Housfater <alonsh@ca.ibm.com>

The IBM Semeru FIPS mode currently leverages Mozilla's NSS library that is installed on RHEL platform. IBM Semeru talks to the NSS native library via the SunPKCS11 security provider which interfaces to NSS using the PKCS11 protocol. When in FIPS mode, the NSS library disables the export/import of cryptographic keys so that cryptographic keys are contained only within the scope of the NSS library. Attempting to extract cryptographic keys that were generated within NSS or import keys so NSS will perform computation on them (such as loading keys from a file) - will throw an exception.

This is a problem for some users such as Liberty, whose Lightweight Third Party Authentication (LTPA) feature requires importing and exporting cryptographic keys. This PR allows a user to export and import cryptographic keys by leveraging the PKCS11 wrapping/unwrapping feature which does allows to indrectly extract/insert keys.

The idea of this PR is to intercept at the point at which a key is imported/exported under regular non-FIPS mode, detect it is in FIPS mode and perform unwrap/wrap to move the key across the PKCS11 module boundary. For importing a key, this is done in the CreateObject call - for exporting a key this is done in the P11Key creation code. The reason we need to modify the pkcs11 security provider at a fairly low level is that we require access to the underlying pkcs11 token in order to invoke the unwrap/wrap calls.