### PR TITLE
JFR copy $(OPENJ9_TOPDIR)/runtime/metadata.blob to $(LIB_DST_DIR)

### DIFF
--- a/closed/custom/copy/Copy-java.base.gmk
+++ b/closed/custom/copy/Copy-java.base.gmk
@@ -1,5 +1,5 @@
 # ===========================================================================
-# (c) Copyright IBM Corp. 2017, 2023 All Rights Reserved
+# (c) Copyright IBM Corp. 2017, 2024 All Rights Reserved
 # ===========================================================================
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
@@ -180,6 +180,14 @@ $(call openj9_copy_files,, \
 		$(LIB_DST_DIR)/$(OPENJ9_LIBS_SUBDIR)))
 
 endif # OPENJ9_ENABLE_DDR
+
+ifeq (true,$(OPENJ9_ENABLE_JFR))
+
+$(call openj9_copy_files,, \
+	$(OPENJ9_TOPDIR)/runtime/metadata.blob \
+	$(LIB_DST_DIR)/metadata.blob)
+
+endif # OPENJ9_ENABLE_JFR
 
 ##########################################################################################
 # Optionally copy OpenSSL Crypto Library


### PR DESCRIPTION
JFR copy `$(OPENJ9_TOPDIR)/runtime/metadata.blob` to `$(LIB_DST_DIR)`

Cherry-pick
* https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/863

Depends on
* https://github.com/eclipse-openj9/openj9/pull/20358

Signed-off-by: Jason Feng <fengj@ca.ibm.com>