### PR TITLE
Integrate OpenJCEPlus into Semeru OpenJDK

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # ===========================================================================
-# (c) Copyright IBM Corp. 2017, 2023 All Rights Reserved
+# (c) Copyright IBM Corp. 2017, 2024 All Rights Reserved
 # ===========================================================================
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
@@ -21,6 +21,7 @@
 # exclude all source directories
 /omr
 /openj9
+/OpenJCEPlus
 /openssl
 # exclude optional eclipse project file
 /.project

--- a/closed/GensrcJ9JCL.gmk
+++ b/closed/GensrcJ9JCL.gmk
@@ -48,6 +48,7 @@ $(eval $(call SetupCopyFiles,COPY_OVERLAY_FILES, \
 		src/java.base/share/classes/java/util/concurrent/ConcurrentHashMap.java \
 		src/java.base/share/classes/jdk/internal/misc/JavaNetInetAddressAccess.java \
 		src/java.base/share/classes/jdk/internal/ref/PhantomCleanable.java \
+		src/java.base/share/classes/module-info.java \
 		src/java.base/share/classes/sun/security/jca/ProviderConfig.java \
 		src/java.base/share/classes/sun/security/jca/ProviderList.java \
 		src/java.base/share/classes/sun/security/provider/DigestBase.java \

--- a/closed/JPP.gmk
+++ b/closed/JPP.gmk
@@ -1,5 +1,5 @@
 # ===========================================================================
-# (c) Copyright IBM Corp. 2023, 2023 All Rights Reserved
+# (c) Copyright IBM Corp. 2023, 2024 All Rights Reserved
 # ===========================================================================
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
@@ -33,6 +33,10 @@ endif # OPENJ9_ENABLE_CRIU_SUPPORT
 ifeq (true,$(OPENJ9_ENABLE_OPENJDK_METHODHANDLES))
   JPP_TAGS += OPENJDK_METHODHANDLES
 endif # OPENJ9_ENABLE_OPENJDK_METHODHANDLES
+
+ifeq (true,$(BUILD_OPENJCEPLUS))
+  JPP_TAGS += OPENJCEPLUS_SUPPORT
+endif # BUILD_OPENJCEPLUS
 
 # invoke JPP to preprocess java source files
 # $1 - configuration

--- a/closed/autoconf/custom-hook.m4
+++ b/closed/autoconf/custom-hook.m4
@@ -1,5 +1,5 @@
 # ===========================================================================
-# (c) Copyright IBM Corp. 2017, 2023 All Rights Reserved
+# (c) Copyright IBM Corp. 2017, 2024 All Rights Reserved
 # ===========================================================================
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
@@ -52,6 +52,7 @@ AC_DEFUN_ONCE([CUSTOM_EARLY_HOOK],
   OPENJ9_CONFIGURE_OPENJDK_METHODHANDLES
   OPENJ9_THIRD_PARTY_REQUIREMENTS
   OPENJ9_CHECK_NASM_VERSION
+  OPENJCEPLUS_SETUP
 ])
 
 AC_DEFUN([OPENJ9_CONFIGURE_CMAKE],
@@ -825,4 +826,29 @@ AC_DEFUN([OPENJ9_GENERATE_TOOL_WRAPPERS],
   OPENJ9_GENERATE_TOOL_WRAPPER([ml64], [$ML64])
   OPENJ9_GENERATE_TOOL_WRAPPER([nasm], [$NASM])
   OPENJ9_GENERATE_TOOL_WRAPPER([rc], [$RC])
+])
+
+AC_DEFUN([OPENJCEPLUS_SETUP],
+[
+  AC_ARG_ENABLE([openjceplus], [AS_HELP_STRING([--enable-openjceplus],
+      [enable OpenJCEPlus integration @<:@disabled@:>@])])
+  AC_MSG_CHECKING([for OpenJCEPlus])
+  if test "x$enable_openjceplus" = xyes ; then
+    if test -d "$TOPDIR/OpenJCEPlus" ; then
+      AC_MSG_RESULT([yes (explicitly set)])
+      BUILD_OPENJCEPLUS=true
+    else
+      AC_MSG_RESULT([no])
+      AC_MSG_ERROR([OpenJCEPlus not found at $TOPDIR/OpenJCEPlus])
+    fi
+  elif test "x$enable_openjceplus" = xno ; then
+    AC_MSG_RESULT([no])
+    BUILD_OPENJCEPLUS=false
+  elif test "x$enable_openjceplus" = x ; then
+    AC_MSG_RESULT([no (default)])
+    BUILD_OPENJCEPLUS=false
+  else
+    AC_MSG_ERROR([--enable-openjceplus accepts no argument])
+  fi
+  AC_SUBST(BUILD_OPENJCEPLUS)
 ])

--- a/closed/autoconf/custom-spec.gmk.in
+++ b/closed/autoconf/custom-spec.gmk.in
@@ -1,5 +1,5 @@
 # ===========================================================================
-# (c) Copyright IBM Corp. 2017, 2023 All Rights Reserved
+# (c) Copyright IBM Corp. 2017, 2024 All Rights Reserved
 # ===========================================================================
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
@@ -179,3 +179,7 @@ ifeq (riscv64,$(OPENJDK_TARGET_CPU))
     JAVA_FLAGS += -DserverStartupTimeout=36000
   endif
 endif
+
+# Required by OpenJCEPlus.
+BUILD_OPENJCEPLUS  := @BUILD_OPENJCEPLUS@
+OPENJCEPLUS_TOPDIR := $(TOPDIR)/OpenJCEPlus

--- a/closed/custom/Images-pre.gmk
+++ b/closed/custom/Images-pre.gmk
@@ -1,5 +1,5 @@
 # ===========================================================================
-# (c) Copyright IBM Corp. 2020, 2021 All Rights Reserved
+# (c) Copyright IBM Corp. 2020, 2024 All Rights Reserved
 # ===========================================================================
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
@@ -24,4 +24,5 @@ JRE_MODULES += \
 	openj9.dataaccess \
 	openj9.dtfj \
 	openj9.gpu \
+	$(if $(call equals, $(BUILD_OPENJCEPLUS), true), openjceplus) \
 	#

--- a/closed/custom/Main.gmk
+++ b/closed/custom/Main.gmk
@@ -1,5 +1,5 @@
 # ===========================================================================
-# (c) Copyright IBM Corp. 2017, 2023 All Rights Reserved
+# (c) Copyright IBM Corp. 2017, 2024 All Rights Reserved
 # ===========================================================================
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
@@ -109,3 +109,23 @@ ifneq (,$(HEALTHCENTER_JAR))
   # The content must be extracted before module-info can be compiled.
   ibm.healthcenter-java : ibm.healthcenter-copy
 endif # HEALTHCENTER_JAR
+
+ifeq (true,$(BUILD_OPENJCEPLUS))
+
+ifeq ($(call And, $(call isTargetOs, windows) $(call isTargetCpu, x86_64)), true)
+  OPENJCEPLUS_JGSKIT_MAKE := jgskit.win64.mak
+else
+  OPENJCEPLUS_JGSKIT_MAKE := jgskit.mak
+endif
+
+openjceplus-copy : openjceplus-libs
+
+.PHONY : openjceplus-clean
+
+openjceplus-clean :
+	@$(ECHO) Cleaning OpenJCEPlus native code
+	$(MAKE) -C $(OPENJCEPLUS_TOPDIR)/src/main/native -f $(OPENJCEPLUS_JGSKIT_MAKE) cleanAll
+
+clean-openjceplus : openjceplus-clean
+
+endif # BUILD_OPENJCEPLUS

--- a/closed/custom/ReleaseFile.gmk
+++ b/closed/custom/ReleaseFile.gmk
@@ -1,5 +1,5 @@
 # ===========================================================================
-# (c) Copyright IBM Corp. 2017, 2022 All Rights Reserved
+# (c) Copyright IBM Corp. 2017, 2024 All Rights Reserved
 # ===========================================================================
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
@@ -21,3 +21,6 @@
 SOURCE_REVISION := OpenJDK:$(shell $(GIT) -C $(TOPDIR) rev-parse --short HEAD)
 SOURCE_REVISION += OpenJ9:$(shell $(GIT) -C $(OPENJ9_TOPDIR) rev-parse --short HEAD)
 SOURCE_REVISION += OMR:$(shell $(GIT) -C $(OPENJ9OMR_TOPDIR) rev-parse --short HEAD)
+ifeq (true,$(BUILD_OPENJCEPLUS))
+  SOURCE_REVISION += OpenJCEPlus:$(shell $(GIT) -C $(OPENJCEPLUS_TOPDIR) rev-parse --short HEAD)
+endif

--- a/closed/custom/common/Modules.gmk
+++ b/closed/custom/common/Modules.gmk
@@ -1,5 +1,5 @@
 # ===========================================================================
-# (c) Copyright IBM Corp. 2017, 2022 All Rights Reserved
+# (c) Copyright IBM Corp. 2017, 2024 All Rights Reserved
 # ===========================================================================
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
@@ -55,6 +55,10 @@ MODULES_FILTER += \
 TOP_SRC_DIRS += \
 	$(J9JCL_SOURCES_DIR) \
 	#
+
+ifeq (true,$(BUILD_OPENJCEPLUS))
+  TOP_SRC_DIRS += $(OPENJCEPLUS_TOPDIR)/src/main
+endif
 
 .PHONY : generate-j9jcl-sources
 

--- a/closed/custom/common/SetupJavaCompilers.gmk
+++ b/closed/custom/common/SetupJavaCompilers.gmk
@@ -1,5 +1,5 @@
 # ===========================================================================
-# (c) Copyright IBM Corp. 2018, 2022 All Rights Reserved
+# (c) Copyright IBM Corp. 2018, 2024 All Rights Reserved
 # ===========================================================================
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
@@ -24,6 +24,7 @@ WARNING_MODULES := \
 	openj9.dtfj \
 	openj9.dtfjview \
 	openj9.traceformat \
+	openjceplus \
 	#
 
 ifneq (,$(filter $(WARNING_MODULES),$(MODULE)))

--- a/closed/make/copy/Copy-openjceplus.gmk
+++ b/closed/make/copy/Copy-openjceplus.gmk
@@ -1,0 +1,58 @@
+# ===========================================================================
+# (c) Copyright IBM Corp. 2023, 2024 All Rights Reserved
+# ===========================================================================
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.
+#
+# IBM designates this particular file as subject to the "Classpath" exception
+# as provided by IBM in the LICENSE file that accompanied this code.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, see <http://www.gnu.org/licenses/>.
+# ===========================================================================
+
+include $(TOPDIR)/closed/CopySupport.gmk
+
+ifeq (true,$(BUILD_OPENJCEPLUS))
+  # Copy OpenJCEPlus legal files.
+  $(call openj9_copy_files,, \
+      $(OPENJCEPLUS_TOPDIR)/LICENSE \
+      $(LEGAL_DST_DIR)/OPENJCEPLUS_LICENSE)
+
+  $(call openj9_copy_files,, \
+      $(OPENJCEPLUS_TOPDIR)/NOTICES.md \
+      $(LEGAL_DST_DIR)/NOTICES.md)
+
+  # Copy OpenJCEPlus native libraries.
+  $(eval $(call SetupCopyFiles, OPENJCEPLUS_JGSKIT_LIBS_COPY, \
+      SRC := $(OPENJCEPLUS_TOPDIR)/target, \
+      FILES := $(filter %.dll %.so %.x, $(call FindFiles, $(OPENJCEPLUS_TOPDIR)/target)), \
+      FLATTEN := true, \
+      DEST := $(LIB_DST_DIR), \
+  ))
+
+  TARGETS += $(OPENJCEPLUS_JGSKIT_LIBS_COPY)
+
+  # Bundle GSKIT library.
+  OPENJCEPLUS_OCK_DIR := $(OPENJCEPLUS_TOPDIR)/ock/jgsk_sdk/lib64
+  ifeq ($(call isTargetOs, windows), true)
+    OPENJCEPLUS_OCK_SUB_DIR := modules_cmds
+  else
+    OPENJCEPLUS_OCK_SUB_DIR := modules_libs
+  endif
+
+  $(eval $(call SetupCopyFiles, OPENJCEPLUS_OCK_COPY, \
+      SRC := $(OPENJCEPLUS_OCK_DIR), \
+      DEST := $(SUPPORT_OUTPUTDIR)/$(OPENJCEPLUS_OCK_SUB_DIR)/$(MODULE), \
+      FILES := $(call FindFiles, $(OPENJCEPLUS_OCK_DIR)), \
+  ))
+
+  TARGETS += $(OPENJCEPLUS_OCK_COPY)
+endif # BUILD_OPENJCEPLUS

--- a/closed/make/lib/Lib-openjceplus.gmk
+++ b/closed/make/lib/Lib-openjceplus.gmk
@@ -1,0 +1,71 @@
+# ===========================================================================
+# (c) Copyright IBM Corp. 2023, 2024 All Rights Reserved
+# ===========================================================================
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.
+#
+# IBM designates this particular file as subject to the "Classpath" exception
+# as provided by IBM in the LICENSE file that accompanied this code.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, see <http://www.gnu.org/licenses/>.
+# ===========================================================================
+
+include LibCommon.gmk
+
+ifeq (true,$(BUILD_OPENJCEPLUS))
+
+# Identify the desired JGSKIT target platform.
+OPENJCEPLUS_BOOT_JDK := $(BOOT_JDK)
+OPENJCEPLUS_GSKIT_HOME := $(OPENJCEPLUS_TOPDIR)/ock/jgsk_sdk
+OPENJCEPLUS_JCE_CLASSPATH := $(JDK_OUTPUTDIR)/modules/openjceplus:$(JDK_OUTPUTDIR)/modules/java.base
+OPENJCEPLUS_JGSKIT_MAKE := jgskit.mak
+OPENJCEPLUS_JGSKIT_MAKE_PATH := $(OPENJCEPLUS_TOPDIR)/src/main/native
+OPENJCEPLUS_JGSKIT_PLATFORM :=
+
+ifeq ($(call isTargetOs, aix), true)
+  OPENJCEPLUS_JGSKIT_PLATFORM := ppc-aix64
+else ifeq ($(call isTargetOs, linux), true)
+  ifeq ($(call isTargetCpu, ppc64le), true)
+    OPENJCEPLUS_JGSKIT_PLATFORM := ppcle-linux64
+  else ifeq ($(call isTargetCpu, s390x), true)
+    OPENJCEPLUS_JGSKIT_PLATFORM := s390-linux64
+  else ifeq ($(call isTargetCpu, x86_64), true)
+    OPENJCEPLUS_JGSKIT_PLATFORM := x86-linux64
+  endif
+else ifeq ($(call isTargetOs, windows), true)
+  ifeq ($(call isTargetCpu, x86_64), true)
+    OPENJCEPLUS_BOOT_JDK := $(call MixedPath,$(OPENJCEPLUS_BOOT_JDK))
+    OPENJCEPLUS_GSKIT_HOME := $(call MixedPath,$(OPENJCEPLUS_GSKIT_HOME))
+    OPENJCEPLUS_JCE_CLASSPATH := "$(call MixedPath,$(JDK_OUTPUTDIR)/modules/openjceplus)\;$(call MixedPath,$(JDK_OUTPUTDIR)/modules/java.base)"
+    OPENJCEPLUS_JGSKIT_MAKE := jgskit.win64.mak
+    OPENJCEPLUS_JGSKIT_PLATFORM := win64
+  endif
+endif
+
+ifeq (,$(OPENJCEPLUS_JGSKIT_PLATFORM))
+  $(error Unsupported platform $(OPENJDK_TARGET_OS)-$(OPENJDK_TARGET_CPU))
+endif # OPENJCEPLUS_JGSKIT_PLATFORM
+
+.PHONY : compile-libs
+
+compile-libs :
+	@$(ECHO) Compiling OpenJCEPlus native code
+	export \
+			GSKIT_HOME=$(OPENJCEPLUS_GSKIT_HOME) \
+			JAVA_HOME=$(OPENJCEPLUS_BOOT_JDK) \
+			JCE_CLASSPATH=$(OPENJCEPLUS_JCE_CLASSPATH) \
+			PLATFORM=$(OPENJCEPLUS_JGSKIT_PLATFORM) \
+		&& $(MAKE) -j1 -C $(OPENJCEPLUS_JGSKIT_MAKE_PATH) -f $(OPENJCEPLUS_JGSKIT_MAKE) all
+	@$(ECHO) OpenJCEplus compile complete
+
+TARGETS += compile-libs
+
+endif # BUILD_OPENJCEPLUS

--- a/closed/src/java.base/share/classes/openj9/internal/security/RestrictedSecurity.java
+++ b/closed/src/java.base/share/classes/openj9/internal/security/RestrictedSecurity.java
@@ -78,7 +78,7 @@ public final class RestrictedSecurity {
         supportedPlatformsNSS.put("Arch", List.of("amd64", "ppc64le", "s390x"));
         supportedPlatformsNSS.put("OS", List.of("Linux"));
 
-        supportedPlatformsOpenJCEPlus.put("Arch", List.of("amd64", "ppc64"));
+        supportedPlatformsOpenJCEPlus.put("Arch", List.of("amd64", "ppc64", "s390x"));
         supportedPlatformsOpenJCEPlus.put("OS", List.of("Linux", "AIX", "Windows"));
 
         @SuppressWarnings("removal")

--- a/get_source.sh
+++ b/get_source.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # ===========================================================================
-# (c) Copyright IBM Corp. 2017, 2022 All Rights Reserved
+# (c) Copyright IBM Corp. 2017, 2024 All Rights Reserved
 # ===========================================================================
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -40,6 +40,13 @@ usage() {
 	echo "  -omr-branch       the OpenJ9/omr git branch: openj9"
 	echo "  -omr-sha          a commit SHA for the omr repository"
 	echo "  -omr-reference    a local repo to use as a clone reference"
+	echo "  -openjceplus-repo the OpenJCEPlus repository url"
+	echo "  -openjceplus-branch the OpenJCEPlus git branch"
+	echo "  -openjceplus-sha  a commit SHA for the OpenJCEPlus repository"
+	echo "  -openjceplus-reference a local repo to use as a clone reference"
+	echo "  -gskit-bin        the GSKit binary url"
+	echo "  -gskit-sdk-bin    the GSKIT SDK binary url"
+	echo "  -gskit-credential the credential for downloading the GSKit and GSKit SDK"
 	echo "  -parallel         (boolean) if 'true' then the clone j9 repository commands run in parallel, default is false"
 	echo "  --openssl-repo    Specify the OpenSSL repository to download from"
 	echo "  --openssl-version Specify the version of OpenSSL source to download"
@@ -57,7 +64,23 @@ for i in "$@" ; do
 			usage
 			;;
 
-		-openj9-repo=* | -openj9-branch=* | -openj9-sha=* | -openj9-reference=* | -omr-repo=* | -omr-branch=* | -omr-sha=* | -omr-reference=* | -parallel=* )
+		  -gskit-bin=* \
+		| -gskit-credential=* \
+		| -gskit-sdk-bin=* \
+		| -omr-branch=* \
+		| -omr-reference=* \
+		| -omr-repo=* \
+		| -omr-sha=* \
+		| -openj9-branch=* \
+		| -openj9-reference=* \
+		| -openj9-repo=* \
+		| -openj9-sha=* \
+		| -openjceplus-branch=* \
+		| -openjceplus-reference=* \
+		| -openjceplus-repo=* \
+		| -openjceplus-sha=* \
+		| -parallel=* \
+		)
 			j9options="${j9options} ${i}"
 			;;
 

--- a/src/java.base/share/classes/module-info.java
+++ b/src/java.base/share/classes/module-info.java
@@ -25,7 +25,7 @@
 
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2022, 2023 All Rights Reserved
+ * (c) Copyright IBM Corp. 2022, 2024 All Rights Reserved
  * ===========================================================================
  */
 
@@ -160,6 +160,9 @@ module java.base {
         jdk.compiler,
         jdk.jlink;
     exports jdk.internal.logger to
+/*[IF OPENJCEPLUS_SUPPORT]*/
+        openjceplus,
+/*[ENDIF] OPENJCEPLUS_SUPPORT */
         java.logging;
     exports jdk.internal.org.objectweb.asm to
         jdk.jartool,
@@ -182,6 +185,9 @@ module java.base {
     exports jdk.internal.org.xml.sax.helpers to
         jdk.jfr;
     exports jdk.internal.misc to
+/*[IF OPENJCEPLUS_SUPPORT]*/
+        openjceplus,
+/*[ENDIF] OPENJCEPLUS_SUPPORT */
         java.desktop,
         java.logging,
         java.management,
@@ -252,6 +258,9 @@ module java.base {
         jdk.jconsole,
         jdk.sctp;
     exports sun.net.www to
+/*[IF OPENJCEPLUS_SUPPORT]*/
+        openjceplus,
+/*[ENDIF] OPENJCEPLUS_SUPPORT */
         java.desktop,
         java.net.http,
         jdk.jartool;
@@ -283,8 +292,14 @@ module java.base {
         java.security.jgss,
         jdk.crypto.ec;
     exports sun.security.internal.interfaces to
+/*[IF OPENJCEPLUS_SUPPORT]*/
+        openjceplus,
+/*[ENDIF] OPENJCEPLUS_SUPPORT */
         jdk.crypto.cryptoki;
     exports sun.security.internal.spec to
+/*[IF OPENJCEPLUS_SUPPORT]*/
+        openjceplus,
+/*[ENDIF] OPENJCEPLUS_SUPPORT */
         jdk.crypto.cryptoki;
     exports sun.security.jca to
         java.smartcardio,
@@ -292,6 +307,9 @@ module java.base {
         jdk.crypto.cryptoki,
         jdk.naming.dns;
     exports sun.security.pkcs to
+/*[IF OPENJCEPLUS_SUPPORT]*/
+        openjceplus,
+/*[ENDIF] OPENJCEPLUS_SUPPORT */
         jdk.crypto.ec,
         jdk.jartool;
     exports sun.security.provider to
@@ -312,6 +330,9 @@ module java.base {
     exports sun.security.tools to
         jdk.jartool;
     exports sun.security.util to
+/*[IF OPENJCEPLUS_SUPPORT]*/
+        openjceplus,
+/*[ENDIF] OPENJCEPLUS_SUPPORT */
         java.desktop,
         java.naming,
         java.rmi,
@@ -330,6 +351,9 @@ module java.base {
     exports sun.security.util.math.intpoly to
         jdk.crypto.ec
     exports sun.security.x509 to
+/*[IF OPENJCEPLUS_SUPPORT]*/
+        openjceplus,
+/*[ENDIF] OPENJCEPLUS_SUPPORT */
         jdk.crypto.ec,
         jdk.crypto.cryptoki,
         jdk.jartool;
@@ -342,6 +366,9 @@ module java.base {
         jdk.jlink,
         jdk.localedata;
     exports sun.util.logging to
+/*[IF OPENJCEPLUS_SUPPORT]*/
+        openjceplus,
+/*[ENDIF] OPENJCEPLUS_SUPPORT */
         java.desktop,
         java.logging,
         java.prefs;

--- a/src/java.base/share/conf/security/java.security
+++ b/src/java.base/share/conf/security/java.security
@@ -88,10 +88,12 @@ security.provider.tbd=Apple
 security.provider.tbd=SunPKCS11
 #endif
 
-#if defined linux-x86 || defined linux-ppc || defined linux-s390
+#if defined aix-ppc || defined linux-ppc || defined linux-s390 || defined linux-x86 || defined windows
 #
 # Java Restricted Security Mode
 #
+#endif
+#if defined linux-ppc || defined linux-s390 || defined linux-x86
 RestrictedSecurity.NSS.140-2.desc.name = Red Hat Enterprise Linux 8 NSS Cryptographic Module FIPS 140-2
 RestrictedSecurity.NSS.140-2.desc.default = true
 RestrictedSecurity.NSS.140-2.desc.fips = true
@@ -154,6 +156,59 @@ RestrictedSecurity.NSS.140-2.javax.net.ssl.keyStore = NONE
 
 RestrictedSecurity.NSS.140-2.securerandom.provider = SunPKCS11-NSS-FIPS
 RestrictedSecurity.NSS.140-2.securerandom.algorithm = PKCS11
+#endif
+
+#if defined aix-ppc || defined linux-ppc || defined linux-s390 || defined linux-x86 || defined windows
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3.desc.name = OpenJCEPlusFIPS Cryptographic Module FIPS 140-3
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3.desc.default = true
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3.desc.fips = true
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3.desc.number = Certificate #XXX
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3.desc.policy = https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3.desc.sunsetDate = 2026-09-21
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3.tls.disabledNamedCurves =
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3.tls.disabledAlgorithms = \
+    3DES_EDE_CBC, \
+    anon, \
+    DES, \
+    DH keySize < 2048, \
+    EC keySize < 224, \
+    MD5withRSA, \
+    NULL, \
+    RC4, \
+    SSLv3, \
+    TLS_DHE_DSS_WITH_AES_128_CBC_SHA, \
+    TLS_DHE_DSS_WITH_AES_128_CBC_SHA256, \
+    TLS_DHE_DSS_WITH_AES_128_GCM_SHA256, \
+    TLS_DHE_DSS_WITH_AES_256_CBC_SHA, \
+    TLS_DHE_DSS_WITH_AES_256_CBC_SHA256, \
+    TLS_DHE_DSS_WITH_AES_256_GCM_SHA384, \
+    TLS_EMPTY_RENEGOTIATION_INFO_SCSV, \
+    TLS_RSA_WITH_AES_128_CBC_SHA, \
+    TLS_RSA_WITH_AES_128_CBC_SHA256, \
+    TLS_RSA_WITH_AES_128_GCM_SHA256, \
+    TLS_RSA_WITH_AES_256_CBC_SHA, \
+    TLS_RSA_WITH_AES_256_CBC_SHA256, \
+    TLS_RSA_WITH_AES_256_GCM_SHA384, \
+    TLSv1, \
+    TLSv1.1, \
+    X25519, \
+    X448
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3.tls.ephemeralDHKeySize =
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3.tls.legacyAlgorithms =
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3.jce.certpath.disabledAlgorithms =
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3.jce.legacyAlgorithms =
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3.jce.provider.1 = com.ibm.crypto.plus.provider.OpenJCEPlusFIPS
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3.jce.provider.2 = SUN [{CertificateFactory, X.509, ImplementedIn=Software}, \
+    {CertPathBuilder, PKIX, ValidationAlgorithm=RFC5280:ImplementedIn=Software}, \
+    {CertPathValidator, PKIX, ValidationAlgorithm=RFC5280:ImplementedIn=Software}, \
+    {CertStore, Collection, ImplementedIn=Software}, \
+    {CertStore, com.sun.security.IndexedCollection, ImplementedIn=Software}, \
+    {Configuration, JavaLoginConfig, *}, \
+    {Policy, JavaPolicy, *}]
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3.jce.provider.3 = SunJSSE
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3.javax.net.ssl.keyStore = NONE
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3.securerandom.provider = OpenJCEPlusFIPS
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3.securerandom.algorithm = SHA512DRBG
 #endif
 
 #


### PR DESCRIPTION
Integrate the building of OpenJCEPlus with Semeru
OpenJDK as a module "openjceplus". The java codes
will be built with Semeru OpenJDK as a jmod, and
the native codes will be built as a ".so" or ".dll" library.