### PR TITLE
Remove the visitAnnotation for Hidden in generateInvokerTemplate

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/MethodHandleImpl.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandleImpl.java
@@ -25,7 +25,7 @@
 
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2022, 2022 All Rights Reserved
+ * (c) Copyright IBM Corp. 2022, 2023 All Rights Reserved
  * ===========================================================================
  */
 
@@ -33,7 +33,6 @@ package java.lang.invoke;
 
 import jdk.internal.misc.JavaLangInvokeAccess;
 import jdk.internal.misc.SharedSecrets;
-import jdk.internal.org.objectweb.asm.AnnotationVisitor;
 import jdk.internal.org.objectweb.asm.ClassWriter;
 import jdk.internal.org.objectweb.asm.MethodVisitor;
 import jdk.internal.reflect.CallerSensitive;
@@ -1308,7 +1307,6 @@ import static jdk.internal.org.objectweb.asm.Opcodes.*;
             ClassWriter cw = new ClassWriter(0);
 
             // private static class InjectedInvoker {
-            //     @Hidden
             //     static Object invoke_V(MethodHandle vamh, Object[] args) throws Throwable {
             //        return vamh.invokeExact(args);
             //     }
@@ -1318,10 +1316,6 @@ import static jdk.internal.org.objectweb.asm.Opcodes.*;
             MethodVisitor mv = cw.visitMethod(ACC_STATIC, "invoke_V",
                           "(Ljava/lang/invoke/MethodHandle;[Ljava/lang/Object;)Ljava/lang/Object;",
                           null, null);
-
-            // Suppress invoker method in stack traces.
-            AnnotationVisitor av0 = mv.visitAnnotation("Ljava/lang/invoke/LambdaForm$Hidden;", true);
-            av0.visitEnd();
 
             mv.visitCode();
             mv.visitVarInsn(ALOAD, 0);


### PR DESCRIPTION
This patch fixes both eclipse-openj9/openj9#14553 and eclipse-openj9/openj9#18245. The visitAnnotation for Hidden seems to have unwanted side effects when OJDK MHs are enabled and invokeWithArguments is used in JDK11. The behaviour when removing the visitAnnotation matches the behaviour of the RI and the implementation for JDK17.

Closes: eclipse-openj9/openj9#14553 eclipse-openj9/openj9#18245
Signed-off-by: Nathan Henderson <nathan.henderson@ibm.com>