### PR TITLE
Conform to spec for MethodHandles::loop's with void return types

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
@@ -22,6 +22,11 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2023, 2023 All Rights Reserved
+ * ===========================================================================
+ */
 
 package java.lang.invoke;
 
@@ -4896,7 +4901,7 @@ assertEquals("boojum", (String) catTrace.invokeExact("boo", "jum"));
                 pred.set(i, dropArguments0(constant(boolean.class, true), 0, commonParameterSequence));
             }
             if (fini.get(i) == null) {
-                fini.set(i, empty(methodType(t, commonParameterSequence)));
+                fini.set(i, empty(methodType(loopReturnType, commonParameterSequence)));
             }
         }
 


### PR DESCRIPTION
This patch fixes eclipse-openj9/openj9#18293; which is really a duplicate of eclipse-openj9/openj9#11937. 'loop' in OJDK MHs does not conform to the spec w.r.t. setting loop finalizers for loop's with void return types. This patch properly sets default finalizer values.

The patch conforms to the spec: https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/invoke/MethodHandles.html#loop(java.lang.invoke.MethodHandle[]...) for 3.d

Closes: eclipse-openj9/openj9#18293
Signed-off-by: Nathan Henderson <nathan.henderson@ibm.com>