### PR TITLE
OpenJDK test HugeCapacity needs to run with -XX:+CompactStrings

### DIFF
--- a/test/jdk/java/lang/StringBuilder/HugeCapacity.java
+++ b/test/jdk/java/lang/StringBuilder/HugeCapacity.java
@@ -21,13 +21,19 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2022, 2022 All Rights Reserved
+ * ===========================================================================
+ */
+
 /**
  * @test
  * @bug 8149330
  * @summary Capacity should not get close to Integer.MAX_VALUE unless
  *          necessary
  * @requires (sun.arch.data.model == "64" & os.maxMemory >= 6G)
- * @run main/othervm -Xmx5G HugeCapacity
+ * @run main/othervm -Xmx5G -XX:+CompactStrings HugeCapacity
  */
 
 public class HugeCapacity {


### PR DESCRIPTION
-XX:+CompactStrings is the default for OpenJDK 11, but not OpenJ9.

The test is failing in the acceptance build. The test was set `@ignore`, but this is removed in the staging branch, jdk-11.0.18+1.
https://openj9-jenkins.osuosl.org/job/Pipeline-OpenJDK11-Acceptance/59/

Tested in grinder https://openj9-jenkins.osuosl.org/view/Test/job/Grinder/1488