### PR TITLE
Cause a system dump on failure of UncaughtExceptionsTest

### DIFF
--- a/test/jdk/java/lang/Thread/UncaughtExceptionsTest.java
+++ b/test/jdk/java/lang/Thread/UncaughtExceptionsTest.java
@@ -67,9 +67,9 @@ public class UncaughtExceptionsTest {
     public void test(String className, int exitValue, String stdOutMatch, String stdErrMatch) throws Throwable {
         ProcessBuilder processBuilder = ProcessTools.createJavaProcessBuilder(String.format("UncaughtExitSimulator$%s",className));
         OutputAnalyzer outputAnalyzer = ProcessTools.executeCommand(processBuilder);
-        outputAnalyzer.shouldHaveExitValue(exitValue);
-        outputAnalyzer.stderrShouldMatch(stdErrMatch);
         try {
+            outputAnalyzer.shouldHaveExitValue(exitValue);
+            outputAnalyzer.stderrShouldMatch(stdErrMatch);
             outputAnalyzer.stdoutShouldMatch(stdOutMatch);
         } catch (RuntimeException e) {
             com.ibm.jvm.Dump.SystemDump();


### PR DESCRIPTION
Seems I caught the exception on the wrong line. Include all the cases.

Related to https://github.com/ibmruntimes/openj9-openjdk-jdk11/pull/647 and https://github.com/eclipse-openj9/openj9/issues/11930#issuecomment-1544458452