### PR TITLE
Remove useless definitions of make macros

### DIFF
--- a/closed/custom/lib/Lib-java.base.gmk
+++ b/closed/custom/lib/Lib-java.base.gmk
@@ -1,5 +1,5 @@
 # ===========================================================================
-# (c) Copyright IBM Corp. 2018, 2020 All Rights Reserved
+# (c) Copyright IBM Corp. 2018, 2023 All Rights Reserved
 # ===========================================================================
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
@@ -18,24 +18,17 @@
 # 2 along with this work; if not, see <http://www.gnu.org/licenses/>.
 # ===========================================================================
 
-################################################################################
 # Create the Java Native crypto library
 ifeq ($(WITH_OPENSSL), yes)
   $(eval $(call SetupJdkLibrary, BUILD_JNCRYPTO, \
       NAME := jncrypto, \
       OPTIMIZATION := LOW, \
-      CFLAGS := $(CFLAGS_JDKLIB) \
-                -c $(OPENSSL_CFLAGS), \
+      CFLAGS := $(CFLAGS_JDKLIB) $(OPENSSL_CFLAGS), \
       DISABLED_WARNINGS_gcc := sign-compare implicit-fallthrough unused-value, \
       DISABLED_WARNINGS_clang := sign-compare, \
       DISABLED_WARNINGS_microsoft := 4101 4244 4146 4018, \
-      LDFLAGS := $(LDFLAGS_JDKLIB) \
-          $(call SET_SHARED_LIBRARY_ORIGIN), \
+      LDFLAGS := $(LDFLAGS_JDKLIB) $(call SET_SHARED_LIBRARY_ORIGIN), \
       LIBS_unix := $(LIBDL), \
   ))
   TARGETS += $(BUILD_JNCRYPTO)
 endif
-
-INCLUDE_CUSTOM_EXTENSION_SYMBOLS := $(SUPPORT_OUTPUTDIR)/modules_libs/java.base/$(LIBRARY_PREFIX)jncrypto.symbols
-INCLUDE_CUSTOM_EXTENSION_LIB := BUILD_JNCRYPTO
-################################################################################

--- a/make/lib/Lib-java.base.gmk
+++ b/make/lib/Lib-java.base.gmk
@@ -24,7 +24,7 @@
 #
 
 # ===========================================================================
-# (c) Copyright IBM Corp. 2018, 2018 All Rights Reserved
+# (c) Copyright IBM Corp. 2018, 2023 All Rights Reserved
 # ===========================================================================
 
 include LibCommon.gmk
@@ -198,7 +198,6 @@ ifeq ($(STATIC_BUILD), true)
       $(SUPPORT_OUTPUTDIR)/modules_libs/java.base/$(LIBRARY_PREFIX)zip.symbols \
       $(SUPPORT_OUTPUTDIR)/modules_libs/java.base/$(LIBRARY_PREFIX)jimage.symbols \
       $(SUPPORT_OUTPUTDIR)/modules_libs/java.base/server/$(LIBRARY_PREFIX)jvm.symbols \
-      $(INCLUDE_CUSTOM_EXTENSION_SYMBOLS) \
       #
 
   JAVA_BASE_EXPORT_SYMBOL_FILE := $(SUPPORT_OUTPUTDIR)/modules_libs/java.base/java.base.symbols
@@ -210,8 +209,7 @@ ifeq ($(STATIC_BUILD), true)
   # The individual symbol files is generated when the respective lib is built
   $(JAVA_BASE_EXPORT_SYMBOLS_SRC): $(BUILD_LIBJLI) $(BUILD_LIBJAVA) \
       $(BUILD_LIBNET) $(BUILD_LIBNIO) $(BUILD_LIBVERIFY) $(BUILD_LIBZIP) \
-      $(BUILD_LIBJIMAGE) \
-      $(INCLUDE_CUSTOM_EXTENSION_LIB)
+      $(BUILD_LIBJIMAGE)
 
   TARGETS += $(JAVA_BASE_EXPORT_SYMBOL_FILE)
 endif


### PR DESCRIPTION
These symbols would only be used if `STATIC_BUILD` is `true`:
```
  INCLUDE_CUSTOM_EXTENSION_SYMBOLS
  INCLUDE_CUSTOM_EXTENSION_LIB
```
The configuration option `--enable-static-build` is only accepted on macOS, but we don't use that option and it would fail anyway with errors like
```
  No rule to make target .../vm/runtime/libmanagement_ext.a
```
and various other static libraries.

Also remove redundant `-c` from `CFLAGS`.

See also https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/692.