### PR TITLE
Modify jdk.crypto.ec libsunec mpi.c to avoid writes to unallocated mem

### DIFF
--- a/src/jdk.crypto.ec/share/native/libsunec/impl/mpi.c
+++ b/src/jdk.crypto.ec/share/native/libsunec/impl/mpi.c
@@ -37,6 +37,12 @@
  * Last Modified Date from the Original Code: Nov 2019
  *********************************************************************** */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2023, 2023 All Rights Reserved
+ * ===========================================================================
+ */
+
 /*  Arbitrary precision integer arithmetic library */
 
 #include "mpi-priv.h"
@@ -1727,17 +1733,28 @@ int    mp_cmp_mag(mp_int *a, mp_int *b)
  */
 int    mp_cmp_int(const mp_int *a, long z, int kmflag)
 {
-  mp_int  tmp;
-  int     out;
+  mp_sign signz = z < 0 ? NEG : ZPOS;
 
   ARGCHK(a != NULL, MP_EQ);
 
-  mp_init(&tmp, kmflag); mp_set_int(&tmp, z);
-  out = mp_cmp(a, &tmp);
-  mp_clear(&tmp);
+  if(SIGN(a) == signz) {
+    unsigned long v = labs(z);
 
-  return out;
+    if(USED(a) > 1)
+      return signz == ZPOS ? MP_GT : MP_LT;
 
+    if(DIGIT(a, 0) == v)
+      return MP_EQ;
+    if(DIGIT(a, 0) > v) {
+      return signz == ZPOS ? MP_GT : MP_LT;
+    } else {
+      return signz == ZPOS ? MP_LT : MP_GT;
+    }
+  } else if(SIGN(a) == ZPOS) {
+    return MP_GT;
+  } else {
+    return MP_LT;
+  }
 } /* end mp_cmp_int() */
 
 /* }}} */


### PR DESCRIPTION
See https://openj9-jenkins.osuosl.org/job/Build_JDK11_s390x_linux_Personal/767/ for the gcc 11.2 compile error on the original code.
```
18:08:54  In function 'mp_zero',
18:08:54      inlined from 'mp_zero' at /home/jenkins/workspace/Build_JDK11_s390x_linux_Personal/src/jdk.crypto.ec/share/native/libsunec/impl/mpi.c:316:8,
18:08:54      inlined from 'mp_set_int' at /home/jenkins/workspace/Build_JDK11_s390x_linux_Personal/src/jdk.crypto.ec/share/native/libsunec/impl/mpi.c:353:3,
18:08:54      inlined from 'mp_cmp_int' at /home/jenkins/workspace/Build_JDK11_s390x_linux_Personal/src/jdk.crypto.ec/share/native/libsunec/impl/mpi.c:1735:26:
18:08:54  /home/jenkins/workspace/Build_JDK11_s390x_linux_Personal/src/jdk.crypto.ec/share/native/libsunec/impl/mpi.c:321:3: error: 'tmp.dp' may be used uninitialized [-Werror=maybe-uninitialized]
18:08:54    321 |   s_mp_setz(DIGITS(mp), ALLOC(mp));
18:08:54        |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
18:08:54  /home/jenkins/workspace/Build_JDK11_s390x_linux_Personal/src/jdk.crypto.ec/share/native/libsunec/impl/mpi.c: In function 'mp_cmp_int':
18:08:54  /home/jenkins/workspace/Build_JDK11_s390x_linux_Personal/src/jdk.crypto.ec/share/native/libsunec/impl/mpi.c:1730:11: note: 'tmp' declared here
18:08:54   1730 |   mp_int  tmp;
18:08:54        |           ^~~
18:08:54  In function 'mp_zero',
18:08:54      inlined from 'mp_zero' at /home/jenkins/workspace/Build_JDK11_s390x_linux_Personal/src/jdk.crypto.ec/share/native/libsunec/impl/mpi.c:316:8,
18:08:54      inlined from 'mp_set_int' at /home/jenkins/workspace/Build_JDK11_s390x_linux_Personal/src/jdk.crypto.ec/share/native/libsunec/impl/mpi.c:353:3,
18:08:54      inlined from 'mp_cmp_int' at /home/jenkins/workspace/Build_JDK11_s390x_linux_Personal/src/jdk.crypto.ec/share/native/libsunec/impl/mpi.c:1735:26:
18:08:54  /home/jenkins/workspace/Build_JDK11_s390x_linux_Personal/src/jdk.crypto.ec/share/native/libsunec/impl/mpi.c:321:3: error: 'tmp.alloc' may be used uninitialized [-Werror=maybe-uninitialized]
18:08:54    321 |   s_mp_setz(DIGITS(mp), ALLOC(mp));
18:08:54        |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
18:08:54  /home/jenkins/workspace/Build_JDK11_s390x_linux_Personal/src/jdk.crypto.ec/share/native/libsunec/impl/mpi.c: In function 'mp_cmp_int':
18:08:54  /home/jenkins/workspace/Build_JDK11_s390x_linux_Personal/src/jdk.crypto.ec/share/native/libsunec/impl/mpi.c:1730:11: note: 'tmp' declared here
18:08:54   1730 |   mp_int  tmp;
18:08:54        |           ^~~
18:08:54  In function 'mp_zero',
18:08:54      inlined from 'mp_zero' at /home/jenkins/workspace/Build_JDK11_s390x_linux_Personal/src/jdk.crypto.ec/share/native/libsunec/impl/mpi.c:316:8,
18:08:54      inlined from 'mp_set_int' at /home/jenkins/workspace/Build_JDK11_s390x_linux_Personal/src/jdk.crypto.ec/share/native/libsunec/impl/mpi.c:353:3,
18:08:54      inlined from 'mp_cmp_int' at /home/jenkins/workspace/Build_JDK11_s390x_linux_Personal/src/jdk.crypto.ec/share/native/libsunec/impl/mpi.c:1735:26:
18:08:54  /home/jenkins/workspace/Build_JDK11_s390x_linux_Personal/src/jdk.crypto.ec/share/native/libsunec/impl/mpi.c:321:3: error: 'tmp.alloc' may be used uninitialized [-Werror=maybe-uninitialized]
18:08:54    321 |   s_mp_setz(DIGITS(mp), ALLOC(mp));
18:08:54        |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
18:08:54  /home/jenkins/workspace/Build_JDK11_s390x_linux_Personal/src/jdk.crypto.ec/share/native/libsunec/impl/mpi.c: In function 'mp_cmp_int':
18:08:54  /home/jenkins/workspace/Build_JDK11_s390x_linux_Personal/src/jdk.crypto.ec/share/native/libsunec/impl/mpi.c:1730:11: note: 'tmp' declared here
18:08:54   1730 |   mp_int  tmp;
18:08:54        |           ^~~
18:08:55  cc1: all warnings being treated as errors
18:08:55  Lib-jdk.crypto.ec.gmk:41: recipe for target '/home/jenkins/workspace/Build_JDK11_s390x_linux_Personal/build/linux-s390x-normal-server-release/support/native/jdk.crypto.ec/libsunec/mpi.o' failed
```

Tested via
https://openj9-jenkins.osuosl.org/job/Pipeline-Build-Test-Personal/448/
https://openj9-jenkins.osuosl.org/job/Pipeline-Build-Test-Personal/452/