### PR TITLE
Modify JSR166TestCase to gather more error information

### DIFF
--- a/test/jdk/java/util/concurrent/tck/JSR166TestCase.java
+++ b/test/jdk/java/util/concurrent/tck/JSR166TestCase.java
@@ -39,7 +39,10 @@
  * @summary Conformance testing variant of JSR-166 tck tests.
  * @build *
  * @modules java.management
- * @run junit/othervm/timeout=1000 -Xdump:system+java+snap:events=systhrow,filter=java/lang/Exception,msg_filter=*JUnit* JSR166TestCase
+ * @run junit/othervm/timeout=1000
+ *      -Xdump:system+java+snap:events=throw+systhrow,filter=java/lang/Exception,msg_filter=*JUnit*
+ *      -Xdump:system+java+snap:events=throw+systhrow,filter=junit/framework/AssertionFailedError
+ *      JSR166TestCase
  */
 
 /*
@@ -53,7 +56,8 @@
  *      --add-opens java.base/java.lang=ALL-UNNAMED
  *      -Djsr166.testImplementationDetails=true
  *      -Djava.util.concurrent.ForkJoinPool.common.parallelism=0
- *      -Xdump:system+java+snap:events=systhrow,filter=java/lang/Exception,msg_filter=*JUnit*
+ *      -Xdump:system+java+snap:events=throw+systhrow,filter=java/lang/Exception,msg_filter=*JUnit*
+ *      -Xdump:system+java+snap:events=throw+systhrow,filter=junit/framework/AssertionFailedError
  *      JSR166TestCase
  * @run junit/othervm/timeout=1000
  *      --add-opens java.base/java.util.concurrent=ALL-UNNAMED
@@ -61,7 +65,8 @@
  *      -Djsr166.testImplementationDetails=true
  *      -Djava.util.concurrent.ForkJoinPool.common.parallelism=1
  *      -Djava.util.secureRandomSeed=true
- *      -Xdump:system+java+snap:events=systhrow,filter=java/lang/Exception,msg_filter=*JUnit*
+ *      -Xdump:system+java+snap:events=throw+systhrow,filter=java/lang/Exception,msg_filter=*JUnit*
+ *      -Xdump:system+java+snap:events=throw+systhrow,filter=junit/framework/AssertionFailedError
  *      JSR166TestCase
  */
 
@@ -76,13 +81,15 @@
  *      --add-opens java.base/java.util.concurrent=ALL-UNNAMED
  *      --add-opens java.base/java.lang=ALL-UNNAMED
  *      -Djsr166.testImplementationDetails=true
- *      -Xdump:system+java+snap:events=systhrow,filter=java/lang/Exception,msg_filter=*JUnit*
+ *      -Xdump:system+java+snap:events=throw+systhrow,filter=java/lang/Exception,msg_filter=*JUnit*
+ *      -Xdump:system+java+snap:events=throw+systhrow,filter=junit/framework/AssertionFailedError
  *      JSR166TestCase
  * @run junit/othervm/timeout=1000/policy=tck.policy
  *      --add-opens java.base/java.util.concurrent=ALL-UNNAMED
  *      --add-opens java.base/java.lang=ALL-UNNAMED
  *      -Djsr166.testImplementationDetails=true
- *      -Xdump:system+java+snap:events=systhrow,filter=java/lang/Exception,msg_filter=*JUnit*
+ *      -Xdump:system+java+snap:events=throw+systhrow,filter=java/lang/Exception,msg_filter=*JUnit*
+ *      -Xdump:system+java+snap:events=throw+systhrow,filter=junit/framework/AssertionFailedError
  *      JSR166TestCase
  */
 


### PR DESCRIPTION
Update Xdump to catch JUnit exception and AssertionFailedError

Port from: https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/898