### PR TITLE
Always revert to Java impl when OpenSSL fails

### DIFF
--- a/closed/src/jdk.crypto.ec/share/classes/sun/security/ec/NativeECKeyPairGenerator.java
+++ b/closed/src/jdk.crypto.ec/share/classes/sun/security/ec/NativeECKeyPairGenerator.java
@@ -168,17 +168,13 @@ public final class NativeECKeyPairGenerator extends KeyPairGeneratorSpi {
             return this.javaImplementation.generateKeyPair();
         }
 
-        boolean absent;
         long nativePointer = NativeECUtil.encodeGroup(this.params);
 
         if (nativePointer == -1) {
-            absent = NativeECUtil.putCurveIfAbsent(this.curve, Boolean.FALSE);
-            if (!absent) {
-                throw new ProviderException("Could not encode group");
-            }
+            NativeECUtil.putCurveIfAbsent(this.curve, Boolean.FALSE);
             if (nativeCryptTrace) {
-                System.err.println(this.curve +
-                        " is not supported by OpenSSL, using Java crypto implementation.");
+                System.err.println("Could not encode group for curve " + this.curve
+                        + " in OpenSSL, using Java crypto implementation.");
             }
             try {
                 this.initializeJavaImplementation();
@@ -195,13 +191,10 @@ public final class NativeECKeyPairGenerator extends KeyPairGeneratorSpi {
         } else if (field instanceof ECFieldF2m) {
             fieldType = NativeCrypto.ECField_F2m;
         } else {
-            absent = NativeECUtil.putCurveIfAbsent(this.curve, Boolean.FALSE);
-            if (!absent) {
-                throw new ProviderException("Field type not supported");
-            }
+            NativeECUtil.putCurveIfAbsent(this.curve, Boolean.FALSE);
             if (nativeCryptTrace) {
-                System.err.println(this.curve +
-                        " is not supported by OpenSSL, using Java crypto implementation.");
+                System.err.println("Field type not supported for curve " + this.curve
+                        + " by OpenSSL, using Java crypto implementation.");
             }
             try {
                 this.initializeJavaImplementation();
@@ -226,13 +219,10 @@ public final class NativeECKeyPairGenerator extends KeyPairGeneratorSpi {
                                                  fieldType);
 
         if (ret == -1) {
-            absent = NativeECUtil.putCurveIfAbsent(this.curve, Boolean.FALSE);
-            if (!absent) {
-                throw new ProviderException("Could not generate key pair");
-            }
+            NativeECUtil.putCurveIfAbsent(this.curve, Boolean.FALSE);
             if (nativeCryptTrace) {
-                System.err.println(this.curve +
-                        " is not supported by OpenSSL, using Java crypto implementation for key generation.");
+                System.err.println("Could not generate key pair for curve " + this.curve
+                        + " using OpenSSL, using Java crypto implementation for key generation.");
             }
             try {
                 this.initializeJavaImplementation();


### PR DESCRIPTION
At the moment, if there is an OpenSSL failure when using `NativeECKeyPairGenerator`, a flag for that particular curve is set and the Sun Java implementation is used to complete the task.

If another instance of `NativeECKeyPairGenerator` reaches the same failure, a `ProviderException` is thrown, as the issue with that particular curve should have been discovered during the call to `initialize()` thus creating and using an instance of `ECKeyPairGenerator`, and that particular point should never have been reached.

However, in the scenario where the second instance of `NativeECKeyPairGenerator` has been initialized earlier, the flag for the problematic curve will never be discovered.

This fix ensures that we always revert to the Sun Java implementation when an OpenSSL failure occurs.

Back-ported from: https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/672

Signed-off by: Kostas Tsiounis [kostas.tsiounis@ibm.com](mailto:kostas.tsiounis@ibm.com)