### PR TITLE
Move ClassSpecializer.java & add NotCheckpointSafe

### DIFF
--- a/closed/GensrcJ9JCL.gmk
+++ b/closed/GensrcJ9JCL.gmk
@@ -51,9 +51,11 @@ $(eval $(call SetupCopyFiles,COPY_OVERLAY_FILES, \
 	SRC := $(TOPDIR), \
 	DEST := $(SUPPORT_OUTPUTDIR)/overlay, \
 	FILES := \
+		src/java.base/share/classes/java/lang/ClassValue.java \
 		src/java.base/share/classes/java/security/Security.java \
 		src/java.base/share/classes/java/util/Timer.java \
 		src/java.base/share/classes/java/util/TimerTask.java \
+		src/java.base/share/classes/java/util/concurrent/ConcurrentHashMap.java \
 		src/java.base/unix/classes/java/lang/ProcessEnvironment.java \
 	))
 

--- a/closed/src/java.base/share/classes/java/lang/invoke/ClassSpecializer.java
+++ b/closed/src/java.base/share/classes/java/lang/invoke/ClassSpecializer.java
@@ -1,0 +1,24 @@
+/*[INCLUDE-IF !OPENJDK_METHODHANDLES]*/
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2022, 2022 All Rights Reserved
+ * ===========================================================================
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * IBM designates this particular file as subject to the "Classpath" exception
+ * as provided by IBM in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, see <http://www.gnu.org/licenses/>.
+ *
+ * ===========================================================================
+ */

--- a/src/java.base/share/classes/java/lang/ClassValue.java
+++ b/src/java.base/share/classes/java/lang/ClassValue.java
@@ -23,6 +23,12 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2022, 2022 All Rights Reserved
+ * ===========================================================================
+ */
+
 package java.lang;
 
 import java.util.WeakHashMap;
@@ -33,6 +39,10 @@ import jdk.internal.misc.Unsafe;
 
 import static java.lang.ClassValue.ClassValueMap.probeHomeLocation;
 import static java.lang.ClassValue.ClassValueMap.probeBackupLocations;
+
+/*[IF CRIU_SUPPORT]*/
+import openj9.internal.criu.NotCheckpointSafe;
+/*[ENDIF] CRIU_SUPPORT */
 
 /**
  * Lazily associate a computed value with (potentially) every type.
@@ -372,6 +382,9 @@ public abstract class ClassValue<T> {
 
     private static final Object CRITICAL_SECTION = new Object();
     private static final Unsafe UNSAFE = Unsafe.getUnsafe();
+    /*[IF CRIU_SUPPORT]*/
+    @NotCheckpointSafe
+    /*[ENDIF] CRIU_SUPPORT */
     private static ClassValueMap initializeMap(Class<?> type) {
         ClassValueMap map;
         synchronized (CRITICAL_SECTION) {  // private object to avoid deadlocks

--- a/src/java.base/share/classes/java/util/concurrent/ConcurrentHashMap.java
+++ b/src/java.base/share/classes/java/util/concurrent/ConcurrentHashMap.java
@@ -33,6 +33,12 @@
  * http://creativecommons.org/publicdomain/zero/1.0/
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2022, 2022 All Rights Reserved
+ * ===========================================================================
+ */
+
 package java.util.concurrent;
 
 import java.io.ObjectStreamField;
@@ -69,6 +75,10 @@ import java.util.function.ToLongBiFunction;
 import java.util.function.ToLongFunction;
 import java.util.stream.Stream;
 import jdk.internal.misc.Unsafe;
+
+/*[IF CRIU_SUPPORT]*/
+import openj9.internal.criu.NotCheckpointSafe;
+/*[ENDIF] CRIU_SUPPORT */
 
 /**
  * A hash table supporting full concurrency of retrievals and
@@ -1685,6 +1695,9 @@ public class ConcurrentHashMap<K,V> extends AbstractMap<K,V>
      * @throws RuntimeException or Error if the mappingFunction does so,
      *         in which case the mapping is left unestablished
      */
+    /*[IF CRIU_SUPPORT]*/
+    @NotCheckpointSafe
+    /*[ENDIF] CRIU_SUPPORT */
     public V computeIfAbsent(K key, Function<? super K, ? extends V> mappingFunction) {
         if (key == null || mappingFunction == null)
             throw new NullPointerException();


### PR DESCRIPTION
Move `ClassSpecializer.java` from OpenJ9 to extension repo, this file is only required by JDK11. When processing OpenJ9 JCL, JPP for other Java levels removes this file which might be generated by another JPP process for extension source files;
Annotated `java.lang.ClassValue.initializeMap()`, and `java.util.concurrent.ConcurrentHashMap.computeIfAbsent()` with
`NotCheckpointSafe` to prevent `JVMCheckpointException`/deadlock.

Adopted https://github.com/ibmruntimes/openj9-openjdk-jdk17/pull/127
Related to https://github.com/eclipse-openj9/openj9/pull/15593

Signed-off-by: Jason Feng <fengj@ca.ibm.com>