### PR TITLE
Add support for a suspendOnRestore option in JDWP

### DIFF
--- a/closed/GensrcJ9JCL.gmk
+++ b/closed/GensrcJ9JCL.gmk
@@ -49,6 +49,12 @@ $(eval $(call SetupCopyFiles,COPY_OVERLAY_FILES, \
 		src/java.base/share/classes/sun/security/jca/ProviderConfig.java \
 		src/java.base/share/classes/sun/security/jca/ProviderList.java \
 		src/java.base/unix/classes/java/lang/ProcessEnvironment.java \
+		make/data/jdwp/jdwp.spec \
+		src/jdk.jdi/share/classes/com/sun/tools/example/debug/tty/EventHandler.java \
+		src/jdk.jdi/share/classes/com/sun/tools/example/debug/tty/EventNotifier.java \
+		src/jdk.jdi/share/classes/com/sun/tools/example/debug/tty/TTY.java \
+		src/jdk.jdi/share/classes/com/sun/tools/example/debug/tty/TTYResources.java \
+		src/jdk.jdi/share/classes/com/sun/tools/jdi/EventSetImpl.java \
 	))
 
 IncludeIfUnsure := -includeIfUnsure -noWarnIncludeIf

--- a/closed/src/jdk.jdi/share/classes/com/sun/jdi/event/VMRestoreEvent.java
+++ b/closed/src/jdk.jdi/share/classes/com/sun/jdi/event/VMRestoreEvent.java
@@ -1,0 +1,50 @@
+/*[INCLUDE-IF CRIU_SUPPORT]*/
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2023, 2023 All Rights Reserved
+ * ===========================================================================
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * IBM designates this particular file as subject to the "Classpath" exception
+ * as provided by IBM in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, see <http://www.gnu.org/licenses/>.
+ *
+ * ===========================================================================
+ */
+package com.sun.jdi.event;
+
+import com.sun.jdi.ThreadReference;
+import com.sun.jdi.VirtualMachine;
+
+/**
+ * Notification of when the VM is restored from a checkpoint. Similar to
+ * VMStartEvent this occurs before application code has run, including any
+ * application hooks for the restore event.
+ * The event is generated even if not explicitly requested.
+ *
+ * @see VMStartEvent
+ * @see VMDeathEvent
+ * @see EventQueue
+ * @see VirtualMachine
+ */
+public interface VMRestoreEvent extends Event {
+
+    /**
+     * Returns the thread which is restoring the VM from a checkpoint.
+     *
+     * @return a {@link ThreadReference} representing the restore thread
+     * on the target VM.
+     */
+    public ThreadReference thread();
+}

--- a/make/data/jdwp/jdwp.spec
+++ b/make/data/jdwp/jdwp.spec
@@ -22,6 +22,11 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+ /*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2023, 2023 All Rights Reserved
+ * ===========================================================================
+ */
 
 JDWP "Java(tm) Debug Wire Protocol"
 (CommandSet VirtualMachine=1
@@ -3094,6 +3099,17 @@ JDWP "Java(tm) Debug Wire Protocol"
                         (int requestID
                                 "Request that generated event")
                     )
+/*[IF CRIU_SUPPORT]*/
+                    (Alt VMRestore=JDWP.EventKind.VM_RESTORE
+                        "Notification of when the VM is restored from a checkpoint. Similar to"
+                        "VMStartEvent this occurs before application code has run, including any"
+                        "application hooks for the restore event."
+                        "The event is generated even if not explicitly requested."
+
+                        (int requestID "Request that generated event")
+                        (threadObject thread "The thread restoring the VM from a checkpoint.")
+                    )
+/*[ENDIF] CRIU_SUPPORT */
                 )
             )
         )
@@ -3223,6 +3239,9 @@ JDWP "Java(tm) Debug Wire Protocol"
     (Constant VM_INIT                =90  "obsolete - was used in jvmdi")
     (Constant VM_DEATH               =99  )
     (Constant VM_DISCONNECTED        =100 "Never sent across JDWP")
