### PR TITLE
Add NULL check for CRIU field retrieval

### DIFF
--- a/src/java.base/share/classes/java/util/Timer.java
+++ b/src/java.base/share/classes/java/util/Timer.java
@@ -203,7 +203,9 @@ public class Timer {
             throw new IllegalArgumentException("Negative delay.");
         /*[IF CRIU_SUPPORT]*/
         // only tasks scheduled before Checkpoint to be adjusted
-        if (InternalCRIUSupport.getCheckpointRestoreNanoTimeDelta() == 0) {
+        if ((InternalCRIUSupport.getCheckpointRestoreNanoTimeDelta() == 0)
+            && (task != null)
+        ) {
             task.criuAdjustRequired = true;
         }
         /*[ENDIF] CRIU_SUPPORT*/
@@ -264,7 +266,9 @@ public class Timer {
             throw new IllegalArgumentException("Non-positive period.");
         /*[IF CRIU_SUPPORT]*/
         // only tasks scheduled before Checkpoint to be adjusted
-        if (InternalCRIUSupport.getCheckpointRestoreNanoTimeDelta() == 0) {
+        if ((InternalCRIUSupport.getCheckpointRestoreNanoTimeDelta() == 0)
+            && (task != null)
+        ) {
             task.criuAdjustRequired = true;
         }
         /*[ENDIF] CRIU_SUPPORT*/
@@ -350,7 +354,9 @@ public class Timer {
             throw new IllegalArgumentException("Non-positive period.");
         /*[IF CRIU_SUPPORT]*/
         // only tasks scheduled before Checkpoint to be adjusted
-        if (InternalCRIUSupport.getCheckpointRestoreNanoTimeDelta() == 0) {
+        if ((InternalCRIUSupport.getCheckpointRestoreNanoTimeDelta() == 0)
+            && (task != null)
+        ) {
             task.criuAdjustRequired = true;
         }
         /*[ENDIF] CRIU_SUPPORT*/


### PR DESCRIPTION
The `task` could be null.

An internal test expects `IllegalArgumentException` when `task` is `null` and `time < 0` [1].

[1] https://github.com/ibmruntimes/openj9-openjdk-jdk11/blob/20d13352ee5c9569416880e340d5c589161082f9/src/java.base/share/classes/java/util/Timer.java#L415-L417

Signed-off-by: Jason Feng <fengj@ca.ibm.com>