### PR TITLE
Update SunJSSE fully qualified name for test cases

### DIFF
--- a/closed/test/jdk/openj9/internal/security/property-java.security
+++ b/closed/test/jdk/openj9/internal/security/property-java.security
@@ -36,7 +36,7 @@ RestrictedSecurity.TestBase.Version.jce.certpath.disabledAlgorithms =
 RestrictedSecurity.TestBase.Version.jce.legacyAlgorithms =
 RestrictedSecurity.TestBase.Version.jce.provider.1 = sun.security.provider.Sun
 RestrictedSecurity.TestBase.Version.jce.provider.2 = com.sun.crypto.provider.SunJCE
-RestrictedSecurity.TestBase.Version.jce.provider.3 = sun.security.ssl.SunJSSE
+RestrictedSecurity.TestBase.Version.jce.provider.3 = com.sun.net.ssl.internal.ssl.Provider
 
 RestrictedSecurity.TestBase.Version.javax.net.ssl.keyStore = NONE
 RestrictedSecurity.TestBase.Version.securerandom.provider = OpenJCEPlusFIPS
@@ -50,7 +50,7 @@ RestrictedSecurity.TestBase.Version-Extended.tls.disabledAlgorithms =
 RestrictedSecurity.TestBase.Version-Extended.jce.provider.1 = sun.security.provider.Sun
 RestrictedSecurity.TestBase.Version-Extended.jce.provider.2 = sun.security.rsa.SunRsaSign
 RestrictedSecurity.TestBase.Version-Extended.jce.provider.3 = sun.security.ec.SunEC
-RestrictedSecurity.TestBase.Version-Extended.jce.provider.4 = sun.security.ssl.SunJSSE
+RestrictedSecurity.TestBase.Version-Extended.jce.provider.4 = com.sun.net.ssl.internal.ssl.Provider
 RestrictedSecurity.TestBase.Version-Extended.jce.provider.5 = com.sun.crypto.provider.SunJCE
 RestrictedSecurity.TestBase.Version-Extended.jce.provider.6 = sun.security.jgss.SunProvider
 RestrictedSecurity.TestBase.Version-Extended.jce.provider.7 = com.sun.security.sasl.Provider
@@ -76,7 +76,7 @@ RestrictedSecurity.Test-Profile.Base.tls.disabledAlgorithmsWrongTypo =
 
 RestrictedSecurity.Test-Profile.Base.jce.provider.1 = sun.security.provider.Sun
 RestrictedSecurity.Test-Profile.Base.jce.provider.2 = com.sun.crypto.provider.SunJCE
-RestrictedSecurity.Test-Profile.Base.jce.provider.3 = sun.security.ssl.SunJSSE
+RestrictedSecurity.Test-Profile.Base.jce.provider.3 = com.sun.net.ssl.internal.ssl.Provider
 
 RestrictedSecurity.Test-Profile.Base.securerandom.provider = OpenJCEPlusFIPS
 RestrictedSecurity.Test-Profile.Base.securerandom.algorithm = SHA512DRBG
@@ -94,7 +94,7 @@ RestrictedSecurity.Test-Profile.Extended_1.jce.provider.1 = sun.security.provide
 RestrictedSecurity.Test-Profile.Extended_1.jce.provider.2 = com.sun.crypto.provider.SunJCE
 RestrictedSecurity.Test-Profile.Extended_1.jce.providerWrongTypo = sun.security.rsa.SunRsaSign
 RestrictedSecurity.Test-Profile.Extended_1.jce.provider.4 = sun.security.ec.SunEC
-RestrictedSecurity.Test-Profile.Extended_1.jce.provider.5 = sun.security.ssl.SunJSSE
+RestrictedSecurity.Test-Profile.Extended_1.jce.provider.5 = com.sun.net.ssl.internal.ssl.Provider
 
 #
 # Test-Profile.Extended_2
@@ -127,7 +127,7 @@ RestrictedSecurity.Test-Profile-MultiDefault.Base.fips.mode = 140-3
 
 RestrictedSecurity.Test-Profile-MultiDefault.Base.jce.provider.1 = sun.security.provider.Sun
 RestrictedSecurity.Test-Profile-MultiDefault.Base.jce.provider.2 = com.sun.crypto.provider.SunJCE
