### PR TITLE
Update export/import of plain keys in FIPS

### DIFF
--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Key.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Key.java
@@ -25,7 +25,7 @@
 
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2022, 2022 All Rights Reserved
+ * (c) Copyright IBM Corp. 2022, 2023 All Rights Reserved
  * ===========================================================================
  */
 
@@ -384,8 +384,8 @@ abstract class P11Key implements Key, Length {
             new CK_ATTRIBUTE(CKA_SENSITIVE),
             new CK_ATTRIBUTE(CKA_EXTRACTABLE),
         });
-        if (attributes[1].getBoolean() || (attributes[2].getBoolean() == false)) {
-            if ((SunPKCS11.mysunpkcs11 != null) && "RSA".equals(algorithm)) {
+        if ((SunPKCS11.mysunpkcs11 != null) && "RSA".equals(algorithm)) {
+            if (attributes[0].getBoolean() || attributes[1].getBoolean() || (attributes[2].getBoolean() == false)) {
                 try {
                     byte[] key = SunPKCS11.mysunpkcs11.exportKey(session.id(), attributes, keyID);
                     RSAPrivateKey rsaPrivKey = RSAPrivateCrtKeyImpl.newKey(key);
@@ -398,6 +398,8 @@ abstract class P11Key implements Key, Length {
                     // Attempt failed, create a P11PrivateKey object.
                 }
             }
+        }
+        if (attributes[1].getBoolean() || (attributes[2].getBoolean() == false)) {
             return new P11PrivateKey
                 (session, keyID, algorithm, keyLength, attributes);
         } else {

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/SunPKCS11.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/SunPKCS11.java
@@ -25,7 +25,7 @@
 
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2022, 2022 All Rights Reserved
+ * (c) Copyright IBM Corp. 2022, 2023 All Rights Reserved
  * ===========================================================================
  */
 
@@ -35,8 +35,6 @@ import java.io.*;
 import java.util.*;
 
 import java.security.*;
-import java.security.InvalidAlgorithmParameterException;
-import java.security.InvalidKeyException;
 import java.security.interfaces.*;
 import java.util.function.Consumer;
 
@@ -489,8 +487,9 @@ public final class SunPKCS11 extends AuthProvider {
         }
     }
 
-    long importKey(long hSession, CK_ATTRIBUTE[] attributes) throws PKCS11Exception {
-        long unwrappedKeyId, keyClass = 0, keyType = 0;
+    public long importKey(long hSession, CK_ATTRIBUTE[] attributes) throws PKCS11Exception {
+        long keyClass = 0;
+        long keyType = 0;
         byte[] keyBytes = null;
         // Extract key information.
         for (CK_ATTRIBUTE attr : attributes) {
@@ -530,7 +529,7 @@ public final class SunPKCS11 extends AuthProvider {
 
                 // Unwrap the secret key.
                 CK_ATTRIBUTE[] unwrapAttributes = token.getAttributes(TemplateManager.O_IMPORT, keyClass, keyType, attributes);
-                unwrappedKeyId = token.p11.C_UnwrapKey(hSession, wrapMechanism, wrapKeyId, wrappedBytes, unwrapAttributes);
+                return token.p11.C_UnwrapKey(hSession, wrapMechanism, wrapKeyId, wrappedBytes, unwrapAttributes);
             } catch (PKCS11Exception | NoSuchPaddingException | NoSuchAlgorithmException | BadPaddingException | InvalidAlgorithmParameterException | InvalidKeyException | IllegalBlockSizeException e) {
                 throw new PKCS11Exception(CKR_GENERAL_ERROR);
             } finally {
@@ -540,7 +539,6 @@ public final class SunPKCS11 extends AuthProvider {
             // Unsupported key type or invalid bytes.
             throw new PKCS11Exception(CKR_GENERAL_ERROR);
         }
-        return Long.valueOf(unwrappedKeyId);
     }
 
     private static final class Descriptor {


### PR DESCRIPTION
Signed-off-by: Tao Liu tao.liu@ibm.com

According to the suggestion in JDK PR https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/469, add CKA_TOKEN in the condition for export/import plain keys in FIPS mode. And also, back-ports some changes included in JDKnext PR https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/469 to JDK11 for all version consistent.