### PR TITLE
CRIU adds @NotCheckpointSafe for ZipFile.getEntry(String, Function)

### DIFF
--- a/closed/GensrcJ9JCL.gmk
+++ b/closed/GensrcJ9JCL.gmk
@@ -47,6 +47,7 @@ $(eval $(call SetupCopyFiles,COPY_OVERLAY_FILES, \
 		src/java.base/share/classes/java/util/Timer.java \
 		src/java.base/share/classes/java/util/TimerTask.java \
 		src/java.base/share/classes/java/util/concurrent/ConcurrentHashMap.java \
+		src/java.base/share/classes/java/util/zip/ZipFile.java \
 		src/java.base/share/classes/jdk/internal/misc/JavaNetInetAddressAccess.java \
 		src/java.base/share/classes/jdk/internal/ref/PhantomCleanable.java \
 		src/java.base/share/classes/module-info.java \

--- a/src/java.base/share/classes/java/util/zip/ZipFile.java
+++ b/src/java.base/share/classes/java/util/zip/ZipFile.java
@@ -23,6 +23,12 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2024, 2024 All Rights Reserved
+ * ===========================================================================
+ */
+
 package java.util.zip;
 
 import java.io.Closeable;
@@ -72,6 +78,10 @@ import java.security.AccessController;
 
 import static java.util.zip.ZipConstants64.*;
 import static java.util.zip.ZipUtils.*;
+
+/*[IF CRIU_SUPPORT]*/
+import openj9.internal.criu.NotCheckpointSafe;
+/*[ENDIF] CRIU_SUPPORT */
 
 /**
  * This class is used to read entries from a zip file.
@@ -352,6 +362,9 @@ class ZipFile implements ZipConstants, Closeable {
      * @return the zip file entry, or null if not found
      * @throws IllegalStateException if the zip file has been closed
      */
+    /*[IF CRIU_SUPPORT]*/
+    @NotCheckpointSafe
+    /*[ENDIF] CRIU_SUPPORT */
     private ZipEntry getEntry(String name, Function<String, ? extends ZipEntry> func) {
         Objects.requireNonNull(name, "name");
         synchronized (this) {


### PR DESCRIPTION
CRIU adds `@NotCheckpointSafe for ZipFile.getEntry(String)`

Cherry-pick
* https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/840

To adopt JDK11 methods, moved the annotation to the private helper method `ZipFile.getEntry(String name, Function<String, ? extends ZipEntry> func)`.

Signed-off-by: Jason Feng <fengj@ca.ibm.com>