### PR TITLE
Remove useless patterns from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,11 @@
 # ===========================================================================
-# (c) Copyright IBM Corp. 2017, 2018 All Rights Reserved
+# (c) Copyright IBM Corp. 2017, 2023 All Rights Reserved
 # ===========================================================================
-#
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
 # published by the Free Software Foundation.
 #
-# IBM designates this particular file as subject to the "Classpath" exception 
+# IBM designates this particular file as subject to the "Classpath" exception
 # as provided by IBM in the LICENSE file that accompanied this code.
 #
 # This code is distributed in the hope that it will be useful, but WITHOUT
@@ -17,21 +16,14 @@
 #
 # You should have received a copy of the GNU General Public License version
 # 2 along with this work; if not, see <http://www.gnu.org/licenses/>.
-#
 # ===========================================================================
 #
-# exclude build directories
-/.build
 # exclude all source directories
 /omr
 /openj9
 /openssl
 # exclude optional eclipse project file
 /.project
-
-# ignore derived artifacts created when configure option '--with-freetype-src' is used
-/freetype.bat
-/freetype.log
 
 # openjdk gitignore
 /build/


### PR DESCRIPTION
Noticed while reviewing #652 (see https://github.com/ibmruntimes/openj9-openjdk-jdk11/pull/652#issuecomment-1534893774).

* configure option `--with-freetype-src` has been removed, so `freetype.bat` and `freetype.log` should not be created
* I don't think `/.build` ever needed to be ignored