### PR TITLE
Cause a better system dump on failure of UncaughtExceptionsTest

### DIFF
--- a/test/jdk/java/lang/Thread/UncaughtExceptionsTest.java
+++ b/test/jdk/java/lang/Thread/UncaughtExceptionsTest.java
@@ -67,14 +67,9 @@ public class UncaughtExceptionsTest {
     public void test(String className, int exitValue, String stdOutMatch, String stdErrMatch) throws Throwable {
         ProcessBuilder processBuilder = ProcessTools.createJavaProcessBuilder(String.format("UncaughtExitSimulator$%s",className));
         OutputAnalyzer outputAnalyzer = ProcessTools.executeCommand(processBuilder);
-        try {
-            outputAnalyzer.shouldHaveExitValue(exitValue);
-            outputAnalyzer.stderrShouldMatch(stdErrMatch);
-            outputAnalyzer.stdoutShouldMatch(stdOutMatch);
-        } catch (RuntimeException e) {
-            com.ibm.jvm.Dump.SystemDump();
-            throw e;
-        }
+        outputAnalyzer.shouldHaveExitValue(exitValue);
+        outputAnalyzer.stderrShouldMatch(stdErrMatch);
+        outputAnalyzer.stdoutShouldMatch(stdOutMatch);
     }
 
 }
@@ -98,7 +93,12 @@ class UncaughtExitSimulator extends Thread implements Runnable {
 
     public static void throwRuntimeException() { throw new RuntimeException("simulateUncaughtExitEvent"); }
 
-    public void run() { throwRuntimeException(); }
+    public void run() {
+        if (!Thread.currentThread().getName().equals("Thread-0")) {
+            com.ibm.jvm.Dump.SystemDump();
+        }
+        throwRuntimeException();
+    }
 
     /**
      * A thread is never alive after you've join()ed it.


### PR DESCRIPTION
Obsoletes https://github.com/ibmruntimes/openj9-openjdk-jdk11/pull/655

Related to
https://github.com/eclipse-openj9/openj9/issues/11930#issuecomment-1544458452