### PR TITLE
Set OpenJDK test property vm.hasJFR to false in OpenJ9PropsExt

### DIFF
--- a/closed/test/jtreg-ext/requires/OpenJ9PropsExt.java
+++ b/closed/test/jtreg-ext/requires/OpenJ9PropsExt.java
@@ -38,6 +38,7 @@ public class OpenJ9PropsExt implements Callable<Map<String, String>> {
         try {
             map.put("vm.bits", vmBits());
             map.put("vm.graal.enabled", "false");
+            map.put("vm.hasJFR", "false");
             map.put("vm.musl", "false");
         }
         catch (Exception e) {


### PR DESCRIPTION
Fixes https://github.com/eclipse-openj9/openj9/issues/15802

The property is already set for jdk17+

Signed-off-by: Peter Shipton <Peter_Shipton@ca.ibm.com>