### PR TITLE
Allow any text without whitespace for the openssl version

### DIFF
--- a/closed/get_openssl_source.sh
+++ b/closed/get_openssl_source.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # ===========================================================================
-# (c) Copyright IBM Corp. 2018, 2022 All Rights Reserved
+# (c) Copyright IBM Corp. 2018, 2023 All Rights Reserved
 # ===========================================================================
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -72,7 +72,7 @@ case "$OPENSSL_VERSION" in
 		OPENSSL_SOURCE_TAG="openssl-$OPENSSL_VERSION"
 		;;
 	*)
-		usage
+		OPENSSL_SOURCE_TAG=$OPENSSL_VERSION
 		;;
 esac
 


### PR DESCRIPTION
Will port to other versions after review.

Example build using this https://openj9-jenkins.osuosl.org/job/Build_JDK11_aarch64_mac_Personal/316

  extra_getsource_options: '--openssl-version=OpenSSL_1_1_1-stable --openssl-repo=https://github.com/ibmruntimes/openssl.git'
