### PR TITLE
Fix mode of ReleasePrimitiveArrayCritical to ensure copying of data

### DIFF
--- a/closed/src/java.base/share/native/libjncrypto/NativeCrypto.c
+++ b/closed/src/java.base/share/native/libjncrypto/NativeCrypto.c
@@ -2450,13 +2450,13 @@ Java_jdk_crypto_jniprovider_NativeCrypto_ECGenerateKeyPair
 
 cleanup:
     if (NULL != nativeX) {
-        (*env)->ReleasePrimitiveArrayCritical(env, x, nativeX, JNI_ABORT);
+        (*env)->ReleasePrimitiveArrayCritical(env, x, nativeX, 0);
     }
     if (NULL != nativeY) {
-        (*env)->ReleasePrimitiveArrayCritical(env, y, nativeY, JNI_ABORT);
+        (*env)->ReleasePrimitiveArrayCritical(env, y, nativeY, 0);
     }
     if (NULL != nativeS) {
-        (*env)->ReleasePrimitiveArrayCritical(env, s, nativeS, JNI_ABORT);
+        (*env)->ReleasePrimitiveArrayCritical(env, s, nativeS, 0);
     }
     if (NULL != ctx) {
         (*OSSL_BN_CTX_free)(ctx);
@@ -3041,7 +3041,7 @@ cleanup:
         (*env)->ReleasePrimitiveArrayCritical(env, salt, nativeSalt, JNI_ABORT);
     }
     if (NULL != nativeKey) {
-        (*env)->ReleasePrimitiveArrayCritical(env, key, nativeKey, JNI_ABORT);
+        (*env)->ReleasePrimitiveArrayCritical(env, key, nativeKey, 0);
     }
 
     return ret;


### PR DESCRIPTION
Change mode value from `JNI_ABORT` to `0` in `ReleasePrimitiveArrayCritical` of arrays pertaining to EC and PBE key generation.

This makes no difference if a direct reference to the array is provided by the JVM, but it ensures copying of data to the original array, in case a copy of it was provided when calling `GetPrimitiveArrayCritical`.

Back-ported from: https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/603

Signed-off by: Kostas Tsiounis [kostas.tsiounis@ibm.com](mailto:kostas.tsiounis@ibm.com)