### PR TITLE
Set OpenJDK test property vm.musl to false in OpenJ9PropsExt

### DIFF
--- a/closed/test/jtreg-ext/requires/OpenJ9PropsExt.java
+++ b/closed/test/jtreg-ext/requires/OpenJ9PropsExt.java
@@ -1,6 +1,6 @@
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2019, 2020 All Rights Reserved
+ * (c) Copyright IBM Corp. 2019, 2022 All Rights Reserved
  * ===========================================================================
  * 
  * This code is free software; you can redistribute it and/or modify it
@@ -36,8 +36,9 @@ public class OpenJ9PropsExt implements Callable<Map<String, String>> {
 
         Map<String, String> map = new HashMap<>();
         try {
-            map.put("vm.graal.enabled", "false");
             map.put("vm.bits", vmBits());
+            map.put("vm.graal.enabled", "false");
+            map.put("vm.musl", "false");
         }
         catch (Exception e) {
             e.printStackTrace();


### PR DESCRIPTION
It's now used by java/lang/ProcessBuilder/Basic.java
https://github.com/ibmruntimes/openj9-openjdk-jdk11/blob/openj9-staging/test/jdk/java/lang/ProcessBuilder/Basic.java#L40

The property is already set for jdk17+

Signed-off-by: Peter Shipton <Peter_Shipton@ca.ibm.com>