-RestrictedSecurity.Test-Profile-MultiDefault.Base.jce.provider.3 = sun.security.ssl.SunJSSE
+RestrictedSecurity.Test-Profile-MultiDefault.Base.jce.provider.3 = com.sun.net.ssl.internal.ssl.Provider
 
 RestrictedSecurity.Test-Profile-MultiDefault.Base.securerandom.provider = OpenJCEPlusFIPS
 RestrictedSecurity.Test-Profile-MultiDefault.Base.securerandom.algorithm = SHA512DRBG
@@ -253,7 +253,7 @@ RestrictedSecurity.Test-Profile-SetProperty.Base.tls.ephemeralDHKeySize =
 RestrictedSecurity.Test-Profile-SetProperty.Base.jce.certpath.disabledAlgorithms =
 RestrictedSecurity.Test-Profile-SetProperty.Base.jce.provider.1 = sun.security.provider.Sun
 RestrictedSecurity.Test-Profile-SetProperty.Base.jce.provider.2 = com.sun.crypto.provider.SunJCE
-RestrictedSecurity.Test-Profile-SetProperty.Base.jce.provider.3 = sun.security.ssl.SunJSSE
+RestrictedSecurity.Test-Profile-SetProperty.Base.jce.provider.3 = com.sun.net.ssl.internal.ssl.Provider
 
 RestrictedSecurity.Test-Profile-SetProperty.Base.securerandom.provider = OpenJCEPlusFIPS
 RestrictedSecurity.Test-Profile-SetProperty.Base.securerandom.algorithm = SHA512DRBG
@@ -533,7 +533,7 @@ RestrictedSecurity.Test-Profile-ConstraintChanged_3.Base.securerandom.algorithm 
 RestrictedSecurity.Test-Profile-SameStartWithoutVersion.desc.name = Test-Profile-SameStartWithoutVersion
 RestrictedSecurity.Test-Profile-SameStartWithoutVersion.desc.default = true
 RestrictedSecurity.Test-Profile-SameStartWithoutVersion.desc.fips = true
-RestrictedSecurity.Test-Profile-SameStartWithoutVersion.desc.hash = SHA256:2c893d75043da09c3dba8d8b24cb71dc1c7ceac5fb8bf362a35847418a933a06
+RestrictedSecurity.Test-Profile-SameStartWithoutVersion.desc.hash = SHA256:92693ffabd97694f750d645934cb6d0d3f13e4cade30070fd2479b7b9bcb7f42
 RestrictedSecurity.Test-Profile-SameStartWithoutVersion.desc.number = Certificate #XXX
 RestrictedSecurity.Test-Profile-SameStartWithoutVersion.desc.policy = https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/
 RestrictedSecurity.Test-Profile-SameStartWithoutVersion.desc.sunsetDate = 2026-09-21
@@ -541,7 +541,7 @@ RestrictedSecurity.Test-Profile-SameStartWithoutVersion.fips.mode = 140-3
 
 RestrictedSecurity.Test-Profile-SameStartWithoutVersion.jce.provider.1 = sun.security.provider.Sun
 RestrictedSecurity.Test-Profile-SameStartWithoutVersion.jce.provider.2 = com.sun.crypto.provider.SunJCE
-RestrictedSecurity.Test-Profile-SameStartWithoutVersion.jce.provider.3 = sun.security.ssl.SunJSSE
+RestrictedSecurity.Test-Profile-SameStartWithoutVersion.jce.provider.3 = com.sun.net.ssl.internal.ssl.Provider
 
 RestrictedSecurity.Test-Profile-SameStartWithoutVersion.securerandom.provider = OpenJCEPlusFIPS
 RestrictedSecurity.Test-Profile-SameStartWithoutVersion.securerandom.algorithm = SHA512DRBG
@@ -557,7 +557,7 @@ RestrictedSecurity.Test-Profile-SameStartWithoutVersionPart.fips.mode = 140-3
 
 RestrictedSecurity.Test-Profile-SameStartWithoutVersionPart.jce.provider.1 = sun.security.provider.Sun
 RestrictedSecurity.Test-Profile-SameStartWithoutVersionPart.jce.provider.2 = com.sun.crypto.provider.SunJCE
-RestrictedSecurity.Test-Profile-SameStartWithoutVersionPart.jce.provider.3 = sun.security.ssl.SunJSSE
+RestrictedSecurity.Test-Profile-SameStartWithoutVersionPart.jce.provider.3 = com.sun.net.ssl.internal.ssl.Provider
 
 RestrictedSecurity.Test-Profile-SameStartWithoutVersionPart.securerandom.provider = OpenJCEPlusFIPS
 RestrictedSecurity.Test-Profile-SameStartWithoutVersionPart.securerandom.algorithm = SHA512DRBG