+/*[IF CRIU_SUPPORT]*/
+    (Constant VM_RESTORE             =101 "OpenJ9 VM Restored")
+/*[ENDIF] CRIU_SUPPORT */
 )
 
 (ConstantSet ThreadStatus

--- a/src/jdk.jdi/share/classes/com/sun/tools/example/debug/tty/EventHandler.java
+++ b/src/jdk.jdi/share/classes/com/sun/tools/example/debug/tty/EventHandler.java
@@ -22,6 +22,11 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2023, 2023 All Rights Reserved
+ * ===========================================================================
+ */
 
 /*
  * This source code is provided to illustrate the usage of a given feature
@@ -118,6 +123,10 @@ public class EventHandler implements Runnable {
             return threadDeathEvent(event);
         } else if (event instanceof VMStartEvent) {
             return vmStartEvent(event);
+/*[IF CRIU_SUPPORT]*/
+        } else if (event instanceof VMRestoreEvent) {
+            return vmRestoreEvent(event);
+/*[ENDIF] CRIU_SUPPORT */
         } else {
             return handleExitEvent(event);
         }
@@ -179,6 +188,10 @@ public class EventHandler implements Runnable {
             return ((ThreadDeathEvent)event).thread();
         } else if (event instanceof VMStartEvent) {
             return ((VMStartEvent)event).thread();
+/*[IF CRIU_SUPPORT]*/
+        } else if (event instanceof VMRestoreEvent) {
+            return ((VMRestoreEvent)event).thread();
+/*[ENDIF] CRIU_SUPPORT */
         } else {
             return null;
         }
@@ -209,6 +222,14 @@ public class EventHandler implements Runnable {
         notifier.vmStartEvent(se);
         return stopOnVMStart;
     }
+
+/*[IF CRIU_SUPPORT]*/
+    private boolean vmRestoreEvent(Event event)  {
+        VMRestoreEvent se = (VMRestoreEvent)event;
+        notifier.vmRestoreEvent(se);
+        return stopOnVMStart;
+    }
+/*[ENDIF] CRIU_SUPPORT */
 
     private boolean breakpointEvent(Event event)  {
         BreakpointEvent be = (BreakpointEvent)event;

--- a/src/jdk.jdi/share/classes/com/sun/tools/example/debug/tty/EventNotifier.java
+++ b/src/jdk.jdi/share/classes/com/sun/tools/example/debug/tty/EventNotifier.java
@@ -22,6 +22,11 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2023, 2023 All Rights Reserved
+ * ===========================================================================
+ */
 
 /*
  * This source code is provided to illustrate the usage of a given feature
@@ -38,6 +43,9 @@ import com.sun.jdi.event.*;
 
 interface EventNotifier {
     void vmStartEvent(VMStartEvent e);
+/*[IF CRIU_SUPPORT]*/
+    void vmRestoreEvent(VMRestoreEvent e);
+/*[ENDIF] CRIU_SUPPORT */
     void vmDeathEvent(VMDeathEvent e);
     void vmDisconnectEvent(VMDisconnectEvent e);
 

--- a/src/jdk.jdi/share/classes/com/sun/tools/example/debug/tty/TTY.java
+++ b/src/jdk.jdi/share/classes/com/sun/tools/example/debug/tty/TTY.java
@@ -22,6 +22,11 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2023, 2023 All Rights Reserved
+ * ===========================================================================
+ */
 
 /*
  * This source code is provided to illustrate the usage of a given feature
@@ -72,6 +77,14 @@ public class TTY implements EventNotifier {
         Thread.yield();  // fetch output
         MessageOutput.lnprint("VM Started:");
     }
+
+/*[IF CRIU_SUPPORT]*/
+    @Override
+    public void vmRestoreEvent(VMRestoreEvent re)  {
+        Thread.yield();  // fetch output
+        MessageOutput.lnprint("VM Restored:");
+    }
+/*[ENDIF] CRIU_SUPPORT */
 
     @Override
     public void vmDeathEvent(VMDeathEvent e)  {

--- a/src/jdk.jdi/share/classes/com/sun/tools/example/debug/tty/TTYResources.java
+++ b/src/jdk.jdi/share/classes/com/sun/tools/example/debug/tty/TTYResources.java
@@ -22,6 +22,11 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2023, 2023 All Rights Reserved
+ * ===========================================================================
+ */
 
 /*
  * This source code is provided to illustrate the usage of a given feature
@@ -456,6 +461,9 @@ public class TTYResources extends java.util.ListResourceBundle {
              "<arguments> are the arguments passed to the main() method of <class>\n" +
              "\n" +
              "For command help type ''help'' at {0} prompt"},
+/*[IF CRIU_SUPPORT]*/
+        {"VM Restored:", "VM restored from checkpoint: "},
+/*[ENDIF] CRIU_SUPPORT */
         // END OF MATERIAL TO LOCALIZE
         };
 

--- a/src/jdk.jdi/share/classes/com/sun/tools/jdi/EventSetImpl.java
+++ b/src/jdk.jdi/share/classes/com/sun/tools/jdi/EventSetImpl.java
@@ -22,6 +22,11 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2023, 2023 All Rights Reserved
+ * ===========================================================================
+ */
 
 package com.sun.tools.jdi;
 
@@ -64,6 +69,9 @@ import com.sun.jdi.event.ThreadStartEvent;
 import com.sun.jdi.event.VMDeathEvent;
 import com.sun.jdi.event.VMDisconnectEvent;
 import com.sun.jdi.event.VMStartEvent;
+/*[IF CRIU_SUPPORT]*/
+import com.sun.jdi.event.VMRestoreEvent;
+/*[ENDIF] CRIU_SUPPORT */
 import com.sun.jdi.event.WatchpointEvent;
 import com.sun.jdi.request.EventRequest;
 
@@ -495,6 +503,19 @@ public class EventSetImpl extends ArrayList<Event> implements EventSet {
         }
     }
 
