### PR TITLE
Parse -Xmso from more locations

### DIFF
--- a/src/java.base/share/native/libjli/java.c
+++ b/src/java.base/share/native/libjli/java.c
@@ -221,6 +221,44 @@ static jlong initialHeapSize    = 0;  /* inital heap size */
 #define STACK_SIZE_MINIMUM (64 * KB)
 #endif
 
+static void
+parseXmso(JLI_List openj9Args)
+{
+    size_t i = openj9Args->size;
+    while (i > 0) {
+        i -= 1;
+        if (JLI_StrCCmp(openj9Args->elements[i], "-Xmso") == 0) {
+            jlong tmp = 0;
+            if (parse_size(openj9Args->elements[i] + 5, &tmp)) {
+                threadStackSize = tmp;
+                if (threadStackSize > 0 && threadStackSize < (jlong)STACK_SIZE_MINIMUM) {
+                    threadStackSize = STACK_SIZE_MINIMUM;
+                }
+            }
+            break;
+        }
+    }
+    JLI_List_free(openj9Args);
+}
+
+static void
+parseXmsoInFile(const char *filename)
+{
+    JLI_List openj9Args = JLI_ParseOpenJ9ArgsFile(filename);
+    if (openj9Args != NULL) {
+        parseXmso(openj9Args);
+    }
+}
+
+static void
+parseXmsoInEnv(const char *envVar)
+{
+    JLI_List openj9Args = JLI_List_new(8); /* 8 is arbitrary */
+    if (JLI_ParseOpenJ9ArgsFromEnvVar(openj9Args, envVar)) {
+        parseXmso(openj9Args);
+    }
+}
+
 /*
  * Entry point.
  */
@@ -325,29 +363,17 @@ JLI_Launch(int argc, char ** argv,              /* main argc, argv */
         }
     }
 
+    /* Process -Xmso to set the main thread stack size. May be overridden by
+     * a later command line option.
+     */
     {
-        /* Process -Xmso in the OPENJ9_JAVA_OPTIONS environment variable to
-         * set the main thread stack size. May be overridden by a later command
-         * line option.
-         */
-        JLI_List openj9Args = JLI_List_new(8); /* 8 is arbitrary */
-        if (JLI_ParseOpenJ9ArgsFromEnvVar(openj9Args, "OPENJ9_JAVA_OPTIONS")) {
-            size_t i = openj9Args->size;
-            while (i > 0) {
-                i -= 1;
-                if (JLI_StrCCmp(openj9Args->elements[i], "-Xmso") == 0) {
-                    jlong tmp = 0;
-                    if (parse_size(openj9Args->elements[i] + 5, &tmp)) {
-                        threadStackSize = tmp;
-                        if (threadStackSize > 0 && threadStackSize < (jlong)STACK_SIZE_MINIMUM) {
-                            threadStackSize = STACK_SIZE_MINIMUM;
-                        }
-                    }
-                    break;
-                }
-            }
-            JLI_List_free(openj9Args);
-        }
+#define OPTIONS_DEFAULT_PATH "/lib/options.default"
+        char optionsfile[sizeof(jrepath) + sizeof(OPTIONS_DEFAULT_PATH) - 1];
+        JLI_Snprintf(optionsfile, sizeof(optionsfile), "%s" OPTIONS_DEFAULT_PATH, jrepath);
+        parseXmsoInFile(optionsfile);
+        parseXmsoInEnv("JAVA_TOOL_OPTIONS");
+        parseXmsoInEnv("OPENJ9_JAVA_OPTIONS");
+        parseXmsoInEnv("IBM_JAVA_OPTIONS");
     }
 
     /* Parse command line options; if the return value of
@@ -968,8 +994,13 @@ AddOption(char *str, void *info)
     options[numOptions++].extraInfo = info;
 
     /* In OpenJ9 -Xmso is used to set native stack size instead of -Xss. -Xss is used to
-     * set Java thread size only, which is handled in the JVM code.
+     * set Java thread size only, which is handled in the JVM code. Check for -Xmso in any
+     * -Xoptionsfile= and on the command line itself. The default.options file and relevent
+     * environment variables are checked earlier.
      */
+    if (JLI_StrCCmp(str, "-Xoptionsfile=") == 0) {
+        parseXmsoInFile(str + 14);
+    }
     if (JLI_StrCCmp(str, "-Xmso") == 0) {
         jlong tmp;
         if (parse_size(str + 5, &tmp)) {

--- a/src/java.base/share/native/libjli/jli_util.h
+++ b/src/java.base/share/native/libjli/jli_util.h
@@ -174,4 +174,7 @@ JLI_AddArgsFromEnvVar(JLI_List args, const char *var_name);
 JNIEXPORT jboolean JNICALL
 JLI_ParseOpenJ9ArgsFromEnvVar(JLI_List args, const char *var_name);
 
+JNIEXPORT JLI_List JNICALL
+JLI_ParseOpenJ9ArgsFile(const char *filename);
+
 #endif  /* _JLI_UTIL_H */


### PR DESCRIPTION
To match OpenJ9, look in the options.default file, JAVA_TOOL_OPTIONS, IBM_JAVA_OPTIONS, and -Xoptionsfile= on the command line.

Issue https://github.com/eclipse-openj9/openj9/issues/16105
Backport of https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/657