--- a/closed/test/jdk/openj9/internal/security/provider-java.security
+++ b/closed/test/jdk/openj9/internal/security/provider-java.security
@@ -21,7 +21,7 @@
 RestrictedSecurity.TestBase.Version.desc.name = Test Base Profile
 RestrictedSecurity.TestBase.Version.desc.default = false
 RestrictedSecurity.TestBase.Version.desc.fips = true
-RestrictedSecurity.TestBase.Version.desc.hash = SHA256:0ca32676ac2ae92d0469cbf293f3a69416c5d0312c80473319452f4d6995d234
+RestrictedSecurity.TestBase.Version.desc.hash = SHA256:24859dcd916c3d301c0a8d0a58f96f7c3a493cadad48ff1c91a5151f2cdd2d49
 RestrictedSecurity.TestBase.Version.desc.number = Certificate #XXX
 RestrictedSecurity.TestBase.Version.desc.policy = https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/
 RestrictedSecurity.TestBase.Version.desc.sunsetDate = 2026-09-21
@@ -36,7 +36,7 @@ RestrictedSecurity.TestBase.Version.jce.certpath.disabledAlgorithms =
 RestrictedSecurity.TestBase.Version.jce.legacyAlgorithms =
 RestrictedSecurity.TestBase.Version.jce.provider.1 = sun.security.provider.Sun
 RestrictedSecurity.TestBase.Version.jce.provider.2 = com.sun.crypto.provider.SunJCE
-RestrictedSecurity.TestBase.Version.jce.provider.3 = sun.security.ssl.SunJSSE
+RestrictedSecurity.TestBase.Version.jce.provider.3 = com.sun.net.ssl.internal.ssl.Provider
 
 RestrictedSecurity.TestBase.Version.javax.net.ssl.keyStore = NONE
 RestrictedSecurity.TestBase.Version.securerandom.provider = OpenJCEPlusFIPS
@@ -50,7 +50,7 @@ RestrictedSecurity.TestBase.Version-Extended.tls.disabledAlgorithms =
 RestrictedSecurity.TestBase.Version-Extended.jce.provider.1 = sun.security.provider.Sun
 RestrictedSecurity.TestBase.Version-Extended.jce.provider.2 = sun.security.rsa.SunRsaSign
 RestrictedSecurity.TestBase.Version-Extended.jce.provider.3 = sun.security.ec.SunEC
-RestrictedSecurity.TestBase.Version-Extended.jce.provider.4 = sun.security.ssl.SunJSSE
+RestrictedSecurity.TestBase.Version-Extended.jce.provider.4 = com.sun.net.ssl.internal.ssl.Provider
 RestrictedSecurity.TestBase.Version-Extended.jce.provider.5 = com.sun.crypto.provider.SunJCE
 RestrictedSecurity.TestBase.Version-Extended.jce.provider.6 = sun.security.jgss.SunProvider
 RestrictedSecurity.TestBase.Version-Extended.jce.provider.7 = com.sun.security.sasl.Provider
@@ -82,7 +82,7 @@ RestrictedSecurity.Test-Profile.Updated_2.extends = RestrictedSecurity.TestBase.
 RestrictedSecurity.Test-Profile.Updated_2.tls.disabledAlgorithms =
 
 RestrictedSecurity.Test-Profile.Updated_2.jce.provider.1 = sun.security.provider.Sun
-RestrictedSecurity.Test-Profile.Updated_2.jce.provider.3 = sun.security.ssl.SunJSSE
+RestrictedSecurity.Test-Profile.Updated_2.jce.provider.3 = com.sun.net.ssl.internal.ssl.Provider
 
 #
 # Test-Profile.Updated_3
@@ -97,7 +97,7 @@ RestrictedSecurity.Test-Profile.Updated_3.jce.provider.1 = sun.security.provider
 RestrictedSecurity.Test-Profile.Updated_3.jce.provider.2 = com.sun.crypto.provider.SunJCE
 RestrictedSecurity.Test-Profile.Updated_3.jce.provider.3 =
 RestrictedSecurity.Test-Profile.Updated_3.jce.provider.4 = sun.security.ec.SunEC
-RestrictedSecurity.Test-Profile.Updated_3.jce.provider.5 = sun.security.ssl.SunJSSE
+RestrictedSecurity.Test-Profile.Updated_3.jce.provider.5 = com.sun.net.ssl.internal.ssl.Provider
 
 #
 # Test-Profile.Updated_4
