### PR TITLE
Add the test cases for Restricted Security Mode

### DIFF
--- a/closed/test/jdk/TEST.ROOT
+++ b/closed/test/jdk/TEST.ROOT
@@ -1,0 +1,23 @@
+# ===========================================================================
+# (c) Copyright IBM Corp. 2024, 2024 All Rights Reserved
+# ===========================================================================
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.
+#
+# IBM designates this particular file as subject to the "Classpath" exception
+# as provided by IBM in the LICENSE file that accompanied this code.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, see <http://www.gnu.org/licenses/>.
+# ===========================================================================
+
+# Path to libraries in the topmost test directory. This is needed so @library
+# does not need ../../../ notation to reach them.
+external.lib.roots = ../../../

--- a/closed/test/jdk/openj9/internal/security/TestProperties.java
+++ b/closed/test/jdk/openj9/internal/security/TestProperties.java
@@ -1,0 +1,182 @@
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2024, 2024 All Rights Reserved
+ * ===========================================================================
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * IBM designates this particular file as subject to the "Classpath" exception
+ * as provided by IBM in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, see <http://www.gnu.org/licenses/>.
+ *
+ * ===========================================================================
+ */
+
+/*
+ * @test
+ * @summary Test Restricted Security Mode Properties
+ * @library /test/lib
+ * @run junit TestProperties
+ */
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.security.Provider;
+import java.security.Security;
+
+import java.util.stream.Stream;
+
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+
+public class TestProperties {
+
+    private static Stream<Arguments> patternMatches_expectedExitValue1() {
+        return Stream.of(
+                // 1 - Test profile - base profile misspell properties.
+                Arguments.of("Test-Profile.Base",
+                        System.getProperty("test.src") + "/property-java.security",
+                        "The property names: RestrictedSecurity.Test-Profile.Base.tls.disabledAlgorithmsWrongTypo "
+                            + "in profile RestrictedSecurity.Test-Profile.Base \\(or a base profile\\) are not recognized"),
+                // 2 - Test profile - extenstion profile misspell properties.
+                Arguments.of("Test-Profile.Extended_1",
+                        System.getProperty("test.src") + "/property-java.security",
+                        "The property names: RestrictedSecurity.Test-Profile.Extended_1.desc.nameWrongTypo, "
+                            + "RestrictedSecurity.Test-Profile.Extended_1.jce.providerWrongTypo in profile "
+                            + "RestrictedSecurity.Test-Profile.Extended_1 \\(or a base profile\\) are not recognized"),
+                // 3 - Test profile - extension profile from another extension profile misspell properties.
+                Arguments.of("Test-Profile.Extended_2",
+                        System.getProperty("test.src") + "/property-java.security",
+                        "The property names: RestrictedSecurity.Test-Profile.Extended_2.jce.providerWrongTypo "
+                            + "in profile RestrictedSecurity.Test-Profile.Extended_2 \\(or a base profile\\) are not recognized"),
+                // 4 - Test profile - profile not exist.
+                Arguments.of("Test-Profile-NotExist.Base",
+                        System.getProperty("test.src") + "/property-java.security",
+                        "Test-Profile-NotExist.Base is not present in the java.security file."),
+                // 5 - Test profile - Multi Default profile.
+                Arguments.of("Test-Profile-MultiDefault",
+                        System.getProperty("test.src") + "/property-java.security",
+                        "Multiple default RestrictedSecurity profiles for Test-Profile-MultiDefault"),
+                // 6 - Test profile - no default profile.
+                Arguments.of("Test-Profile-NoDefault",
+                        System.getProperty("test.src") + "/property-java.security",
+                        "No default RestrictedSecurity profile was found for Test-Profile-NoDefault"),
+                // 7 - Test profile - base profile does not exist.
+                Arguments.of("Test-Profile.Extended_3",
+                        System.getProperty("test.src") + "/property-java.security",
+                        "RestrictedSecurity.Test-Profile.BaseNotExist that is supposed to extend \\'RestrictedSecurity.Test-Profile.Extended_3\\' "
+                            + "is not present in the java.security file or any appended files"),
+                // 8 - Test profile - base profile not full profile name.
+                Arguments.of("Test-Profile.Extended_4",
+                        System.getProperty("test.src") + "/property-java.security",
+                        "RestrictedSecurity.BaseNotFullProfileName that is supposed to extend \\'RestrictedSecurity.Test-Profile.Extended_4\\' "
+                            + "is not a full profile name"),
+                // 9 - Test profile - base profile without hash value.
+                Arguments.of("Test-Profile-BaseWithoutHash",
+                        System.getProperty("test.src") + "/property-java.security",
+                        "Test-Profile-BaseWithoutHash is a base profile, so a hash value is mandatory"),
+                // 10 - Test profile - incorrect definition of hash value.
+                Arguments.of("Test-Profile-Hash_1",
+                        System.getProperty("test.src") + "/property-java.security",
+                        "Incorrect definition of hash value for RestrictedSecurity.Test-Profile-Hash_1"),
+                // 11 - Test profile - incorrect hash value.
+                Arguments.of("Test-Profile-Hash_2",
+                        System.getProperty("test.src") + "/property-java.security",
+                        "Hex produced from profile is not the same is a base profile, so a hash value is mandatory"),
+                // 12 - Test property - property not appendable.
+                Arguments.of("Test-Profile-SetProperty.Extension_1",
+                        System.getProperty("test.src") + "/property-java.security",
+                        "Property \\'jdkSecureRandomProvider\\' is not appendable"),
+                // 13 - Test property - property does not exist in parent profile, cannot append.
+                Arguments.of("Test-Profile-SetProperty.Extension_2",
+                        System.getProperty("test.src") + "/property-java.security",
+                        "Property \\'jdkTlsDisabledNamedCurves\\' does not exist in parent profile or java.security file. Cannot append"),
+                // 14 - Test property - property value is not in existing values.
+                Arguments.of("Test-Profile-SetProperty.Extension_3",
+                        System.getProperty("test.src") + "/property-java.security",
+                        "Value \\'TestDisabledlgorithms\\' is not in existing values"),
+                // 15 - Test property - policy sunset.
+                Arguments.of("Test-Profile-PolicySunset.Base",
+                        System.getProperty("test.src") + "/property-java.security",
+                        "Restricted security policy expired"),
+                // 16 - Test property - policy sunset format.
+                Arguments.of("Test-Profile-PolicySunsetFormat.Base",
+                        System.getProperty("test.src") + "/property-java.security",
+                        "Restricted security policy sunset date is incorrect, the correct format is yyyy-MM-dd"),
+                // 17 - Test property - secure random check 1.
+                Arguments.of("Test-Profile-SecureRandomCheck_1",
+                        System.getProperty("test.src") + "/property-java.security",
+                        "Restricted security mode secure random is missing"),
+                // 18 - Test property - secure random check 2.
+                Arguments.of("Test-Profile-SecureRandomCheck_2",
+                        System.getProperty("test.src") + "/property-java.security",
+                        "Restricted security mode secure random is missing"),
+                // 19 - Test constraint - constraint check 1.
+                Arguments.of("Test-Profile-Constraint_1",
+                        System.getProperty("test.src") + "/property-java.security",
+                        "Provider format is incorrect"),
+                // 20 - Test constraint - constraint check 2.
+                Arguments.of("Test-Profile-Constraint_2",
+                        System.getProperty("test.src") + "/property-java.security",
+                        "Incorrect constraint definition for provider"),
+                // 21 - Test constraint - constraint check 3.
+                Arguments.of("Test-Profile-Constraint_3",
+                        System.getProperty("test.src") + "/property-java.security",
+                        "Incorrect constraint definition for provider"),
+                // 22 - Test constraint - constraint attributes check.
+                Arguments.of("Test-Profile-Constraint_Attributes",
+                        System.getProperty("test.src") + "/property-java.security",
+                        "Constraint attributes format is incorrect"),
+                // 23 - Test constraint - constraint changed 1.
+                Arguments.of("Test-Profile-ConstraintChanged_1.Extension",
+                        System.getProperty("test.src") + "/property-java.security",
+                        "Cannot append or remove constraints since the provider (.*?) "
+                            + "wasn't in this position in the profile extended"),
+                // 24 - Test constraint - constraint changed 2.
+                Arguments.of("Test-Profile-ConstraintChanged_2.Extension",
+                        System.getProperty("test.src") + "/property-java.security",
+                        "Constraint (.*?)is not part of existing constraints"),
+                // 25 - Test constraint - constraint changed 3.
+                Arguments.of("Test-Profile-ConstraintChanged_3.Base",
+                        System.getProperty("test.src") + "/property-java.security",
+                        "You cannot add or remove to provider (.*?). This is the base profile.")
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("patternMatches_expectedExitValue1")
+    public void shouldContain_expectedExitValue1(String customprofile, String securityPropertyFile, String expected) throws Exception {
+        OutputAnalyzer outputAnalyzer = ProcessTools.executeTestJava(
+                "-Dsemeru.fips=true",
+                "-Dsemeru.customprofile=" + customprofile,
+                "-Djava.security.properties=" + securityPropertyFile,
+                "TestProperties"
+        );
+        outputAnalyzer.reportDiagnosticSummary();
+        outputAnalyzer.shouldHaveExitValue(1).shouldMatch(expected);
+    }
+
+    public static void main(String[] args) {
+        // Something to trigger "properties" debug output.
+        try {
+            for (Provider provider : Security.getProviders()) {
+                System.out.println("Provider Name: " + provider.getName());
+                System.out.println("Provider Version: " + provider.getVersionStr());
+            }
+        } catch (Exception e) {
+            System.out.println(e);
+        }
+    }
+}

--- a/closed/test/jdk/openj9/internal/security/TestProviders.java
+++ b/closed/test/jdk/openj9/internal/security/TestProviders.java
@@ -1,0 +1,159 @@
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2024, 2024 All Rights Reserved
+ * ===========================================================================
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * IBM designates this particular file as subject to the "Classpath" exception
+ * as provided by IBM in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, see <http://www.gnu.org/licenses/>.
+ *
+ * ===========================================================================
+ */
+
+/*
+ * @test
+ * @summary Test Restricted Security Mode Provider List
+ * @library /test/lib
+ * @run junit TestProviders
+ */
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.security.Provider;
+import java.security.Security;
+
+import java.util.stream.Stream;
+
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+
+public class TestProviders {
+
+    private static Stream<Arguments> patternMatches_expectedExitValue0() {
+        return Stream.of(
+                // Test strict profile provider list.
+                Arguments.of("TestBase.Version",
+                        System.getProperty("test.src") + "/provider-java.security",
+                        "(?s)(?=.*Sun)(?=.*\\bSunJCE\\b)(?=.*SunJSSE)"),
+                // Test default profile provider list.
+                Arguments.of("TestBase",
+                        System.getProperty("test.src") + "/provider-java.security",
+                        "(?s)(?=.*Sun)(?=.*SunRsaSign)(?=.*SunEC)(?=.*SunJSSE)"
+                            + "(?=.*SunJCE)(?=.*SunJGSS)(?=.*SunSASL)"
+                            + "(?=.*XMLDSig)(?=.*SunPCSC)(?=.*JdkLDAP)(?=.*JdkSASL)"),
+                // Test extended profile provider list.
+                Arguments.of("TestBase.Version-Extended",
+                        System.getProperty("test.src") + "/provider-java.security",
+                        "(?s)(?=.*Sun)(?=.*SunRsaSign)(?=.*SunEC)(?=.*SunJSSE)"
+                            + "(?=.*SunJCE)(?=.*SunJGSS)(?=.*SunSASL)"
+                            + "(?=.*XMLDSig)(?=.*SunPCSC)(?=.*JdkLDAP)(?=.*JdkSASL)"),
+                // Test update provider list with value.
+                Arguments.of("Test-Profile.Updated_1",
+                        System.getProperty("test.src") + "/provider-java.security",
+                        "(?s)(?=.*Sun)(?=.*\\bSunJCE\\b)(?=.*SunSASL)"),
+                // Test update provider list with null.
+                Arguments.of("Test-Profile.Updated_2",
+                        System.getProperty("test.src") + "/provider-java.security",
+                        "(?s)(?=.*Sun)(?=.*\\bSunJCE\\b)(?=.*SunJSSE)")
+        );
+    }
+
+    private static Stream<Arguments> patternMatches_expectedExitValue1() {
+        return Stream.of(
+                // Test base profile - provider order numbers are not consecutive.
+                Arguments.of("Test-Profile.Base",
+                        System.getProperty("test.src") + "/provider-java.security",
+                        "The order numbers of providers in profile RestrictedSecurity.Test-Profile.Base "
+                            + "\\(or a base profile\\) are not consecutive"),
+                // Test extended profile, provider order numbers are not consecutive.
+                Arguments.of("Test-Profile.Extended_1",
+                        System.getProperty("test.src") + "/provider-java.security",
+                        "The order numbers of providers in profile RestrictedSecurity.Test-Profile.Extended_1 "
+                            + "\\(or a base profile\\) are not consecutive."),
+                // Test extended profile from another extended profile, provider order numbers are not consecutive.
+                Arguments.of("Test-Profile.Extended_2",
+                        System.getProperty("test.src") + "/provider-java.security",
+                        "The order numbers of providers in profile RestrictedSecurity.Test-Profile.Extended_2 "
+                            + "\\(or a base profile\\) are not consecutive."),
+                // Test update provider list with empty, the empty is the last one in base profile.
+                Arguments.of("Test-Profile.Updated_3",
+                        System.getProperty("test.src") + "/provider-java.security",
+                        "Cannot add a provider in position \\d+ after removing the ones in previous positions"),
+                // Test update provider list with empty, the empty is NOT the last one in base profile.
+                Arguments.of("Test-Profile.Updated_4",
+                        System.getProperty("test.src") + "/provider-java.security",
+                        "Cannot specify an empty provider in position \\d+ when non-empty ones are specified after it"),
+                // Test base profile - one of the provider in list empty.
+                Arguments.of("Test-Profile.BaseOneProviderEmpty",
+                        System.getProperty("test.src") + "/provider-java.security",
+                        "Cannot specify an empty provider in position \\d+. Nothing specified before"),
+                // Test extended profile - one of the provider in list empty.
+                Arguments.of("Test-Profile.ExtendedOneProviderEmpty",
+                        System.getProperty("test.src") + "/provider-java.security",
+                        "Cannot specify an empty provider in position \\d+. Nothing specified before"),
+                // Test base profile - no provider list.
+                Arguments.of("Test-Profile.BaseNoProviderList",
+                        System.getProperty("test.src") + "/provider-java.security",
+                        "No providers are specified as part of the Restricted Security profile"),
+                // Test profile - provider must be specified using the fully-qualified class name.
+                Arguments.of("Test-Profile.ProviderClassName",
+                        System.getProperty("test.src") + "/provider-java.security",
+                        "Provider must be specified using the fully-qualified class name"),
+                // Test profile - provider format is incorrect.
+                Arguments.of("Test-Profile.ProviderFormat",
+                        System.getProperty("test.src") + "/provider-java.security",
+                        "Provider format is incorrect")
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("patternMatches_expectedExitValue0")
+    public void shouldContain_expectedExitValue0(String customprofile, String securityPropertyFile, String expected) throws Exception {
+        OutputAnalyzer outputAnalyzer = ProcessTools.executeTestJava(
+                "-Dsemeru.fips=true",
+                "-Dsemeru.customprofile=" + customprofile,
+                "-Djava.security.properties=" + securityPropertyFile,
+                "TestProviders"
+        );
+        outputAnalyzer.reportDiagnosticSummary();
+        outputAnalyzer.shouldHaveExitValue(0).shouldMatch(expected);
+    }
+
+    @ParameterizedTest
+    @MethodSource("patternMatches_expectedExitValue1")
+    public void shouldContain_expectedExitValue1(String customprofile, String securityPropertyFile, String expected) throws Exception {
+        OutputAnalyzer outputAnalyzer = ProcessTools.executeTestJava(
+                "-Dsemeru.fips=true",
+                "-Dsemeru.customprofile=" + customprofile,
+                "-Djava.security.properties=" + securityPropertyFile,
+                "TestProviders"
+        );
+        outputAnalyzer.reportDiagnosticSummary();
+        outputAnalyzer.shouldHaveExitValue(1).shouldMatch(expected);
+    }
+
+    public static void main(String[] args) {
+        try {
+            for (Provider provider : Security.getProviders()) {
+                System.out.println("Provider Name: " + provider.getName());
+                System.out.println("Provider Version: " + provider.getVersionStr());
+            }
+        } catch (Exception e) {
+            System.out.println(e);
+        }
+    }
+}

--- a/closed/test/jdk/openj9/internal/security/property-java.security
+++ b/closed/test/jdk/openj9/internal/security/property-java.security
@@ -1,0 +1,527 @@
+# ===========================================================================
+# (c) Copyright IBM Corp. 2024, 2024 All Rights Reserved
+# ===========================================================================
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.
+#
+# IBM designates this particular file as subject to the "Classpath" exception
+# as provided by IBM in the LICENSE file that accompanied this code.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, see <http://www.gnu.org/licenses/>.
+# ===========================================================================
+
+RestrictedSecurity.TestBase.Version.desc.name = Test Base Profile
+RestrictedSecurity.TestBase.Version.desc.default = false
+RestrictedSecurity.TestBase.Version.desc.fips = true
+RestrictedSecurity.TestBase.Version.desc.hash = SHA256:0ca32676ac2ae92d0469cbf293f3a69416c5d0312c80473319452f4d6995d234
+RestrictedSecurity.TestBase.Version.desc.number = Certificate #XXX
+RestrictedSecurity.TestBase.Version.desc.policy = https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/
+RestrictedSecurity.TestBase.Version.desc.sunsetDate = 2026-09-21
+RestrictedSecurity.TestBase.Version.fips.mode = 140-3
+
+RestrictedSecurity.TestBase.Version.tls.disabledNamedCurves =
+RestrictedSecurity.TestBase.Version.tls.disabledAlgorithms =
+RestrictedSecurity.TestBase.Version.tls.ephemeralDHKeySize =
+RestrictedSecurity.TestBase.Version.tls.legacyAlgorithms =
+
+RestrictedSecurity.TestBase.Version.jce.certpath.disabledAlgorithms =
+RestrictedSecurity.TestBase.Version.jce.legacyAlgorithms =
+RestrictedSecurity.TestBase.Version.jce.provider.1 = sun.security.provider.Sun
+RestrictedSecurity.TestBase.Version.jce.provider.2 = com.sun.crypto.provider.SunJCE
+RestrictedSecurity.TestBase.Version.jce.provider.3 = sun.security.ssl.SunJSSE
+
+RestrictedSecurity.TestBase.Version.javax.net.ssl.keyStore = NONE
+RestrictedSecurity.TestBase.Version.securerandom.provider = OpenJCEPlusFIPS
+RestrictedSecurity.TestBase.Version.securerandom.algorithm = SHA512DRBG
+
+RestrictedSecurity.TestBase.Version-Extended.desc.name = Test Base Profile Extended
+RestrictedSecurity.TestBase.Version-Extended.desc.default = true
+RestrictedSecurity.TestBase.Version-Extended.extends = RestrictedSecurity.TestBase.Version
+RestrictedSecurity.TestBase.Version-Extended.tls.disabledAlgorithms =
+
+RestrictedSecurity.TestBase.Version-Extended.jce.provider.1 = sun.security.provider.Sun
+RestrictedSecurity.TestBase.Version-Extended.jce.provider.2 = sun.security.rsa.SunRsaSign
+RestrictedSecurity.TestBase.Version-Extended.jce.provider.3 = sun.security.ec.SunEC
+RestrictedSecurity.TestBase.Version-Extended.jce.provider.4 = sun.security.ssl.SunJSSE
+RestrictedSecurity.TestBase.Version-Extended.jce.provider.5 = com.sun.crypto.provider.SunJCE
+RestrictedSecurity.TestBase.Version-Extended.jce.provider.6 = sun.security.jgss.SunProvider
+RestrictedSecurity.TestBase.Version-Extended.jce.provider.7 = com.sun.security.sasl.Provider
+RestrictedSecurity.TestBase.Version-Extended.jce.provider.8 = org.jcp.xml.dsig.internal.dom.XMLDSigRI
+RestrictedSecurity.TestBase.Version-Extended.jce.provider.9 = sun.security.smartcardio.SunPCSC
+RestrictedSecurity.TestBase.Version-Extended.jce.provider.10 = sun.security.provider.certpath.ldap.JdkLDAP
+RestrictedSecurity.TestBase.Version-Extended.jce.provider.11 = com.sun.security.sasl.gsskerb.JdkSASL
+
+#
+# Test-Profile.Base
+# Test profile - base profile misspell properties
+#
+RestrictedSecurity.Test-Profile.Base.desc.name = Test-Profile.Base
+RestrictedSecurity.Test-Profile.Base.desc.default = true
+RestrictedSecurity.Test-Profile.Base.desc.fips = true
+RestrictedSecurity.Test-Profile.Base.desc.hash = SHA256:4fab3014e91072587e76c6ebb393ceea710d76582069d46a70eab31c30f57e45
+RestrictedSecurity.Test-Profile.Base.desc.number = Certificate #XXX
+RestrictedSecurity.Test-Profile.Base.desc.policy = https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/
+RestrictedSecurity.Test-Profile.Base.desc.sunsetDate = 2026-09-21
+RestrictedSecurity.Test-Profile.Base.fips.mode = 140-3
+
+RestrictedSecurity.Test-Profile.Base.tls.disabledAlgorithmsWrongTypo =
+
+RestrictedSecurity.Test-Profile.Base.jce.provider.1 = sun.security.provider.Sun
+RestrictedSecurity.Test-Profile.Base.jce.provider.2 = com.sun.crypto.provider.SunJCE
+RestrictedSecurity.Test-Profile.Base.jce.provider.3 = sun.security.ssl.SunJSSE
+
+RestrictedSecurity.Test-Profile.Base.securerandom.provider = OpenJCEPlusFIPS
+RestrictedSecurity.Test-Profile.Base.securerandom.algorithm = SHA512DRBG
+
+#
+# Test-Profile.Extended_1
+# Test profile - extenstion profile misspell properties
+#
+RestrictedSecurity.Test-Profile.Extended_1.desc.nameWrongTypo = Test-Profile.Extended_1
+RestrictedSecurity.Test-Profile.Extended_1.desc.default = true
+RestrictedSecurity.Test-Profile.Extended_1.extends = RestrictedSecurity.TestBase.Version
+RestrictedSecurity.Test-Profile.Extended_1.tls.disabledAlgorithms =
+
+RestrictedSecurity.Test-Profile.Extended_1.jce.provider.1 = sun.security.provider.Sun
+RestrictedSecurity.Test-Profile.Extended_1.jce.provider.2 = com.sun.crypto.provider.SunJCE
+RestrictedSecurity.Test-Profile.Extended_1.jce.providerWrongTypo = sun.security.rsa.SunRsaSign
+RestrictedSecurity.Test-Profile.Extended_1.jce.provider.4 = sun.security.ec.SunEC
+RestrictedSecurity.Test-Profile.Extended_1.jce.provider.5 = sun.security.ssl.SunJSSE
+
+#
+# Test-Profile.Extended_2
+# Test profile - extension profile from another extension profile misspell properties
+#
+RestrictedSecurity.Test-Profile.Extended_2.desc.name = Test-Profile.Extended_2
+RestrictedSecurity.Test-Profile.Extended_2.desc.default = false
+RestrictedSecurity.Test-Profile.Extended_2.extends = RestrictedSecurity.TestBase.Version-Extended
+RestrictedSecurity.Test-Profile.Extended_2.tls.disabledAlgorithms =
+
+RestrictedSecurity.Test-Profile.Extended_2.jce.providerWrongTypo = sun.security.pkcs11.SunPKCS11
+
+#
+# Test-Profile-NotExist.Base
+# Test profile - profile not exist
+#
+
+#
+# Test-Profile-MultiDefault.Base
+# Test profile - Multi Default Base profile
+#
+RestrictedSecurity.Test-Profile-MultiDefault.Base.desc.name = Test-Profile-MultiDefault.Base
+RestrictedSecurity.Test-Profile-MultiDefault.Base.desc.default = true
+RestrictedSecurity.Test-Profile-MultiDefault.Base.desc.fips = true
+RestrictedSecurity.Test-Profile-MultiDefault.Base.desc.hash = SHA256:adf136024d9c047f3ffb1dac41e5f553eee5e7b6dec13bfc13b431a2a8a2525d
+RestrictedSecurity.Test-Profile-MultiDefault.Base.desc.number = Certificate #XXX
+RestrictedSecurity.Test-Profile-MultiDefault.Base.desc.policy = https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/
+RestrictedSecurity.Test-Profile-MultiDefault.Base.desc.sunsetDate = 2026-09-21
+RestrictedSecurity.Test-Profile-MultiDefault.Base.fips.mode = 140-3
+
+RestrictedSecurity.Test-Profile-MultiDefault.Base.jce.provider.1 = sun.security.provider.Sun
+RestrictedSecurity.Test-Profile-MultiDefault.Base.jce.provider.2 = com.sun.crypto.provider.SunJCE
+RestrictedSecurity.Test-Profile-MultiDefault.Base.jce.provider.3 = sun.security.ssl.SunJSSE
+
+RestrictedSecurity.Test-Profile-MultiDefault.Base.securerandom.provider = OpenJCEPlusFIPS
+RestrictedSecurity.Test-Profile-MultiDefault.Base.securerandom.algorithm = SHA512DRBG
+
+#
+# Test-Profile-MultiDefault.Extension
+# Test profile - Multi Default Extension profile
+#
+RestrictedSecurity.Test-Profile-MultiDefault.Extension.desc.name = Test-Profile-MultiDefault.Extension
+RestrictedSecurity.Test-Profile-MultiDefault.Extension.desc.default = true
+RestrictedSecurity.Test-Profile-MultiDefault.Extension.extends = RestrictedSecurity.Test-Profile-MultiDefault.Base
+RestrictedSecurity.Test-Profile-MultiDefault.Extension.tls.disabledAlgorithms =
+
+RestrictedSecurity.Test-Profile-MultiDefault.Extension.jce.provider.1 = sun.security.provider.Sun
+
+#
+# Test-Profile-NoDefault
+# Test profile - no default profile
+#
+RestrictedSecurity.Test-Profile-NoDefault.desc.name = Test-Profile-NoDefault
+RestrictedSecurity.Test-Profile-NoDefault.desc.default = false
+RestrictedSecurity.Test-Profile-NoDefault.extends = RestrictedSecurity.TestBase.Version
+RestrictedSecurity.Test-Profile-NoDefault.tls.disabledAlgorithms =
+
+RestrictedSecurity.Test-Profile-NoDefault.jce.providerWrongTypo.1 = sun.security.provider.Sun
+
+#
+# Test-Profile.Extended_3
+# Test profile - base profile not exist
+#
+RestrictedSecurity.Test-Profile.Extended_3.desc.name = Test-Profile.Extended_3
+RestrictedSecurity.Test-Profile.Extended_3.desc.default = false
+RestrictedSecurity.Test-Profile.Extended_3.extends = RestrictedSecurity.Test-Profile.BaseNotExist
+RestrictedSecurity.Test-Profile.Extended_3.tls.disabledAlgorithms =
+
+RestrictedSecurity.Test-Profile.Extended_3.jce.providerWrongTypo.1 = sun.security.provider.Sun
+
+#
+# Test-Profile.Extended_4
+# Test profile - base profile not full profile name
+#
+RestrictedSecurity.Test-Profile.Extended_4.desc.name = Test-Profile.Extended_4
+RestrictedSecurity.Test-Profile.Extended_4.desc.default = false
+RestrictedSecurity.Test-Profile.Extended_4.extends = RestrictedSecurity.BaseNotFullProfileName
+RestrictedSecurity.Test-Profile.Extended_4.tls.disabledAlgorithms =
+
+RestrictedSecurity.Test-Profile.Extended_4.jce.providerWrongTypo.1 = sun.security.provider.Sun
+
+#
+# Test-Profile-BaseWithoutHash
+# Test profile - base profile without hash value
+#
+RestrictedSecurity.Test-Profile-BaseWithoutHash.desc.name = Test-Profile-BaseWithoutHash
+RestrictedSecurity.Test-Profile-BaseWithoutHash.desc.default = true
+RestrictedSecurity.Test-Profile-BaseWithoutHash.desc.fips = true
+RestrictedSecurity.Test-Profile-BaseWithoutHash.desc.number = Certificate #XXX
+RestrictedSecurity.Test-Profile-BaseWithoutHash.desc.policy = https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/
+RestrictedSecurity.Test-Profile-BaseWithoutHash.desc.sunsetDate = 2026-09-21
+RestrictedSecurity.Test-Profile-BaseWithoutHash.fips.mode = 140-3
+
+RestrictedSecurity.Test-Profile-BaseWithoutHash.jce.provider.1 = sun.security.provider.Sun
+
+RestrictedSecurity.Test-Profile-BaseWithoutHash.securerandom.provider = OpenJCEPlusFIPS
+RestrictedSecurity.Test-Profile-BaseWithoutHash.securerandom.algorithm = SHA512DRBG
+
+#
+# Test-Profile-Hash_1
+# Test profile - incorrect definition of hash value
+#
+RestrictedSecurity.Test-Profile-Hash_1.desc.name = Test-Profile-Hash_1
+RestrictedSecurity.Test-Profile-Hash_1.desc.default = true
+RestrictedSecurity.Test-Profile-Hash_1.desc.fips = true
+RestrictedSecurity.Test-Profile-Hash_1.desc.hash = SHA2564fab3014e91072587e76c6ebb393ceea710d76582069d46a70eab31c30f57e45
+RestrictedSecurity.Test-Profile-Hash_1.desc.number = Certificate #XXX
+RestrictedSecurity.Test-Profile-Hash_1.desc.policy = https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/
+RestrictedSecurity.Test-Profile-Hash_1.desc.sunsetDate = 2026-09-21
+RestrictedSecurity.Test-Profile-Hash_1.fips.mode = 140-3
+
+RestrictedSecurity.Test-Profile-Hash_1.jce.provider.1 = sun.security.provider.Sun
+
+RestrictedSecurity.Test-Profile-Hash_1.securerandom.provider = OpenJCEPlusFIPS
+RestrictedSecurity.Test-Profile-Hash_1.securerandom.algorithm = SHA512DRBG
+
+#
+# Test-Profile-Hash_2
+# Test profile - incorrect hash value
+#
+RestrictedSecurity.Test-Profile-Hash_2.desc.name = Test-Profile-Hash_2
+RestrictedSecurity.Test-Profile-Hash_2.desc.default = true
+RestrictedSecurity.Test-Profile-Hash_2.desc.fips = true
+RestrictedSecurity.Test-Profile-Hash_2.desc.hash = SHA256:4fab3014e91072587e76c6ebb393ceea710d76582069d46a70eab31c30f57e45
+RestrictedSecurity.Test-Profile-Hash_2.desc.number = Certificate #XXX
+RestrictedSecurity.Test-Profile-Hash_2.desc.policy = https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/
+RestrictedSecurity.Test-Profile-Hash_2.desc.sunsetDate = 2026-09-21
+RestrictedSecurity.Test-Profile-Hash_2.fips.mode = 140-3
+
+RestrictedSecurity.Test-Profile-Hash_2.jce.provider.1 = sun.security.provider.Sun
+
+RestrictedSecurity.Test-Profile-Hash_2.securerandom.provider = OpenJCEPlusFIPS
+RestrictedSecurity.Test-Profile-Hash_2.securerandom.algorithm = SHA512DRBG
+
+#
+# Test-Profile-SetProperty.Base
+# Test profile set property base
+#
+RestrictedSecurity.Test-Profile-SetProperty.Base.desc.name = Test-Profile-SetProperty.Base
+RestrictedSecurity.Test-Profile-SetProperty.Base.desc.default = false
+RestrictedSecurity.Test-Profile-SetProperty.Base.desc.fips = true
+RestrictedSecurity.Test-Profile-SetProperty.Base.desc.hash = SHA256:c6348b840ab42f891e3bde552b8d908be37571804750312aabe8f17e48830564
+RestrictedSecurity.Test-Profile-SetProperty.Base.desc.number = Certificate #XXX
+RestrictedSecurity.Test-Profile-SetProperty.Base.desc.policy = https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/
+RestrictedSecurity.Test-Profile-SetProperty.Base.desc.sunsetDate = 2026-09-21
+RestrictedSecurity.Test-Profile-SetProperty.Base.fips.mode = 140-3
+
+RestrictedSecurity.Test-Profile-SetProperty.Base.tls.disabledAlgorithms = \
+    3DES_EDE_CBC, \
+    TLSv1, \
+    TLSv1.1, \
+    X25519, \
+    X448
+RestrictedSecurity.Test-Profile-SetProperty.Base.tls.ephemeralDHKeySize =
+
+RestrictedSecurity.Test-Profile-SetProperty.Base.jce.certpath.disabledAlgorithms =
+RestrictedSecurity.Test-Profile-SetProperty.Base.jce.provider.1 = sun.security.provider.Sun
+RestrictedSecurity.Test-Profile-SetProperty.Base.jce.provider.2 = com.sun.crypto.provider.SunJCE
+RestrictedSecurity.Test-Profile-SetProperty.Base.jce.provider.3 = sun.security.ssl.SunJSSE
+
+RestrictedSecurity.Test-Profile-SetProperty.Base.securerandom.provider = OpenJCEPlusFIPS
+RestrictedSecurity.Test-Profile-SetProperty.Base.securerandom.algorithm = SHA512DRBG
+
+#
+# Test-Profile-SetProperty.Extension_1
+# Test property - property not appendable
+#
+RestrictedSecurity.Test-Profile-SetProperty.Extension_1.desc.name = Test-Profile-SetProperty.Extension_1
+RestrictedSecurity.Test-Profile-SetProperty.Extension_1.desc.default = true
+RestrictedSecurity.Test-Profile-SetProperty.Extension_1.extends = RestrictedSecurity.Test-Profile-SetProperty.Base
+RestrictedSecurity.Test-Profile-SetProperty.Extension_1.securerandom.provider = + Sun
+
+RestrictedSecurity.Test-Profile-SetProperty.Extension_1.jce.provider.1 = sun.security.provider.Sun
+
+#
+# Test-Profile-SetProperty.Extension_2
+# Test property - property does not exist in parent profile, cannot append
+#
+RestrictedSecurity.Test-Profile-SetProperty.Extension_2.desc.name = Test-Profile-SetProperty.Extension_2
+RestrictedSecurity.Test-Profile-SetProperty.Extension_2.desc.default = true
+RestrictedSecurity.Test-Profile-SetProperty.Extension_2.extends = RestrictedSecurity.Test-Profile-SetProperty.Base
+RestrictedSecurity.Test-Profile-SetProperty.Extension_2.tls.disabledNamedCurves = + TestNamedCurves
+
+RestrictedSecurity.Test-Profile-SetProperty.Extension_2.jce.provider.1 = sun.security.provider.Sun
+
+#
+# Test-Profile-SetProperty.Extension_3
+# Test property - property value is not in existing values
+#
+RestrictedSecurity.Test-Profile-SetProperty.Extension_3.desc.name = Test-Profile-SetProperty.Extension_3
+RestrictedSecurity.Test-Profile-SetProperty.Extension_3.desc.default = true
+RestrictedSecurity.Test-Profile-SetProperty.Extension_3.extends = RestrictedSecurity.Test-Profile-SetProperty.Base
+RestrictedSecurity.Test-Profile-SetProperty.Extension_3.tls.disabledAlgorithms = - TestDisabledlgorithms
+
+RestrictedSecurity.Test-Profile-SetProperty.Extension_3.jce.provider.1 = sun.security.provider.Sun
+
+#
+# Test-Profile-PolicySunset.Base
+# Test property - policy sunset
+#
+RestrictedSecurity.Test-Profile-PolicySunset.Base.desc.name = Test-Profile-PolicySunset.Base
+RestrictedSecurity.Test-Profile-PolicySunset.Base.desc.default = true
+RestrictedSecurity.Test-Profile-PolicySunset.Base.desc.fips = true
+RestrictedSecurity.Test-Profile-PolicySunset.Base.desc.hash = SHA256:e71c49d65fd291efe75993ccbe6999e6cfb26bf9ef3e8424cb086c7e2a225ce6
+RestrictedSecurity.Test-Profile-PolicySunset.Base.desc.number = Certificate #XXX
+RestrictedSecurity.Test-Profile-PolicySunset.Base.desc.policy = https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/
+RestrictedSecurity.Test-Profile-PolicySunset.Base.desc.sunsetDate = 2023-09-21
+RestrictedSecurity.Test-Profile-PolicySunset.Base.fips.mode = 140-3
+
+RestrictedSecurity.Test-Profile-PolicySunset.Base.jce.provider.1 = sun.security.provider.Sun
+
+RestrictedSecurity.Test-Profile-PolicySunset.Base.securerandom.provider = OpenJCEPlusFIPS
+RestrictedSecurity.Test-Profile-PolicySunset.Base.securerandom.algorithm = SHA512DRBG
+
+#
+# Test-Profile-PolicySunsetFormat.Base
+# Test property - policy sunset format
+#
+RestrictedSecurity.Test-Profile-PolicySunsetFormat.Base.desc.name = Test-Profile-PolicySunsetFormat.Base
+RestrictedSecurity.Test-Profile-PolicySunsetFormat.Base.desc.default = true
+RestrictedSecurity.Test-Profile-PolicySunsetFormat.Base.desc.fips = true
+RestrictedSecurity.Test-Profile-PolicySunsetFormat.Base.desc.hash = SHA256:e71c49d65fd291efe75993ccbe6999e6cfb26bf9ef3e8424cb086c7e2a225ce6
+RestrictedSecurity.Test-Profile-PolicySunsetFormat.Base.desc.number = Certificate #XXX
+RestrictedSecurity.Test-Profile-PolicySunsetFormat.Base.desc.policy = https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/
+RestrictedSecurity.Test-Profile-PolicySunsetFormat.Base.desc.sunsetDate = 09-21-2024
+RestrictedSecurity.Test-Profile-PolicySunsetFormat.Base.fips.mode = 140-3
+
+RestrictedSecurity.Test-Profile-PolicySunsetFormat.Base.jce.provider.1 = sun.security.provider.Sun
+
+RestrictedSecurity.Test-Profile-PolicySunsetFormat.Base.securerandom.provider = OpenJCEPlusFIPS
+RestrictedSecurity.Test-Profile-PolicySunsetFormat.Base.securerandom.algorithm = SHA512DRBG
+
+#
+# Test-Profile-SecureRandomCheck_1
+# Test property - secure random check
+#
+RestrictedSecurity.Test-Profile-SecureRandomCheck_1.desc.name = Test-Profile-SecureRandomCheck_1
+RestrictedSecurity.Test-Profile-SecureRandomCheck_1.desc.default = true
+RestrictedSecurity.Test-Profile-SecureRandomCheck_1.desc.fips = true
+RestrictedSecurity.Test-Profile-SecureRandomCheck_1.desc.hash = SHA256:e71c49d65fd291efe75993ccbe6999e6cfb26bf9ef3e8424cb086c7e2a225ce6
+RestrictedSecurity.Test-Profile-SecureRandomCheck_1.desc.number = Certificate #XXX
+RestrictedSecurity.Test-Profile-SecureRandomCheck_1.desc.policy = https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/
+RestrictedSecurity.Test-Profile-SecureRandomCheck_1.desc.sunsetDate = 2026-09-21
+RestrictedSecurity.Test-Profile-SecureRandomCheck_1.fips.mode = 140-3
+
+RestrictedSecurity.Test-Profile-SecureRandomCheck_1.jce.provider.1 = sun.security.provider.Sun
+
+RestrictedSecurity.Test-Profile-SecureRandomCheck_1.securerandom.provider =
+RestrictedSecurity.Test-Profile-SecureRandomCheck_1.securerandom.algorithm = SHA512DRBG
+
+#
+# Test-Profile-SecureRandomCheck_2
+# Test property - secure random check
+#
+RestrictedSecurity.Test-Profile-SecureRandomCheck_2.desc.name = Test-Profile-SecureRandomCheck_2
+RestrictedSecurity.Test-Profile-SecureRandomCheck_2.desc.default = true
+RestrictedSecurity.Test-Profile-SecureRandomCheck_2.desc.fips = true
+RestrictedSecurity.Test-Profile-SecureRandomCheck_2.desc.hash = SHA256:e71c49d65fd291efe75993ccbe6999e6cfb26bf9ef3e8424cb086c7e2a225ce6
+RestrictedSecurity.Test-Profile-SecureRandomCheck_2.desc.number = Certificate #XXX
+RestrictedSecurity.Test-Profile-SecureRandomCheck_2.desc.policy = https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/
+RestrictedSecurity.Test-Profile-SecureRandomCheck_2.desc.sunsetDate = 2026-09-21
+RestrictedSecurity.Test-Profile-SecureRandomCheck_2.fips.mode = 140-3
+
+RestrictedSecurity.Test-Profile-SecureRandomCheck_2.jce.provider.1 = sun.security.provider.Sun
+
+RestrictedSecurity.Test-Profile-SecureRandomCheck_2.securerandom.provider = OpenJCEPlusFIPS
+
+#
+# Test-Profile-Constraint_1
+# Test constraint - constraint check 1
+#
+RestrictedSecurity.Test-Profile-Constraint_1.desc.name = Test-Profile-Constraint_1
+RestrictedSecurity.Test-Profile-Constraint_1.desc.default = true
+RestrictedSecurity.Test-Profile-Constraint_1.desc.fips = true
+RestrictedSecurity.Test-Profile-Constraint_1.desc.hash = SHA256:76dacdfdc5b5811d9b45e72b5b154de6419616556f8f7479819971bba89c41bb
+RestrictedSecurity.Test-Profile-Constraint_1.desc.number = Certificate #XXX
+RestrictedSecurity.Test-Profile-Constraint_1.desc.policy = https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/
+RestrictedSecurity.Test-Profile-Constraint_1.desc.sunsetDate = 2026-09-21
+RestrictedSecurity.Test-Profile-Constraint_1.fips.mode = 140-3
+
+RestrictedSecurity.Test-Profile-Constraint_1.jce.provider.1 = com.sun.crypto.provider.SunJCE  \
+    {AlgorithmParameterGenerator, AESGCM, *}, \
+    {AlgorithmParameterGenerator, CCM, *}]
+
+RestrictedSecurity.Test-Profile-Constraint_1.securerandom.provider = OpenJCEPlusFIPS
+RestrictedSecurity.Test-Profile-Constraint_1.securerandom.algorithm = SHA512DRBG
+
+#
+# Test-Profile-Constraint_2
+# Test constraint - constraint check 2
+#
+RestrictedSecurity.Test-Profile-Constraint_2.desc.name = Test-Profile-Constraint_2
+RestrictedSecurity.Test-Profile-Constraint_2.desc.default = true
+RestrictedSecurity.Test-Profile-Constraint_2.desc.fips = true
+RestrictedSecurity.Test-Profile-Constraint_2.desc.hash = SHA256:76dacdfdc5b5811d9b45e72b5b154de6419616556f8f7479819971bba89c41bb
+RestrictedSecurity.Test-Profile-Constraint_2.desc.number = Certificate #XXX
+RestrictedSecurity.Test-Profile-Constraint_2.desc.policy = https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/
+RestrictedSecurity.Test-Profile-Constraint_2.desc.sunsetDate = 2026-09-21
+RestrictedSecurity.Test-Profile-Constraint_2.fips.mode = 140-3
+
+RestrictedSecurity.Test-Profile-Constraint_2.jce.provider.1 = com.sun.crypto.provider.SunJCE [ \
+    {AlgorithmParameterGenerator, AESGCM, *} \
+    {AlgorithmParameterGenerator, CCM, *}]
+
+RestrictedSecurity.Test-Profile-Constraint_2.securerandom.provider = OpenJCEPlusFIPS
+RestrictedSecurity.Test-Profile-Constraint_2.securerandom.algorithm = SHA512DRBG
+
+#
+# Test-Profile-Constraint_3
+# Test constraint - constraint check 3
+#
+RestrictedSecurity.Test-Profile-Constraint_3.desc.name = Test-Profile-Constraint_3
+RestrictedSecurity.Test-Profile-Constraint_3.desc.default = true
+RestrictedSecurity.Test-Profile-Constraint_3.desc.fips = true
+RestrictedSecurity.Test-Profile-Constraint_3.desc.hash = SHA256:76dacdfdc5b5811d9b45e72b5b154de6419616556f8f7479819971bba89c41bb
+RestrictedSecurity.Test-Profile-Constraint_3.desc.number = Certificate #XXX
+RestrictedSecurity.Test-Profile-Constraint_3.desc.policy = https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/
+RestrictedSecurity.Test-Profile-Constraint_3.desc.sunsetDate = 2026-09-21
+RestrictedSecurity.Test-Profile-Constraint_3.fips.mode = 140-3
+
+RestrictedSecurity.Test-Profile-Constraint_3.jce.provider.1 = com.sun.crypto.provider.SunJCE [ {} ]
+
+RestrictedSecurity.Test-Profile-Constraint_3.securerandom.provider = OpenJCEPlusFIPS
+RestrictedSecurity.Test-Profile-Constraint_3.securerandom.algorithm = SHA512DRBG
+
+#
+# Test-Profile-Constraint_Attributes
+# Test constraint - constraint attributes check
+#
+RestrictedSecurity.Test-Profile-Constraint_Attributes.desc.name = Test-Profile-Constraint_Attributes
+RestrictedSecurity.Test-Profile-Constraint_Attributes.desc.default = true
+RestrictedSecurity.Test-Profile-Constraint_Attributes.desc.fips = true
+RestrictedSecurity.Test-Profile-Constraint_Attributes.desc.hash = SHA256:76dacdfdc5b5811d9b45e72b5b154de6419616556f8f7479819971bba89c41bb
+RestrictedSecurity.Test-Profile-Constraint_Attributes.desc.number = Certificate #XXX
+RestrictedSecurity.Test-Profile-Constraint_Attributes.desc.policy = https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/
+RestrictedSecurity.Test-Profile-Constraint_Attributes.desc.sunsetDate = 2026-09-21
+RestrictedSecurity.Test-Profile-Constraint_Attributes.fips.mode = 140-3
+
+RestrictedSecurity.Test-Profile-Constraint_Attributes.jce.provider.1 = com.sun.crypto.provider.SunJCE
+RestrictedSecurity.Test-Profile-Constraint_Attributes.jce.provider.2 = sun.security.provider.Sun [ \
+    {CertificateFactory, X.509, ImplementedInSoftware}]
+
+RestrictedSecurity.Test-Profile-Constraint_Attributes.securerandom.provider = OpenJCEPlusFIPS
+RestrictedSecurity.Test-Profile-Constraint_Attributes.securerandom.algorithm = SHA512DRBG
+
+#
+# Test-Profile-ConstraintChanged_1.Base
+# Test constraint - constraint changed 1 base
+#
+RestrictedSecurity.Test-Profile-ConstraintChanged_1.Base.desc.name = Test-Profile-ConstraintChanged_1.Base
+RestrictedSecurity.Test-Profile-ConstraintChanged_1.Base.desc.default = false
+RestrictedSecurity.Test-Profile-ConstraintChanged_1.Base.desc.fips = true
+RestrictedSecurity.Test-Profile-ConstraintChanged_1.Base.desc.hash = SHA256:e71c49d65fd291efe75993ccbe6999e6cfb26bf9ef3e8424cb086c7e2a225ce6
+RestrictedSecurity.Test-Profile-ConstraintChanged_1.Base.desc.number = Certificate #XXX
+RestrictedSecurity.Test-Profile-ConstraintChanged_1.Base.desc.policy = https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/
+RestrictedSecurity.Test-Profile-ConstraintChanged_1.Base.desc.sunsetDate = 2026-09-21
+RestrictedSecurity.Test-Profile-ConstraintChanged_1.Base.fips.mode = 140-3
+
+RestrictedSecurity.Test-Profile-ConstraintChanged_1.Base.jce.provider.1 = com.sun.crypto.provider.SunJCE [ \
+    {AlgorithmParameterGenerator, AESGCM, *}, \
+    {AlgorithmParameterGenerator, CCM, *}]
+RestrictedSecurity.Test-Profile-ConstraintChanged_1.Base.jce.provider.2 = sun.security.provider.Sun [ \
+    {CertificateFactory, X.509, ImplementedIn=Software}]
+
+RestrictedSecurity.Test-Profile-ConstraintChanged_1.Base.securerandom.provider = OpenJCEPlusFIPS
+RestrictedSecurity.Test-Profile-ConstraintChanged_1.Base.securerandom.algorithm = SHA512DRBG
+
+#
+# Test-Profile-ConstraintChanged_1.Extension
+# Test constraint - constraint changed 1 extension
+#
+RestrictedSecurity.Test-Profile-ConstraintChanged_1.Extension.desc.name = Test-Profile-ConstraintChanged_1.Extension
+RestrictedSecurity.Test-Profile-ConstraintChanged_1.Extension.desc.default = true
+RestrictedSecurity.Test-Profile-ConstraintChanged_1.Extension.extends = RestrictedSecurity.Test-Profile-ConstraintChanged_1.Base
+
+RestrictedSecurity.Test-Profile-ConstraintChanged_1.Extension.jce.provider.1 = sun.security.provider.Sun [ + \
+    {CertificateFactory, X.509, ImplementedIn=Software}]
+
+#
+# Test-Profile-ConstraintChanged_2.Base
+# Test constraint - constraint changed 2 base
+#
+RestrictedSecurity.Test-Profile-ConstraintChanged_2.Base.desc.name = Test-Profile-ConstraintChanged_2.Base
+RestrictedSecurity.Test-Profile-ConstraintChanged_2.Base.desc.default = false
+RestrictedSecurity.Test-Profile-ConstraintChanged_2.Base.desc.fips = true
+RestrictedSecurity.Test-Profile-ConstraintChanged_2.Base.desc.hash = SHA256:e71c49d65fd291efe75993ccbe6999e6cfb26bf9ef3e8424cb086c7e2a225ce6
+RestrictedSecurity.Test-Profile-ConstraintChanged_2.Base.desc.number = Certificate #XXX
+RestrictedSecurity.Test-Profile-ConstraintChanged_2.Base.desc.policy = https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/
+RestrictedSecurity.Test-Profile-ConstraintChanged_2.Base.desc.sunsetDate = 2026-09-21
+RestrictedSecurity.Test-Profile-ConstraintChanged_2.Base.fips.mode = 140-3
+
+RestrictedSecurity.Test-Profile-ConstraintChanged_2.Base.jce.provider.1 = com.sun.crypto.provider.SunJCE [ \
+    {AlgorithmParameterGenerator, AESGCM, *}, \
+    {AlgorithmParameterGenerator, CCM, *}]
+RestrictedSecurity.Test-Profile-ConstraintChanged_2.Base.jce.provider.2 = sun.security.provider.Sun [ \
+    {CertificateFactory, X.509, ImplementedIn=Software}]
+
+RestrictedSecurity.Test-Profile-ConstraintChanged_2.Base.securerandom.provider = OpenJCEPlusFIPS
+RestrictedSecurity.Test-Profile-ConstraintChanged_2.Base.securerandom.algorithm = SHA512DRBG
+
+#
+# Test-Profile-ConstraintChanged_2.Extension
+# Test constraint - constraint changed 2 extension
+#
+RestrictedSecurity.Test-Profile-ConstraintChanged_2.Extension.desc.name = Test-Profile-ConstraintChanged_2.Extension
+RestrictedSecurity.Test-Profile-ConstraintChanged_2.Extension.desc.default = true
+RestrictedSecurity.Test-Profile-ConstraintChanged_2.Extension.extends = RestrictedSecurity.Test-Profile-ConstraintChanged_2.Base
+
+RestrictedSecurity.Test-Profile-ConstraintChanged_2.Extension.jce.provider.2 = sun.security.provider.Sun [ - \
+    {CertStore, Collection, ImplementedIn=Software}]
+
+#
+# Test-Profile-ConstraintChanged_3.Base
+# Test constraint - constraint changed 3 base
+#
+RestrictedSecurity.Test-Profile-ConstraintChanged_3.Base.desc.name = Test-Profile-ConstraintChanged_3.Base
+RestrictedSecurity.Test-Profile-ConstraintChanged_3.Base.desc.default = true
+RestrictedSecurity.Test-Profile-ConstraintChanged_3.Base.desc.fips = true
+RestrictedSecurity.Test-Profile-ConstraintChanged_3.Base.desc.hash = SHA256:e71c49d65fd291efe75993ccbe6999e6cfb26bf9ef3e8424cb086c7e2a225ce6
+RestrictedSecurity.Test-Profile-ConstraintChanged_3.Base.desc.number = Certificate #XXX
+RestrictedSecurity.Test-Profile-ConstraintChanged_3.Base.desc.policy = https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/
+RestrictedSecurity.Test-Profile-ConstraintChanged_3.Base.desc.sunsetDate = 2026-09-21
+RestrictedSecurity.Test-Profile-ConstraintChanged_3.Base.fips.mode = 140-3
+
+RestrictedSecurity.Test-Profile-ConstraintChanged_3.Base.jce.provider.1 =  com.sun.crypto.provider.SunJCE [ + \
+    {AlgorithmParameterGenerator, AESGCM, *} \
+    {AlgorithmParameterGenerator, CCM, *}]
+
+RestrictedSecurity.Test-Profile-ConstraintChanged_3.Base.securerandom.provider = OpenJCEPlusFIPS
+RestrictedSecurity.Test-Profile-ConstraintChanged_3.Base.securerandom.algorithm = SHA512DRBG

--- a/closed/test/jdk/openj9/internal/security/provider-java.security
+++ b/closed/test/jdk/openj9/internal/security/provider-java.security
@@ -1,0 +1,215 @@
+# ===========================================================================
+# (c) Copyright IBM Corp. 2024, 2024 All Rights Reserved
+# ===========================================================================
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.
+#
+# IBM designates this particular file as subject to the "Classpath" exception
+# as provided by IBM in the LICENSE file that accompanied this code.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, see <http://www.gnu.org/licenses/>.
+# ===========================================================================
+
+RestrictedSecurity.TestBase.Version.desc.name = Test Base Profile
+RestrictedSecurity.TestBase.Version.desc.default = false
+RestrictedSecurity.TestBase.Version.desc.fips = true
+RestrictedSecurity.TestBase.Version.desc.hash = SHA256:0ca32676ac2ae92d0469cbf293f3a69416c5d0312c80473319452f4d6995d234
+RestrictedSecurity.TestBase.Version.desc.number = Certificate #XXX
+RestrictedSecurity.TestBase.Version.desc.policy = https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/
+RestrictedSecurity.TestBase.Version.desc.sunsetDate = 2026-09-21
+RestrictedSecurity.TestBase.Version.fips.mode = 140-3
+
+RestrictedSecurity.TestBase.Version.tls.disabledNamedCurves =
+RestrictedSecurity.TestBase.Version.tls.disabledAlgorithms =
+RestrictedSecurity.TestBase.Version.tls.ephemeralDHKeySize =
+RestrictedSecurity.TestBase.Version.tls.legacyAlgorithms =
+
+RestrictedSecurity.TestBase.Version.jce.certpath.disabledAlgorithms =
+RestrictedSecurity.TestBase.Version.jce.legacyAlgorithms =
+RestrictedSecurity.TestBase.Version.jce.provider.1 = sun.security.provider.Sun
+RestrictedSecurity.TestBase.Version.jce.provider.2 = com.sun.crypto.provider.SunJCE
+RestrictedSecurity.TestBase.Version.jce.provider.3 = sun.security.ssl.SunJSSE
+
+RestrictedSecurity.TestBase.Version.javax.net.ssl.keyStore = NONE
+RestrictedSecurity.TestBase.Version.securerandom.provider = OpenJCEPlusFIPS
+RestrictedSecurity.TestBase.Version.securerandom.algorithm = SHA512DRBG
+
+RestrictedSecurity.TestBase.Version-Extended.desc.name = Test Base Profile Extended
+RestrictedSecurity.TestBase.Version-Extended.desc.default = true
+RestrictedSecurity.TestBase.Version-Extended.extends = RestrictedSecurity.TestBase.Version
+RestrictedSecurity.TestBase.Version-Extended.tls.disabledAlgorithms =
+
+RestrictedSecurity.TestBase.Version-Extended.jce.provider.1 = sun.security.provider.Sun
+RestrictedSecurity.TestBase.Version-Extended.jce.provider.2 = sun.security.rsa.SunRsaSign
+RestrictedSecurity.TestBase.Version-Extended.jce.provider.3 = sun.security.ec.SunEC
+RestrictedSecurity.TestBase.Version-Extended.jce.provider.4 = sun.security.ssl.SunJSSE
+RestrictedSecurity.TestBase.Version-Extended.jce.provider.5 = com.sun.crypto.provider.SunJCE
+RestrictedSecurity.TestBase.Version-Extended.jce.provider.6 = sun.security.jgss.SunProvider
+RestrictedSecurity.TestBase.Version-Extended.jce.provider.7 = com.sun.security.sasl.Provider
+RestrictedSecurity.TestBase.Version-Extended.jce.provider.8 = org.jcp.xml.dsig.internal.dom.XMLDSigRI
+RestrictedSecurity.TestBase.Version-Extended.jce.provider.9 = sun.security.smartcardio.SunPCSC
+RestrictedSecurity.TestBase.Version-Extended.jce.provider.10 = sun.security.provider.certpath.ldap.JdkLDAP
+RestrictedSecurity.TestBase.Version-Extended.jce.provider.11 = com.sun.security.sasl.gsskerb.JdkSASL
+
+#
+# Test-Profile.Updated_1
+# Test update provider list with value
+#
+RestrictedSecurity.Test-Profile.Updated_1.desc.name = Test Updated Profile 1
+RestrictedSecurity.Test-Profile.Updated_1.desc.default = true
+RestrictedSecurity.Test-Profile.Updated_1.extends = RestrictedSecurity.TestBase.Version
+RestrictedSecurity.Test-Profile.Updated_1.tls.disabledAlgorithms =
+
+RestrictedSecurity.Test-Profile.Updated_1.jce.provider.1 = sun.security.provider.Sun
+RestrictedSecurity.Test-Profile.Updated_1.jce.provider.2 = com.sun.crypto.provider.SunJCE
+RestrictedSecurity.Test-Profile.Updated_1.jce.provider.3 = com.sun.security.sasl.Provider
+
+#
+# Test-Profile.Updated_2
+# Test update provider list with null
+#
+RestrictedSecurity.Test-Profile.Updated_2.desc.name = Test Updated Profile 2
+RestrictedSecurity.Test-Profile.Updated_2.desc.default = true
+RestrictedSecurity.Test-Profile.Updated_2.extends = RestrictedSecurity.TestBase.Version
+RestrictedSecurity.Test-Profile.Updated_2.tls.disabledAlgorithms =
+
+RestrictedSecurity.Test-Profile.Updated_2.jce.provider.1 = sun.security.provider.Sun
+RestrictedSecurity.Test-Profile.Updated_2.jce.provider.3 = sun.security.ssl.SunJSSE
+
+#
+# Test-Profile.Updated_3
+# Test update provider list with empty, the empty is the last one in base profile
+#
+RestrictedSecurity.Test-Profile.Updated_3.desc.name = Test Updated Profile 3
+RestrictedSecurity.Test-Profile.Updated_3.desc.default = true
+RestrictedSecurity.Test-Profile.Updated_3.extends = RestrictedSecurity.TestBase.Version
+RestrictedSecurity.Test-Profile.Updated_3.tls.disabledAlgorithms =
+
+RestrictedSecurity.Test-Profile.Updated_3.jce.provider.1 = sun.security.provider.Sun
+RestrictedSecurity.Test-Profile.Updated_3.jce.provider.2 = com.sun.crypto.provider.SunJCE
+RestrictedSecurity.Test-Profile.Updated_3.jce.provider.3 =
+RestrictedSecurity.Test-Profile.Updated_3.jce.provider.4 = sun.security.ec.SunEC
+RestrictedSecurity.Test-Profile.Updated_3.jce.provider.5 = sun.security.ssl.SunJSSE
+
+#
+# Test-Profile.Updated_4
+# Test update provider list with empty, the empty is NOT the last one in base profile
+#
+RestrictedSecurity.Test-Profile.Updated_4.desc.name = Test Updated Profile 3
+RestrictedSecurity.Test-Profile.Updated_4.desc.default = true
+RestrictedSecurity.Test-Profile.Updated_4.extends = RestrictedSecurity.TestBase.Version
+RestrictedSecurity.Test-Profile.Updated_4.tls.disabledAlgorithms =
+
+RestrictedSecurity.Test-Profile.Updated_4.jce.provider.1 = sun.security.provider.Sun
+RestrictedSecurity.Test-Profile.Updated_4.jce.provider.2 =
+RestrictedSecurity.Test-Profile.Updated_4.jce.provider.3 = sun.security.ec.SunEC
+RestrictedSecurity.Test-Profile.Updated_4.jce.provider.4 = sun.security.ssl.SunJSSE
+
+#
+# Test-Profile.Base
+# Test base profile - provider order numbers are not consecutive
+#
+RestrictedSecurity.Test-Profile.Base.desc.name = Test Base Profile
+RestrictedSecurity.Test-Profile.Base.desc.default = true
+RestrictedSecurity.Test-Profile.Base.desc.hash = SHA256:e71c49d65fd291efe75993ccbe6999e6cfb26bf9ef3e8424cb086c7e2a225ce6
+RestrictedSecurity.Test-Profile.Base.tls.disabledAlgorithms =
+
+RestrictedSecurity.Test-Profile.Base.jce.provider.1 = sun.security.provider.Sun
+RestrictedSecurity.Test-Profile.Base.jce.provider.2 = com.sun.crypto.provider.SunJCE
+RestrictedSecurity.Test-Profile.Base.jce.provider.4 = sun.security.ssl.SunJSSE
+
+#
+# Test-Profile.Extended_1
+# Test extended profile, provider order numbers are not consecutive
+#
+RestrictedSecurity.Test-Profile.Extended_1.desc.name = Test Extended_1
+RestrictedSecurity.Test-Profile.Extended_1.desc.default = true
+RestrictedSecurity.Test-Profile.Extended_1.extends = RestrictedSecurity.TestBase.Version
+RestrictedSecurity.Test-Profile.Extended_1.tls.disabledAlgorithms =
+
+RestrictedSecurity.Test-Profile.Extended_1.jce.provider.1 = sun.security.provider.Sun
+RestrictedSecurity.Test-Profile.Extended_1.jce.provider.2 = com.sun.crypto.provider.SunJCE
+RestrictedSecurity.Test-Profile.Extended_1.jce.provider.3 = sun.security.rsa.SunRsaSign
+RestrictedSecurity.Test-Profile.Extended_1.jce.provider.5 = sun.security.ssl.SunJSSE
+
+#
+# Test-Profile.Extended_2
+# Test extended profile from another extended profile, provider order numbers are not consecutive
+#
+RestrictedSecurity.Test-Profile.Extended_2.desc.name = Test Extended_2
+RestrictedSecurity.Test-Profile.Extended_2.desc.default = false
+RestrictedSecurity.Test-Profile.Extended_2.extends = RestrictedSecurity.TestBase.Version-Extended
+RestrictedSecurity.Test-Profile.Extended_2.tls.disabledAlgorithms =
+
+RestrictedSecurity.Test-Profile.Extended_2.jce.provider.14 = sun.security.pkcs11.SunPKCS11
+
+#
+# Test-Profile.BaseOneProviderEmpty
+# Test base profile - one of the provider in list empty
+#
+RestrictedSecurity.Test-Profile.BaseOneProviderEmpty.desc.name = Test Base One Provider Empty
+RestrictedSecurity.Test-Profile.BaseOneProviderEmpty.desc.default = true
+RestrictedSecurity.Test-Profile.BaseOneProviderEmpty.desc.hash = SHA256:e71c49d65fd291efe75993ccbe6999e6cfb26bf9ef3e8424cb086c7e2a225ce6
+RestrictedSecurity.Test-Profile.BaseOneProviderEmpty.tls.disabledAlgorithms =
+
+RestrictedSecurity.Test-Profile.BaseOneProviderEmpty.jce.provider.1 = sun.security.provider.Sun
+RestrictedSecurity.Test-Profile.BaseOneProviderEmpty.jce.provider.2 = com.sun.crypto.provider.SunJCE
+RestrictedSecurity.Test-Profile.BaseOneProviderEmpty.jce.provider.3 =
+RestrictedSecurity.Test-Profile.BaseOneProviderEmpty.jce.provider.4 = sun.security.ssl.SunJSSE
+
+#
+# Test-Profile.ExtendedOneProviderEmpty
+# Test extended profile - one of the provider in list empty
+#
+RestrictedSecurity.Test-Profile.ExtendedOneProviderEmpty.desc.name = Test Extended One Provider Empty
+RestrictedSecurity.Test-Profile.ExtendedOneProviderEmpty.desc.default = true
+RestrictedSecurity.Test-Profile.ExtendedOneProviderEmpty.extends = RestrictedSecurity.TestBase.Version
+RestrictedSecurity.Test-Profile.ExtendedOneProviderEmpty.tls.disabledAlgorithms =
+
+RestrictedSecurity.Test-Profile.ExtendedOneProviderEmpty.jce.provider.1 = sun.security.provider.Sun
+RestrictedSecurity.Test-Profile.ExtendedOneProviderEmpty.jce.provider.2 = com.sun.crypto.provider.SunJCE
+RestrictedSecurity.Test-Profile.ExtendedOneProviderEmpty.jce.provider.3 = sun.security.ssl.SunJSSE
+RestrictedSecurity.Test-Profile.ExtendedOneProviderEmpty.jce.provider.4 = sun.security.ec.SunEC
+RestrictedSecurity.Test-Profile.ExtendedOneProviderEmpty.jce.provider.5 =
+RestrictedSecurity.Test-Profile.ExtendedOneProviderEmpty.jce.provider.6 = sun.security.pkcs11.SunPKCS11
+
+#
+# Test-Profile.BaseNoProviderList
+# Test base profile - no provider list
+#
+RestrictedSecurity.Test-Profile.BaseNoProviderList.desc.name = Test Base Profile
+RestrictedSecurity.Test-Profile.BaseNoProviderList.desc.default = true
+RestrictedSecurity.Test-Profile.BaseNoProviderList.desc.hash = SHA256:e71c49d65fd291efe75993ccbe6999e6cfb26bf9ef3e8424cb086c7e2a225ce6
+RestrictedSecurity.Test-Profile.BaseNoProviderList.tls.disabledAlgorithms =
+
+#
+# Test-Profile.ProviderClassName
+# Test profile - provider must be specified using the fully-qualified class name
+#
+RestrictedSecurity.Test-Profile.ProviderClassName.desc.name = Test Provider Class Name
+RestrictedSecurity.Test-Profile.ProviderClassName.desc.default = true
+RestrictedSecurity.Test-Profile.ProviderClassName.desc.hash = SHA256:e71c49d65fd291efe75993ccbe6999e6cfb26bf9ef3e8424cb086c7e2a225ce6
+RestrictedSecurity.Test-Profile.ProviderClassName.tls.disabledAlgorithms =
+
+RestrictedSecurity.Test-Profile.ProviderClassName.jce.provider.1 = SunJCE
+
+#
+# Test-Profile.ProviderFormat
+# Test profile - provider format is incorrect
+#
+RestrictedSecurity.Test-Profile.ProviderFormat.desc.name = Test Provider Format
+RestrictedSecurity.Test-Profile.ProviderFormat.desc.default = true
+RestrictedSecurity.Test-Profile.ProviderFormat.desc.hash = SHA256:e71c49d65fd291efe75993ccbe6999e6cfb26bf9ef3e8424cb086c7e2a225ce6
+RestrictedSecurity.Test-Profile.ProviderFormat.tls.disabledAlgorithms =
+
+RestrictedSecurity.Test-Profile.ProviderFormat.jce.provider.1 = com.sun.crypto.provider.SunJCE [ \
+    {AlgorithmParameterGenerator, AESGCM, *), \
+    {Signature, SHA512withRSA, *}]


### PR DESCRIPTION
This PR a back-port back from PR https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/871, for adding the test cases for Restricted Security Mode, to cover the restricted security mode providers and properties related test scenarios.