### PR TITLE
Allow loading of OpenSSL 3.x native library for Mac, Windows and AIX

### DIFF
--- a/closed/custom/copy/Copy-java.base.gmk
+++ b/closed/custom/copy/Copy-java.base.gmk
@@ -200,7 +200,7 @@ ifneq ($(OPENSSL_BUNDLE_LIB_PATH), )
     # OpenSSL 1.1.1 on AIX has switched to use archive library files (natural way)
     # instead of 'libcrypto.so' files.
     # See https://github.com/openssl/openssl/pull/6487.
-    LIBCRYPTO_NAMES := libcrypto.so.3 libcrypto.so.1.1 libcrypto.so.1.0.0 libcrypto.a
+    LIBCRYPTO_NAMES := libcrypto64.so.3 libcrypto.so.3 libcrypto.so.1.1 libcrypto.so.1.0.0
   else
     LIBCRYPTO_NAMES := libcrypto.so
   endif

--- a/closed/src/java.base/aix/native/libjncrypto/NativeCrypto_md.c
+++ b/closed/src/java.base/aix/native/libjncrypto/NativeCrypto_md.c
@@ -1,6 +1,6 @@
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2019, 2022 All Rights Reserved
+ * (c) Copyright IBM Corp. 2019, 2023 All Rights Reserved
  * ===========================================================================
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,18 +32,34 @@
 /* Load the crypto library (return NULL on error) */
 void * load_crypto_library(jboolean traceEnabled) {
     void * result = NULL;
+    const char *libname3_a_64 = "libcrypto.a(libcrypto64.so.3)";
+    const char *libname3_64 = "libcrypto64.so.3";
+    const char *libname3_a = "libcrypto.a(libcrypto.so.3)";
+    const char *libname3 = "libcrypto.so.3";
     const char *libname111 = "libcrypto.a(libcrypto64.so.1.1)";
     const char *libname110 = "libcrypto.so.1.1";
     const char *libname102 = "libcrypto.so.1.0.0";
     const char *symlink = "libcrypto.a(libcrypto64.so)";
 
-    result = dlopen (libname111, RTLD_NOW | RTLD_MEMBER);
+    result = dlopen (libname3_a_64, RTLD_NOW | RTLD_MEMBER);
     if (result == NULL) {
-        result = dlopen (libname110, RTLD_NOW);
+        result = dlopen (libname3_64, RTLD_NOW);
         if (result == NULL) {
-            result = dlopen (libname102, RTLD_NOW);
+            result = dlopen (libname3_a, RTLD_NOW | RTLD_MEMBER);
             if (result == NULL) {
-                result = dlopen (symlink, RTLD_NOW | RTLD_MEMBER);
+                result = dlopen (libname3, RTLD_NOW);
+                if (result == NULL) {
+                    result = dlopen (libname111, RTLD_NOW | RTLD_MEMBER);
+                    if (result == NULL) {
+                        result = dlopen (libname110, RTLD_NOW);
+                        if (result == NULL) {
+                            result = dlopen (libname102, RTLD_NOW);
+                            if (result == NULL) {
+                                result = dlopen (symlink, RTLD_NOW | RTLD_MEMBER);
+                            }
+                        }
+                    }
+                }
             }
         }
     }

--- a/closed/src/java.base/macosx/native/libjncrypto/NativeCrypto_md.c
+++ b/closed/src/java.base/macosx/native/libjncrypto/NativeCrypto_md.c
@@ -1,6 +1,6 @@
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2019, 2022 All Rights Reserved
+ * (c) Copyright IBM Corp. 2019, 2023 All Rights Reserved
  * ===========================================================================
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,16 +32,20 @@
 /* Load the crypto library (return NULL on error) */
 void * load_crypto_library(jboolean traceEnabled) {
     void * result = NULL;
-    
+
+    const char *libname3 = "libcrypto.3.dylib";
     const char *libname = "libcrypto.1.1.dylib";
     const char *oldname = "libcrypto.1.0.0.dylib";
     const char *symlink = "libcrypto.dylib";
 
-    result = dlopen (libname,  RTLD_NOW);
+    result = dlopen (libname3,  RTLD_NOW);
     if (result == NULL) {
-        result = dlopen (oldname,  RTLD_NOW);
+        result = dlopen (libname,  RTLD_NOW);
         if (result == NULL) {
-            result = dlopen (symlink,  RTLD_NOW);
+            result = dlopen (oldname,  RTLD_NOW);
+            if (result == NULL) {
+                result = dlopen (symlink,  RTLD_NOW);
+            }
         }
     }
 

--- a/closed/src/java.base/windows/native/libjncrypto/NativeCrypto_md.c
+++ b/closed/src/java.base/windows/native/libjncrypto/NativeCrypto_md.c
@@ -1,6 +1,6 @@
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2019, 2022 All Rights Reserved
+ * (c) Copyright IBM Corp. 2019, 2023 All Rights Reserved
  * ===========================================================================
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,13 +29,16 @@
 /* Load the crypto library (return NULL on error) */
 void * load_crypto_library(jboolean traceEnabled) {
     void * result = NULL;
+    const char *libname3 = "libcrypto-3-x64.dll";
     const char *libname = "libcrypto-1_1-x64.dll";
     const char *oldname = "libeay32.dll";
 
-    result = LoadLibrary(libname);
-    
+    result = LoadLibrary(libname3);
     if (result == NULL) {
-        result = LoadLibrary(oldname);
+        result = LoadLibrary(libname);
+        if (result == NULL) {
+            result = LoadLibrary(oldname);
+        }
     }
 
     return result;


### PR DESCRIPTION
Additional options for potential library files are added to accommodate for use of OpenSSL 3.x in multiple platforms, namely Mac, Windows and AIX.

The list of potential library files to be bundled with OpenJDK for AIX is, also, altered to allow bundling of OpenSSL 3.x while avoiding conflict with other applications that might be using earlier versions.

Back-ported from: https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/616 and https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/632

Signed-off by: Kostas Tsiounis [kostas.tsiounis@ibm.com](mailto:kostas.tsiounis@ibm.com)