### PR TITLE
Backport 8308801, 8308022 to jdk11 

### DIFF
--- a/src/java.base/share/native/libjli/java.c
+++ b/src/java.base/share/native/libjli/java.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1065,10 +1065,11 @@ SetClassPath(const char *s)
     if (sizeof(format) - 2 + JLI_StrLen(s) < JLI_StrLen(s))
         // s is became corrupted after expanding wildcards
         return;
-    def = JLI_MemAlloc(sizeof(format)
+    size_t defSize = sizeof(format)
                        - 2 /* strlen("%s") */
-                       + JLI_StrLen(s));
-    sprintf(def, format, s);
+                       + JLI_StrLen(s);
+    def = JLI_MemAlloc(defSize);
+    snprintf(def, defSize, format, s);
     AddOption(def, NULL);
     if (s != orig)
         JLI_MemFree((char *) s);
@@ -1518,8 +1519,9 @@ ParseArguments(int *pargc, char ***pargv,
                    JLI_StrCCmp(arg, "-oss") == 0 ||
                    JLI_StrCCmp(arg, "-ms") == 0 ||
                    JLI_StrCCmp(arg, "-mx") == 0) {
-            char *tmp = JLI_MemAlloc(JLI_StrLen(arg) + 6);
-            sprintf(tmp, "-X%s", arg + 1); /* skip '-' */
+            size_t tmpSize = JLI_StrLen(arg) + 6;
+            char *tmp = JLI_MemAlloc(tmpSize);
+            snprintf(tmp, tmpSize, "-X%s", arg + 1); /* skip '-' */
             AddOption(tmp, NULL);
         } else if (JLI_StrCmp(arg, "-checksource") == 0 ||
                    JLI_StrCmp(arg, "-cs") == 0 ||
@@ -1851,8 +1853,9 @@ AddApplicationOptions(int cpathc, const char **cpathv)
             s = (char *) JLI_WildcardExpandClasspath(s);
             /* 40 for -Denv.class.path= */
             if (JLI_StrLen(s) + 40 > JLI_StrLen(s)) { // Safeguard from overflow
-                envcp = (char *)JLI_MemAlloc(JLI_StrLen(s) + 40);
-                sprintf(envcp, "-Denv.class.path=%s", s);
+                size_t envcpSize = JLI_StrLen(s) + 40;
+                envcp = (char *)JLI_MemAlloc(envcpSize);
+                snprintf(envcp, envcpSize, "-Denv.class.path=%s", s);
                 AddOption(envcp, NULL);
             }
         }
@@ -1864,8 +1867,9 @@ AddApplicationOptions(int cpathc, const char **cpathv)
     }
 
     /* 40 for '-Dapplication.home=' */
-    apphome = (char *)JLI_MemAlloc(JLI_StrLen(home) + 40);
-    sprintf(apphome, "-Dapplication.home=%s", home);
+    size_t apphomeSize = JLI_StrLen(home) + 40;
+    apphome = (char *)JLI_MemAlloc(apphomeSize);
+    snprintf(apphome, apphomeSize, "-Dapplication.home=%s", home);
     AddOption(apphome, NULL);
 
     /* How big is the application's classpath? */

--- a/src/java.base/unix/native/libjava/TimeZone_md.c
+++ b/src/java.base/unix/native/libjava/TimeZone_md.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -887,14 +887,14 @@ getGMTOffsetID()
     // Ignore daylight saving settings to calculate current time difference
     localtm.tm_isdst = 0;
     int gmt_off = (int)(difftime(mktime(&localtm), mktime(&gmt)) / 60.0);
