### PR TITLE
Reorder the way contents of healthcenter jars are extracted

### DIFF
--- a/closed/make/copy/Copy-ibm.healthcenter.gmk
+++ b/closed/make/copy/Copy-ibm.healthcenter.gmk
@@ -1,5 +1,5 @@
 # ===========================================================================
-# (c) Copyright IBM Corp. 2021, 2021 All Rights Reserved
+# (c) Copyright IBM Corp. 2021, 2024 All Rights Reserved
 # ===========================================================================
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
@@ -47,9 +47,13 @@ TRANSPORT_PROPERTY_SED_SCRIPT := -e 's|$(TRANSPORT_PROPERTY_REGEX)\s*=.*|$(TRANS
 
 HEALTHCENTER_COPY := $(JDK_OUTPUTDIR)/modules/$(MODULE)/_the.$(MODULE)_copy_marker
 
+# The order in which the jars are extracted needs to remain intact,
+# as both jars contain copies of some of the same classes,
+# to avoid a HealthCenterNotSupportedException.
+
 HEALTHCENTER_JARS := \
-	$(HEALTHCENTER_HOME)/healthcenter.jar \
 	$(HEALTHCENTER_HOME)/monitoring-api.jar \
+	$(HEALTHCENTER_HOME)/healthcenter.jar \
 	#
 
 HEALTHCENTER_EXCLUDED_PACKAGES := \


### PR DESCRIPTION
There are two copies of Version.class one in healthcenter.jar and the other in monitoring-api.jar. Version.class from healthcenter.jar should be used to avoid HealthCenterNotSupportedException caused due to long version date in monitoring-api.jar.

Backport for PR: https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/907