### PR TITLE
Remove the 192-bit EC test case

### DIFF
--- a/test/jdk/sun/security/tools/keytool/fakegen/DefaultSignatureAlgorithm.java
+++ b/test/jdk/sun/security/tools/keytool/fakegen/DefaultSignatureAlgorithm.java
@@ -60,7 +60,6 @@ public class DefaultSignatureAlgorithm {
         check("DSA", 1024, null, "SHA256withDSA");
         check("DSA", 3072, null, "SHA256withDSA");
 
-        check("EC", 192, null, "SHA256withECDSA");
         check("EC", 384, null, "SHA384withECDSA");
         check("EC", 571, null, "SHA512withECDSA");
 


### PR DESCRIPTION
This patch eliminates the 192-bit EC test which causes exceptions
seen in issue #18320.

DefaultSignatureAlgorithm test was run in those Redhat OS based machines
in a non-FIPS mode, but with a FIPS version of openssl. So, a 192-bit 
size of EC key pair generator is not allowed by the native code in a
FIPS version of openssl. The code path went to a replacement EC key-pair
generator Java implementation.

issue: https://github.com/eclipse-openj9/openj9/issues/18320