### PR TITLE
Check if OpenSSL is in FIPS mode and use Java for some algorithms

### DIFF
--- a/closed/src/java.base/share/native/libjncrypto/NativeCrypto.c
+++ b/closed/src/java.base/share/native/libjncrypto/NativeCrypto.c
@@ -82,6 +82,9 @@ int OSSL102_RSA_set0_crt_params(RSA *, BIGNUM *, BIGNUM *, BIGNUM *);
 # define EVP_CTRL_AEAD_SET_TAG     EVP_CTRL_GCM_SET_TAG
 #endif
 
+/* Whether loaded library is in FIPS mode. */
+static jboolean OSSL_IS_FIPS;
+
 /* Header for EC algorithm */
 jboolean OSSL_ECGF2M;
 int setECPublicCoordinates(EC_KEY *, BIGNUM *, BIGNUM *, int);
@@ -365,6 +368,18 @@ static jlong extractVersionToJlong(const char *astring)
 }
 
 static void *crypto_library = NULL;
+
+/*
+ * Class:     jdk_crypto_jniprovider_NativeCrypto
+ * Method:    isOpenSSLFIPS
+ * Signature: ()Z
+ */
+JNIEXPORT jboolean JNICALL Java_jdk_crypto_jniprovider_NativeCrypto_isOpenSSLFIPS
+  (JNIEnv *env, jclass clazz)
+{
+    return OSSL_IS_FIPS;
+}
+
 /*
  * Class:     jdk_crypto_jniprovider_NativeCrypto
  * Method:    loadCrypto
@@ -443,6 +458,25 @@ JNIEXPORT jlong JNICALL Java_jdk_crypto_jniprovider_NativeCrypto_loadCrypto
     if (traceEnabled) {
         fprintf(stderr, "Supported OpenSSL version: %s\n", openssl_version);
         fflush(stderr);
+    }
+
+    /* Check whether the loaded OpenSSL library is in FIPS mode. */
+    if (ossl_ver >= OPENSSL_VERSION_3_0_0) {
+        typedef int OSSL_fipsmode_t(OSSL_LIB_CTX *);
+        OSSL_fipsmode_t *ossl_fipsmode = (OSSL_fipsmode_t *)find_crypto_symbol(crypto_library, "EVP_default_properties_is_fips_enabled");
+        if ((NULL != ossl_fipsmode) && (1 == (*ossl_fipsmode)(NULL))) {
+            OSSL_IS_FIPS = JNI_TRUE;
+        } else {
+            OSSL_IS_FIPS = JNI_FALSE;
+        }
+    } else {
+        typedef int OSSL_fipsmode_t(void);
+        OSSL_fipsmode_t *ossl_fipsmode = (OSSL_fipsmode_t *)find_crypto_symbol(crypto_library, "FIPS_mode");
+        if ((NULL != ossl_fipsmode) && (1 == (*ossl_fipsmode)())) {
+            OSSL_IS_FIPS = JNI_TRUE;
+        } else {
+            OSSL_IS_FIPS = JNI_FALSE;
+        }
     }
 
     /* Load the function symbols for OpenSSL errors. */

--- a/src/java.base/share/classes/com/sun/crypto/provider/SunJCE.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/SunJCE.java
@@ -24,7 +24,7 @@
  */
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2018, 2023 All Rights Reserved
+ * (c) Copyright IBM Corp. 2018, 2024 All Rights Reserved
  * ===========================================================================
  */
 
@@ -279,7 +279,10 @@ public final class SunJCE extends Provider {
 
         attrs.clear();
         attrs.put("SupportedKeyFormats", "RAW");
-        if (useNativeChaCha20Cipher && (NativeCrypto.getVersionIfAvailable() >= NativeCrypto.OPENSSL_VERSION_1_1_0)) {
+        if (useNativeChaCha20Cipher
+            && NativeCrypto.isAlgorithmAvailable("ChaCha20")
+            && (NativeCrypto.getVersionIfAvailable() >= NativeCrypto.OPENSSL_VERSION_1_1_0)
+        ) {
             ps("Cipher",  "ChaCha20",
                     "com.sun.crypto.provider.NativeChaCha20Cipher$ChaCha20Only",
                     null, attrs);

--- a/src/java.base/share/classes/sun/security/provider/SunEntries.java
+++ b/src/java.base/share/classes/sun/security/provider/SunEntries.java
@@ -244,8 +244,7 @@ public final class SunEntries {
          */
         /* Don't use native MD5 on AIX due to an observed performance regression. */
         if (useNativeMD5
-            && NativeCrypto.isAllowedAndLoaded()
-            && NativeCrypto.isMD5Available()
+            && NativeCrypto.isAlgorithmAvailable("MD5")
             && !isAIX
         ) {
             providerMD5 = "sun.security.provider.NativeMD5";


### PR DESCRIPTION
If the `OpenSSL` library used is in `FIPS` mode, avoid using it for algorithms that are not `FIPS` compliant and revert to the original Java implementation.

Back-ported by: https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/867

Signed-off-by: Kostas Tsiounis <kostas.tsiounis@ibm.com>