### PR TITLE
Revert debug in UncaughtExceptionsTest

### DIFF
--- a/test/jdk/java/lang/Thread/UncaughtExceptionsTest.java
+++ b/test/jdk/java/lang/Thread/UncaughtExceptionsTest.java
@@ -93,12 +93,7 @@ class UncaughtExitSimulator extends Thread implements Runnable {
 
     public static void throwRuntimeException() { throw new RuntimeException("simulateUncaughtExitEvent"); }
 
-    public void run() {
-        if (!Thread.currentThread().getName().equals("Thread-0")) {
-            com.ibm.jvm.Dump.SystemDump();
-        }
-        throwRuntimeException();
-    }
+    public void run() { throwRuntimeException(); }
 
     /**
      * A thread is never alive after you've join()ed it.


### PR DESCRIPTION
Debug was added via
https://github.com/ibmruntimes/openj9-openjdk-jdk11/pull/663

The debug isn't useful. Related to
https://github.com/eclipse-openj9/openj9/issues/11930