### PR TITLE
Fix incremental DDR builds

### DIFF
--- a/closed/DDR.gmk
+++ b/closed/DDR.gmk
@@ -1,5 +1,5 @@
 # ===========================================================================
-# (c) Copyright IBM Corp. 2018, 2021 All Rights Reserved
+# (c) Copyright IBM Corp. 2018, 2022 All Rights Reserved
 # ===========================================================================
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
@@ -89,6 +89,10 @@ $(eval $(call SetupJavaCompilation,BUILD_DDR_TOOLS, \
 		com/ibm/j9ddr/tools/store/StructureMismatchError.java \
 	))
 
+# Any new references to constants must be paired with additions to the compatibility
+# list unless those constants were defined long ago.
+DDR_COMPATIBILITY_FILE := $(DDR_VM_SRC_ROOT)/com/ibm/j9ddr/CompatibilityConstants29.dat
+
 #############################################################################
 
 # When StructureReader opens the blob, it must be able to find AuxFieldInfo29.dat
@@ -104,7 +108,7 @@ DDR_TOOLS_OPTIONS := \
 # its contents influence the generated class files.
 DDR_FIELDS_FILE := $(DDR_VM_SRC_ROOT)/com/ibm/j9ddr/AuxFieldInfo29.dat
 
-$(DDR_CLASSES_MARKER) : $(DDR_BLOB_FILE) $(DDR_FIELDS_FILE) $(BUILD_DDR_TOOLS)
+$(DDR_CLASSES_MARKER) : $(DDR_BLOB_FILE) $(DDR_COMPATIBILITY_FILE) $(DDR_FIELDS_FILE) $(BUILD_DDR_TOOLS)
 	@$(ECHO) Generating DDR pointer and structure class files
 	@$(RM) -rf $(DDR_CLASSES_BIN)
 	@$(JAVA) $(DDR_TOOLS_OPTIONS) com.ibm.j9ddr.tools.ClassGenerator \
@@ -123,9 +127,6 @@ $(DDR_POINTERS_MARKER) : $(DDR_SUPERSET_FILE) $(DDR_FIELDS_FILE) $(BUILD_DDR_TOO
 		-o $(DDR_GENSRC_DIR)
 	@$(TOUCH) $@
 
-# Any new references to constants must be paired with additions to the compatibility
-# list unless those constants were defined long ago.
-DDR_COMPATIBILITY_FILE := $(DDR_VM_SRC_ROOT)/com/ibm/j9ddr/CompatibilityConstants29.dat
 DDR_RESTRICT_FILE := $(OPENJ9_TOPDIR)/debugtools/DDR_VM/data/superset-constants.dat
 
 $(DDR_STRUCTURES_MARKER) : $(DDR_SUPERSET_FILE) $(DDR_RESTRICT_FILE) $(DDR_COMPATIBILITY_FILE) $(DDR_FIELDS_FILE) $(BUILD_DDR_TOOLS)


### PR DESCRIPTION
`ClassGenerator` reads `CompatibilityConstants29.dat` and so must be executed if that file changes.