### PR TITLE
Remove IBM copyright accidently added

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/font/AWTStrike.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/font/AWTStrike.m
@@ -22,11 +22,6 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-/*
- * ===========================================================================
- * (C) Copyright IBM Corp. 2023 All Rights Reserved.
- * ===========================================================================
- */
 
 #import "java_awt_geom_PathIterator.h"
 #import "sun_font_CStrike.h"

--- a/src/java.desktop/macosx/native/libjsound/PLATFORM_API_MacOSX_Ports.cpp
+++ b/src/java.desktop/macosx/native/libjsound/PLATFORM_API_MacOSX_Ports.cpp
@@ -22,11 +22,6 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-/*
- * ===========================================================================
- * (C) Copyright IBM Corp. 2023 All Rights Reserved.
- * ===========================================================================
- */
 
 //#define USE_ERROR
 //#define USE_TRACE


### PR DESCRIPTION
Added by https://github.com/ibmruntimes/openj9-openjdk-jdk11/pull/678 but the changes are an OpenJDK backport.