-    sprintf(buf, (const char *)"GMT%c%02.2d:%02.2d",
+    snprintf(buf, sizeof(buf), (const char *)"GMT%c%02.2d:%02.2d",
             gmt_off < 0 ? '-' : '+' , abs(gmt_off / 60), gmt_off % 60);
 #else
     if (strftime(offset, 6, "%z", &localtm) != 5) {
         return strdup("GMT");
     }
 
-    sprintf(buf, (const char *)"GMT%c%c%c:%c%c", offset[0], offset[1], offset[2],
+    snprintf(buf, sizeof(buf), (const char *)"GMT%c%c%c:%c%c", offset[0], offset[1], offset[2],
         offset[3], offset[4]);
 #endif
     return strdup(buf);

--- a/src/java.base/unix/native/libjli/java_md_solinux.c
+++ b/src/java.base/unix/native/libjli/java_md_solinux.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -441,7 +441,7 @@ CreateExecutionEnvironment(int *pargc, char ***pargv,
                 if (lastslash)
                     *lastslash = '\0';
 
-                sprintf(new_runpath, LD_LIBRARY_PATH "="
+                snprintf(new_runpath, new_runpath_size, LD_LIBRARY_PATH "="
                         "%s:"
                         "%s/lib:"
 #ifdef AIX
@@ -844,8 +844,9 @@ void SetJavaLauncherPlatformProps() {
    /* Linux only */
 #ifdef __linux__
     const char *substr = "-Dsun.java.launcher.pid=";
-    char *pid_prop_str = (char *)JLI_MemAlloc(JLI_StrLen(substr) + MAX_PID_STR_SZ + 1);
-    sprintf(pid_prop_str, "%s%d", substr, getpid());
+    size_t pid_prop_str_size = JLI_StrLen(substr) + MAX_PID_STR_SZ + 1;
+    char *pid_prop_str = (char *)JLI_MemAlloc(pid_prop_str_size);
+    snprintf(pid_prop_str, pid_prop_str_size, "%s%d", substr, getpid());
     AddOption(pid_prop_str, NULL);
 #endif /* __linux__ */
 }

--- a/src/java.base/unix/native/libnet/NetworkInterface.c
+++ b/src/java.base/unix/native/libnet/NetworkInterface.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1227,7 +1227,7 @@ static netif *enumIPv6Interfaces(JNIEnv *env, int sock, netif *ifs) {
             char addr6[40];
             struct sockaddr_in6 addr;
 
-            sprintf(addr6, "%s:%s:%s:%s:%s:%s:%s:%s",
+            snprintf(addr6, sizeof(addr6), "%s:%s:%s:%s:%s:%s:%s:%s",
                     addr6p[0], addr6p[1], addr6p[2], addr6p[3],
                     addr6p[4], addr6p[5], addr6p[6], addr6p[7]);
 

--- a/src/java.base/unix/native/libnet/net_util_md.c
+++ b/src/java.base/unix/native/libnet/net_util_md.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -431,7 +431,7 @@ void NET_ThrowUnknownHostExceptionWithGaiError(JNIEnv *env,
     buf = (char *) malloc(size);
     if (buf) {
         jstring s;
-        sprintf(buf, format, hostname, error_string);
+        snprintf(buf, size, format, hostname, error_string);
         s = JNU_NewStringPlatform(env, buf);
         if (s != NULL) {
             jobject x = JNU_NewObjectByName(env,

--- a/src/java.base/windows/native/libjava/Console_md.c
+++ b/src/java.base/windows/native/libjava/Console_md.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -56,9 +56,9 @@ Java_java_io_Console_encoding(JNIEnv *env, jclass cls)
     char buf[64];
     int cp = GetConsoleCP();
     if (cp >= 874 && cp <= 950)
-        sprintf(buf, "ms%d", cp);
+        snprintf(buf, sizeof(buf), "ms%d", cp);
     else
-        sprintf(buf, "cp%d", cp);
+        snprintf(buf, sizeof(buf), "cp%d", cp);
     return JNU_NewStringPlatform(env, buf);
 }
 

--- a/src/java.base/windows/native/libjava/TimeZone_md.c
+++ b/src/java.base/windows/native/libjava/TimeZone_md.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -122,7 +122,7 @@ getValueInRegistry(HKEY hKey,
 /*
  * Produces custom name "GMT+hh:mm" from the given bias in buffer.
  */
-static void customZoneName(LONG bias, char *buffer) {
+static void customZoneName(LONG bias, char *buffer, size_t bufSize) {
     LONG gmtOffset;
     int sign;
 
@@ -134,7 +134,7 @@ static void customZoneName(LONG bias, char *buffer) {
         sign = 1;
     }
     if (gmtOffset != 0) {
-        sprintf(buffer, "GMT%c%02d:%02d",
+        snprintf(buffer, bufSize, "GMT%c%02d:%02d",
                 ((sign >= 0) ? '+' : '-'),
                 gmtOffset / 60,
                 gmtOffset % 60);
@@ -146,7 +146,7 @@ static void customZoneName(LONG bias, char *buffer) {
 /*
  * Gets the current time zone entry in the "Time Zones" registry.
  */
-static int getWinTimeZone(char *winZoneName)
+static int getWinTimeZone(char *winZoneName, size_t winZoneNameBufSize)
 {
     DYNAMIC_TIME_ZONE_INFORMATION dtzi;
     DWORD timeType;
@@ -173,7 +173,7 @@ static int getWinTimeZone(char *winZoneName)
      */
     if (dtzi.TimeZoneKeyName[0] != 0) {
         if (dtzi.DynamicDaylightTimeDisabled) {
-            customZoneName(dtzi.Bias, winZoneName);
+            customZoneName(dtzi.Bias, winZoneName, winZoneNameBufSize);
             return VALUE_GMTOFFSET;
         }
         wcstombs(winZoneName, dtzi.TimeZoneKeyName, MAX_ZONE_CHAR);
@@ -206,7 +206,7 @@ static int getWinTimeZone(char *winZoneName)
          * is disabled.
          */
         if (val == 1) {
-            customZoneName(dtzi.Bias, winZoneName);
+            customZoneName(dtzi.Bias, winZoneName, winZoneNameBufSize);
             (void) RegCloseKey(hKey);
             return VALUE_GMTOFFSET;
         }
@@ -251,7 +251,7 @@ static int getWinTimeZone(char *winZoneName)
             if (ret == ERROR_SUCCESS) {
                 if (val == 1 && tzi.DaylightDate.wMonth != 0) {
                     (void) RegCloseKey(hKey);
-                    customZoneName(tzi.Bias, winZoneName);
+                    customZoneName(tzi.Bias, winZoneName, winZoneNameBufSize);
                     return VALUE_GMTOFFSET;
                 }
             }
@@ -519,7 +519,7 @@ char *findJavaTZ_md(const char *java_home_dir)
     char *std_timezone = NULL;
     int  result;
 
-    result = getWinTimeZone(winZoneName);
+    result = getWinTimeZone(winZoneName, sizeof(winZoneName));
 
     if (result != VALUE_UNKNOWN) {
         if (result == VALUE_GMTOFFSET) {
@@ -569,6 +569,6 @@ getGMTOffsetID()
         }
     }
 
-    customZoneName(bias, zonename);
+    customZoneName(bias, zonename, sizeof(zonename));
     return _strdup(zonename);
 }

--- a/src/java.base/windows/native/libjava/java_props_md.c
+++ b/src/java.base/windows/native/libjava/java_props_md.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -139,18 +139,19 @@ getEncodingInternal(LCID lcid)
 
 static char* getConsoleEncoding()
 {
-    char* buf = malloc(16);
+    size_t buflen = 16;
+    char* buf = malloc(buflen);
     int cp;
     if (buf == NULL) {
         return NULL;
     }
     cp = GetConsoleCP();
     if (cp >= 874 && cp <= 950)
-        sprintf(buf, "ms%d", cp);
+        snprintf(buf, buflen, "ms%d", cp);
     else if (cp == 65001)
-        sprintf(buf, "UTF-8");
+        snprintf(buf, buflen, "UTF-8");
     else
-        sprintf(buf, "cp%d", cp);
+        snprintf(buf, buflen, "cp%d", cp);
     return buf;
 }
 
@@ -588,7 +589,7 @@ GetJavaProperties(JNIEnv* env)
             sprops.os_name = "Windows (unknown)";
             break;
         }
-        sprintf(buf, "%d.%d", majorVersion, minorVersion);
+        snprintf(buf, sizeof(buf), "%d.%d", majorVersion, minorVersion);
         sprops.os_version = _strdup(buf);
 #if _M_AMD64
         sprops.os_arch = "amd64";

--- a/src/java.base/windows/native/libnet/net_util_md.c
+++ b/src/java.base/windows/native/libnet/net_util_md.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -190,7 +190,7 @@ NET_ThrowNew(JNIEnv *env, int errorNum, char *msg)
     if (excP == NULL) {
         excP = "SocketException";
     }
-    sprintf(exc, "%s%s", JNU_JAVANETPKG, excP);
+    snprintf(exc, sizeof(exc), "%s%s", JNU_JAVANETPKG, excP);
     JNU_ThrowByName(env, exc, fullMsg);
 }
 


### PR DESCRIPTION
8308801: update for deprecated sprintf for libnet in java.base
https://github.com/ibmruntimes/openj9-openjdk-jdk17/commit/152d486

8308022: update for deprecated sprintf for java.base
https://github.com/ibmruntimes/openj9-openjdk-jdk17/commit/6af76ec98f9