### PR TITLE
Set test flag vm.opt.final.ClassUnloading

### DIFF
--- a/closed/test/jtreg-ext/requires/OpenJ9PropsExt.java
+++ b/closed/test/jtreg-ext/requires/OpenJ9PropsExt.java
@@ -1,6 +1,6 @@
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2019, 2023 All Rights Reserved
+ * (c) Copyright IBM Corp. 2019, 2024 All Rights Reserved
  * ===========================================================================
  * 
  * This code is free software; you can redistribute it and/or modify it
@@ -41,6 +41,7 @@ public class OpenJ9PropsExt implements Callable<Map<String, String>> {
             map.put("vm.graal.enabled", "false");
             map.put("vm.hasJFR", "false");
             map.put("vm.musl", "false");
+            map.put("vm.opt.final.ClassUnloading", "true");
         }
         catch (Exception e) {
             e.printStackTrace();


### PR DESCRIPTION
Backport https://github.com/ibmruntimes/openj9-openjdk-jdk21/pull/34

Issue https://github.com/eclipse-openj9/openj9/issues/20587

Grinder https://openj9-jenkins.osuosl.org/view/Test/job/Grinder/3985/ - passed except for known failure https://github.com/eclipse-openj9/openj9/issues/17700