+/*[IF CRIU_SUPPORT]*/
+class VMRestoreEventImpl extends ThreadedEventImpl implements VMRestoreEvent {
+
+    VMRestoreEventImpl(JDWP.Event.Composite.Events.VMRestore evt) {
+        super(evt, evt.requestID, evt.thread);
+    }
+
+    String eventName() {
+        return "VMRestoreEvent";
+    }
+}
+/*[ENDIF] CRIU_SUPPORT */
+
     class VMDeathEventImpl extends EventImpl implements VMDeathEvent {
 
         VMDeathEventImpl(JDWP.Event.Composite.Events.VMDeath evt) {
@@ -805,6 +826,12 @@ public class EventSetImpl extends ArrayList<Event> implements EventSet {
             case JDWP.EventKind.VM_DEATH:
                 return new VMDeathEventImpl(
                       (JDWP.Event.Composite.Events.VMDeath)comm);
+
+/*[IF CRIU_SUPPORT]*/
+            case JDWP.EventKind.VM_RESTORE:
+                return new VMRestoreEventImpl(
+                      (JDWP.Event.Composite.Events.VMRestore)comm);
+/*[ENDIF] CRIU_SUPPORT */
 
             default:
                 // Ignore unknown event types

--- a/src/jdk.jdwp.agent/share/native/libjdwp/debugInit.h
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/debugInit.h
@@ -22,9 +22,16 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2023, 2023 All Rights Reserved
+ * ===========================================================================
+ */
 
 #ifndef JDWP_DEBUGINIT_H
 #define JDWP_DEBUGINIT_H
+
+#include "j9cfg.h"
 
 void debugInit_waitInitComplete(void);
 jboolean debugInit_isInitComplete(void);
@@ -34,6 +41,9 @@ jboolean debugInit_isInitComplete(void);
  */
 char *debugInit_launchOnInit(void);
 jboolean debugInit_suspendOnInit(void);
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+jboolean debugInit_suspendOnRestore(void);
+#endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
 
 void debugInit_reset(JNIEnv *env);
 void debugInit_exit(jvmtiError, const char *);

--- a/src/jdk.jdwp.agent/share/native/libjdwp/eventFilter.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/eventFilter.c
@@ -23,6 +23,11 @@
  * questions.
  */
 /*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2023, 2023 All Rights Reserved
+ * ===========================================================================
+ */
+/*
  * eventFilter
  *
  * This module handles event filteration and the enabling/disabling
@@ -40,6 +45,7 @@
 #include "threadControl.h"
 #include "SDE.h"
 #include "jvmti.h"
+#include "j9cfg.h"
 
 typedef struct ClassFilter {
     jclass clazz;
@@ -1242,6 +1248,9 @@ enableEvents(HandlerNode *node)
         case EI_VM_DEATH:
         case EI_CLASS_PREPARE:
         case EI_GC_FINISH:
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+        case EI_VM_RESTORE:
+#endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
             return error;
 
         case EI_FIELD_ACCESS:
@@ -1301,6 +1310,9 @@ disableEvents(HandlerNode *node)
         case EI_VM_DEATH:
         case EI_CLASS_PREPARE:
         case EI_GC_FINISH:
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+        case EI_VM_RESTORE:
+#endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
             return error;
 
         case EI_FIELD_ACCESS:

--- a/src/jdk.jdwp.agent/share/native/libjdwp/eventHelper.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/eventHelper.c
@@ -22,12 +22,18 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2023, 2023 All Rights Reserved
+ * ===========================================================================
+ */
 
 #include "util.h"
 #include "outStream.h"
 #include "eventHandler.h"
 #include "threadControl.h"
 #include "invoker.h"
+#include "j9cfg.h"
 
 
 #define COMMAND_LOOP_THREAD_NAME "JDWP Event Helper Thread"
@@ -39,6 +45,9 @@
 #define COMMAND_REPORT_INVOKE_DONE              2
 #define COMMAND_REPORT_VM_INIT                  3
 #define COMMAND_SUSPEND_THREAD                  4
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+#define COMMAND_REPORT_VM_RESTORE               5
+#endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
 
 /*
  * Event helper thread command singleKinds
@@ -89,6 +98,13 @@ typedef struct ReportVMInitCommand {
     jthread thread;
 } ReportVMInitCommand;
 
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+typedef struct ReportVMRestoreCommand {
+    jbyte suspendPolicy; /* NOTE: Must be the first field */
+    jthread thread;
+} ReportVMRestoreCommand;
+#endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
+
 typedef struct SuspendThreadCommand {
     jthread thread;
 } SuspendThreadCommand;
@@ -111,6 +127,9 @@ typedef struct HelperCommand {
         ReportInvokeDoneCommand     reportInvokeDone;
         ReportVMInitCommand         reportVMInit;
         SuspendThreadCommand        suspendThread;
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+        ReportVMRestoreCommand reportVMRestore;
+#endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
     } u;
     /* composite array expand out, put nothing after */
 } HelperCommand;
@@ -595,6 +614,35 @@ handleReportVMInitCommand(JNIEnv* env, ReportVMInitCommand *command)
     /* Why aren't we tossing this: tossGlobalRef(env, &(command->thread)); */
 }
 
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+static void
+handleReportVMRestoreCommand(JNIEnv* env, ReportVMRestoreCommand *command)
+{
+    PacketOutputStream out;
+    jbyte suspendPolicy = command->suspendPolicy;
+
+    if (JDWP_SUSPEND_POLICY(ALL) == suspendPolicy) {
+        (void)threadControl_suspendAll();
+    } else if (JDWP_SUSPEND_POLICY(EVENT_THREAD) == suspendPolicy) {
+        (void)threadControl_suspendThread(command->thread, JNI_FALSE);
+    }
+
+    outStream_initCommand(&out, uniqueID(), 0x0,
+                          JDWP_COMMAND_SET(Event),
+                          JDWP_COMMAND(Event, Composite));
+    (void)outStream_writeByte(&out, suspendPolicy);
+    (void)outStream_writeInt(&out, 1); /* Always one component */
+    (void)outStream_writeByte(&out, JDWP_EVENT(VM_RESTORE));
+    (void)outStream_writeInt(&out, 0); /* Not in response to an event req. */
+
+    (void)outStream_writeObjectRef(env, &out, command->thread);
+
+    outStream_sendCommand(&out);
+    outStream_destroy(&out);
+    tossGlobalRef(env, &command->thread);
+}
+#endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
+
 static void
 handleSuspendThreadCommand(JNIEnv* env, SuspendThreadCommand *command)
 {
@@ -623,6 +671,11 @@ handleCommand(JNIEnv *env, HelperCommand *command)
         case COMMAND_SUSPEND_THREAD:
             handleSuspendThreadCommand(env, &command->u.suspendThread);
             break;
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+        case COMMAND_REPORT_VM_RESTORE:
+            handleReportVMRestoreCommand(env, &command->u.reportVMRestore);
+            break;
+#endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
         default:
             EXIT_ERROR(AGENT_ERROR_INVALID_EVENT_TYPE,"Event Helper Command");
             break;
@@ -1155,6 +1208,23 @@ eventHelper_reportVMInit(JNIEnv *env, jbyte sessionID, jthread thread, jbyte sus
     command->u.reportVMInit.suspendPolicy = suspendPolicy;
     enqueueCommand(command, JNI_TRUE, JNI_FALSE);
 }
+
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+void
+eventHelper_reportVMRestore(JNIEnv *env, jbyte sessionID, jthread thread, jbyte suspendPolicy)
+{
+    HelperCommand *command = jvmtiAllocate(sizeof(*command));
+    if (NULL == command) {
+        EXIT_ERROR(AGENT_ERROR_OUT_OF_MEMORY, "HelperCommmand");
+    }
+    memset(command, 0, sizeof(*command));
+    command->commandKind = COMMAND_REPORT_VM_RESTORE;
+    command->sessionID = sessionID;
+    saveGlobalRef(env, thread, &command->u.reportVMRestore.thread);
+    command->u.reportVMRestore.suspendPolicy = suspendPolicy;
+    enqueueCommand(command, JNI_TRUE, JNI_FALSE);
+}
+#endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
 
 void
 eventHelper_suspendThread(jbyte sessionID, jthread thread)

--- a/src/jdk.jdwp.agent/share/native/libjdwp/eventHelper.h
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/eventHelper.h
@@ -22,12 +22,18 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2023, 2023 All Rights Reserved
+ * ===========================================================================
+ */
 
 #ifndef JDWP_EVENTHELPER_H
 #define JDWP_EVENTHELPER_H
 
 #include "bag.h"
 #include "invoker.h"
+#include "j9cfg.h"
 
 void eventHelper_initialize(jbyte sessionID);
 void eventHelper_reset(jbyte sessionID);
@@ -46,6 +52,9 @@ void eventHelper_recordFrameEvent(jint id, jbyte suspendPolicy, EventIndex ei,
 jbyte eventHelper_reportEvents(jbyte sessionID, struct bag *eventBag);
 void eventHelper_reportInvokeDone(jbyte sessionID, jthread thread);
 void eventHelper_reportVMInit(JNIEnv *env, jbyte sessionID, jthread thread, jbyte suspendPolicy);
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+void eventHelper_reportVMRestore(JNIEnv *env, jbyte sessionID, jthread thread, jbyte suspendPolicy);
+#endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
 void eventHelper_suspendThread(jbyte sessionID, jthread thread);
 
 void eventHelper_holdEvents(void);

--- a/src/jdk.jdwp.agent/share/native/libjdwp/transport.h
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/transport.h
@@ -22,11 +22,17 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2023, 2023 All Rights Reserved
+ * ===========================================================================
+ */
 
 #ifndef JDWP_TRANSPORT_H
 #define JDWP_TRANSPORT_H
 
 #include "jdwpTransport.h"
+#include "j9cfg.h"
 
 void transport_initialize(void);
 void transport_reset(void);
@@ -37,6 +43,9 @@ jint transport_receivePacket(jdwpPacket *);
 jint transport_sendPacket(jdwpPacket *);
 jboolean transport_is_open(void);
 void transport_waitForConnection(void);
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+void transport_waitForConnectionOnRestore(void);
+#endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
 void transport_close(void);
 
 #endif

--- a/src/jdk.jdwp.agent/share/native/libjdwp/util.h
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/util.h
@@ -22,6 +22,11 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2023, 2023 All Rights Reserved
+ * ===========================================================================
+ */
 
 #ifndef JDWP_UTIL_H
 #define JDWP_UTIL_H
@@ -58,6 +63,7 @@
 #include "util_md.h"
 #include "error_messages.h"
 #include "debugInit.h"
+#include "j9cfg.h"
 
 /* Definition of a CommonRef tracked by the backend for the frontend */
 typedef struct RefNode {
@@ -166,7 +172,13 @@ typedef enum {
         EI_MONITOR_WAITED       = 18,
         EI_VM_INIT              = 19,
         EI_VM_DEATH             = 20,
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+        EI_VM_RESTORE           = 21,
+
+        EI_max                  = 21
+#else
         EI_max                  = 20
+#endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
 } EventIndex;
 
 /* Agent errors that might be in a jvmtiError for JDWP or internal.


### PR DESCRIPTION
To help debug issues with checkpoint/restore, add an option similar to "suspend=y" which suspends on VM startup except this new option will suspend when the VM is restored from a checkpoint.
To that end, this PR adds support for a VM_Restore JVMTI event to JDWP and JDB.

Port of https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/591 to JDK11.