### PR TITLE
Add dependency module java.management.rmi for ibm.healthcenter

### DIFF
--- a/closed/src/ibm.healthcenter/share/classes/module-info.java
+++ b/closed/src/ibm.healthcenter/share/classes/module-info.java
@@ -1,6 +1,6 @@
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2021, 2022 All Rights Reserved
+ * (c) Copyright IBM Corp. 2021, 2024 All Rights Reserved
  * ===========================================================================
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
@@ -26,6 +26,7 @@
 module ibm.healthcenter {
   requires java.logging;
   requires java.management;
+  requires java.management.rmi;
   requires java.naming;
   requires java.prefs;
   requires java.rmi;


### PR DESCRIPTION
This change is to avoid HealthCenterException thrown when HC client using healthcenter APIs tries to connect to target JVM running on Semeru JDK11+.

Backport for PR: https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/894