### PR TITLE
OpenJ9 doesn't support Perf, don't try to use it

### DIFF
--- a/src/jdk.internal.jvmstat/share/classes/sun/jvmstat/PlatformSupport.java
+++ b/src/jdk.internal.jvmstat/share/classes/sun/jvmstat/PlatformSupport.java
@@ -56,16 +56,7 @@ public class PlatformSupport {
     }
 
     public static PlatformSupport getInstance() {
-        try {
-            Class<?> c = Class.forName("sun.jvmstat.PlatformSupportImpl");
-            @SuppressWarnings("unchecked")
-            Constructor<PlatformSupport> cntr = (Constructor<PlatformSupport>) c.getConstructor();
-            return cntr.newInstance();
-        } catch (ClassNotFoundException e) {
-            return new PlatformSupport();
-        } catch (ReflectiveOperationException e) {
-            throw new InternalError(e);
-        }
+        return new PlatformSupport();
     }
 
     // package-private

--- a/src/jdk.jconsole/share/classes/sun/tools/jconsole/LocalVirtualMachine.java
+++ b/src/jdk.jconsole/share/classes/sun/tools/jconsole/LocalVirtualMachine.java
@@ -139,16 +139,6 @@ public class LocalVirtualMachine {
                 String name = vmid.toString(); // default to pid if name not available
                 boolean attachable = false;
                 String address = null;
-                try {
-                     MonitoredVm mvm = host.getMonitoredVm(new VmIdentifier(name));
-                     // use the command line as the display name
-                     name =  MonitoredVmUtil.commandLine(mvm);
-                     attachable = MonitoredVmUtil.isAttachable(mvm);
-                     address = ConnectorAddressLink.importFrom(pid);
-                     mvm.detach();
-                } catch (Exception x) {
-                     // ignore
-                }
                 map.put((Integer) vmid,
                         new LocalVirtualMachine(pid, name, attachable, address));
             }


### PR DESCRIPTION
Trying to use jdk.internal.perf.Perf may result in an Assertion "Java_sun_misc_Perf_attach unimplemented" or similar. Calling sun.tools.jconsole.LocalVirtualMachine.getAllVirtualMachines() tries to use Perf.

Issue https://github.com/eclipse-openj9/openj9/issues/16719

I didn't add any IBM copyright since no code was added.

Will port to other versions after the initial review.