@@ -111,7 +111,7 @@ RestrictedSecurity.Test-Profile.Updated_4.tls.disabledAlgorithms =
 RestrictedSecurity.Test-Profile.Updated_4.jce.provider.1 = sun.security.provider.Sun
 RestrictedSecurity.Test-Profile.Updated_4.jce.provider.2 =
 RestrictedSecurity.Test-Profile.Updated_4.jce.provider.3 = sun.security.ec.SunEC
-RestrictedSecurity.Test-Profile.Updated_4.jce.provider.4 = sun.security.ssl.SunJSSE
+RestrictedSecurity.Test-Profile.Updated_4.jce.provider.4 = com.sun.net.ssl.internal.ssl.Provider
 
 #
 # Test-Profile.Base
@@ -124,7 +124,7 @@ RestrictedSecurity.Test-Profile.Base.tls.disabledAlgorithms =
 
 RestrictedSecurity.Test-Profile.Base.jce.provider.1 = sun.security.provider.Sun
 RestrictedSecurity.Test-Profile.Base.jce.provider.2 = com.sun.crypto.provider.SunJCE
-RestrictedSecurity.Test-Profile.Base.jce.provider.4 = sun.security.ssl.SunJSSE
+RestrictedSecurity.Test-Profile.Base.jce.provider.4 = com.sun.net.ssl.internal.ssl.Provider
 
 #
 # Test-Profile.Extended_1
@@ -138,7 +138,7 @@ RestrictedSecurity.Test-Profile.Extended_1.tls.disabledAlgorithms =
 RestrictedSecurity.Test-Profile.Extended_1.jce.provider.1 = sun.security.provider.Sun
 RestrictedSecurity.Test-Profile.Extended_1.jce.provider.2 = com.sun.crypto.provider.SunJCE
 RestrictedSecurity.Test-Profile.Extended_1.jce.provider.3 = sun.security.rsa.SunRsaSign
-RestrictedSecurity.Test-Profile.Extended_1.jce.provider.5 = sun.security.ssl.SunJSSE
+RestrictedSecurity.Test-Profile.Extended_1.jce.provider.5 = com.sun.net.ssl.internal.ssl.Provider
 
 #
 # Test-Profile.Extended_2
@@ -163,7 +163,7 @@ RestrictedSecurity.Test-Profile.BaseOneProviderEmpty.tls.disabledAlgorithms =
 RestrictedSecurity.Test-Profile.BaseOneProviderEmpty.jce.provider.1 = sun.security.provider.Sun
 RestrictedSecurity.Test-Profile.BaseOneProviderEmpty.jce.provider.2 = com.sun.crypto.provider.SunJCE
 RestrictedSecurity.Test-Profile.BaseOneProviderEmpty.jce.provider.3 =
-RestrictedSecurity.Test-Profile.BaseOneProviderEmpty.jce.provider.4 = sun.security.ssl.SunJSSE
+RestrictedSecurity.Test-Profile.BaseOneProviderEmpty.jce.provider.4 = com.sun.net.ssl.internal.ssl.Provider
 
 #
 # Test-Profile.ExtendedOneProviderEmpty
@@ -176,7 +176,7 @@ RestrictedSecurity.Test-Profile.ExtendedOneProviderEmpty.tls.disabledAlgorithms 
 
 RestrictedSecurity.Test-Profile.ExtendedOneProviderEmpty.jce.provider.1 = sun.security.provider.Sun
 RestrictedSecurity.Test-Profile.ExtendedOneProviderEmpty.jce.provider.2 = com.sun.crypto.provider.SunJCE
-RestrictedSecurity.Test-Profile.ExtendedOneProviderEmpty.jce.provider.3 = sun.security.ssl.SunJSSE
+RestrictedSecurity.Test-Profile.ExtendedOneProviderEmpty.jce.provider.3 = com.sun.net.ssl.internal.ssl.Provider
 RestrictedSecurity.Test-Profile.ExtendedOneProviderEmpty.jce.provider.4 = sun.security.ec.SunEC
 RestrictedSecurity.Test-Profile.ExtendedOneProviderEmpty.jce.provider.5 =
 RestrictedSecurity.Test-Profile.ExtendedOneProviderEmpty.jce.provider.6 = sun.security.pkcs11.SunPKCS11


### PR DESCRIPTION
In JDK11, the fully qualified name for SunJSSE provider is `com.sun.net.ssl.internal.ssl.Provider`. Update this for all the restricted security mode test cases. This update only applies to JDK11.