### PR TITLE
LUDCL refresh points

### DIFF
--- a/src/java.base/share/classes/java/io/ObjectInputStream.java
+++ b/src/java.base/share/classes/java/io/ObjectInputStream.java
@@ -545,22 +545,22 @@ public class ObjectInputStream
             throw new AssertionError("internal error");
 
         ClassLoader oldCachedLudcl = null;
-	boolean setCached = false;
+        boolean setCached = false;
 
-	if (((null == curContext) || refreshLudcl) && (isClassCachingEnabled)) {
+        if (((null == curContext) || refreshLudcl) && (isClassCachingEnabled)) {
             oldCachedLudcl = cachedLudcl;
+            setCached = true;
 
             // If caller is not provided, follow the standard path to get the cachedLudcl.
             // Otherwise use the class loader provided by JIT as the cachedLudcl.
 
             if (caller == null) {
-                 cachedLudcl = latestUserDefinedLoader();
+                 refreshLudcl = true;
             }else{
                  cachedLudcl = caller.getClassLoader();
+                 refreshLudcl = false;
             }
 
-            setCached = true;
-            refreshLudcl = false;
             if (null == startingLudclObject) {
                 startingLudclObject = this;
             }
@@ -675,9 +675,8 @@ public class ObjectInputStream
 
         if (((null == curContext) || refreshLudcl) && (isClassCachingEnabled)) {
             oldCachedLudcl = cachedLudcl;
-            cachedLudcl = latestUserDefinedLoader();
             setCached = true;
-            refreshLudcl = false;
+            refreshLudcl = true;
             if (null == startingLudclObject) {
                 startingLudclObject = this;
             }


### PR DESCRIPTION
In `ObjectInputStream`, the latest user defined class loader (LUDCL) is cached. The cache is refreshed at different points in the code by walking the stack, some of the points are called more ofter than where the LUDCL is actually needed (in `resolveClass()`). This causes the cache to be refreshed and perform a stackWalk more times than LUDCL is used.

This fix removes the points of refresh outside `resolveClass()` so a stackWalk is performed at most as many times the LUDCL is needed, or less if already cached.

https://github.com/eclipse-openj9/openj9/issues/15570