### PR TITLE
CRIU restore clears InetAddress.cache

### DIFF
--- a/closed/GensrcJ9JCL.gmk
+++ b/closed/GensrcJ9JCL.gmk
@@ -40,10 +40,12 @@ $(eval $(call SetupCopyFiles,COPY_OVERLAY_FILES, \
 	DEST := $(SUPPORT_OUTPUTDIR)/overlay, \
 	FILES := \
 		src/java.base/share/classes/java/lang/ClassValue.java \
+		src/java.base/share/classes/java/net/InetAddress.java \
 		src/java.base/share/classes/java/security/Security.java \
 		src/java.base/share/classes/java/util/Timer.java \
 		src/java.base/share/classes/java/util/TimerTask.java \
 		src/java.base/share/classes/java/util/concurrent/ConcurrentHashMap.java \
+		src/java.base/share/classes/jdk/internal/misc/JavaNetInetAddressAccess.java \
 		src/java.base/share/classes/sun/security/jca/ProviderConfig.java \
 		src/java.base/share/classes/sun/security/jca/ProviderList.java \
 		src/java.base/unix/classes/java/lang/ProcessEnvironment.java \

--- a/src/java.base/share/classes/java/net/InetAddress.java
+++ b/src/java.base/share/classes/java/net/InetAddress.java
@@ -23,6 +23,12 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2023, 2023 All Rights Reserved
+ * ===========================================================================
+ */
+
 package java.net;
 
 import java.util.NavigableSet;
@@ -336,6 +342,11 @@ class InetAddress implements java.io.Serializable {
                     {
                         return InetAddress.getByName(hostName, hostAddress);
                     }
+                    /*[IF CRIU_SUPPORT]*/
+                    public void clearInetAddressCache() {
+                        InetAddress.clearInetAddressCache();
+                    }
+                    /*[ENDIF] CRIU_SUPPORT */
                 }
         );
         init();
@@ -766,6 +777,16 @@ class InetAddress implements java.io.Serializable {
     // still being looked-up by NameService(s)) or CachedAddresses when cached
     private static final ConcurrentMap<String, Addresses> cache =
         new ConcurrentHashMap<>();
+
+    /*[IF CRIU_SUPPORT]*/
+    /**
+     * To be invoked by CRIU post-restore hook, clear the cache.
+     */
+    static void clearInetAddressCache() {
+        cache.clear();
+        expirySet.clear();
+    }
+    /*[ENDIF] CRIU_SUPPORT */
 
     // CachedAddresses that have to expire are kept ordered in this NavigableSet
     // which is scanned on each access

--- a/src/java.base/share/classes/jdk/internal/misc/JavaNetInetAddressAccess.java
+++ b/src/java.base/share/classes/jdk/internal/misc/JavaNetInetAddressAccess.java
@@ -23,6 +23,12 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2023, 2023 All Rights Reserved
+ * ===========================================================================
+ */
+
 package jdk.internal.misc;
 
 import java.net.InetAddress;
@@ -43,4 +49,11 @@ public interface JavaNetInetAddressAccess {
      */
     InetAddress getByName(String hostName, InetAddress hostAddress)
             throws UnknownHostException;
+
+    /*[IF CRIU_SUPPORT]*/
+    /**
+     * To be invoked by CRIU post-restore hook, clear the cache.
+     */
+    void clearInetAddressCache();
+    /*[ENDIF] CRIU_SUPPORT */
 }


### PR DESCRIPTION
CRIU restore clears InetAddress.cache

Added `InetAddress.clearInetAddressCache()` to be invoked by CRIU post-restore hook via `JavaNetInetAddressAccess()`.

Backport
* https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/604

Related
* https://github.com/eclipse-openj9/openj9/pull/17448

Signed-off-by: Jason Feng <fengj@ca.ibm.com>