### PR TITLE
Add selected tracepoints for OpenJ9 -Xtrace

### DIFF
--- a/make/lib/CoreLibraries.gmk
+++ b/make/lib/CoreLibraries.gmk
@@ -23,6 +23,10 @@
 # questions.
 #
 
+# ===========================================================================
+# (c) Copyright IBM Corp. 2025, 2025 All Rights Reserved
+# ===========================================================================
+
 WIN_VERIFY_LIB := $(SUPPORT_OUTPUTDIR)/native/$(MODULE)/libverify/verify.lib
 
 # Hook to include the corresponding custom file, if present.
@@ -102,8 +106,30 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBJAVA, \
     OPTIMIZATION := HIGH, \
     CFLAGS := $(CFLAGS_JDKLIB) \
         $(LIBJAVA_CFLAGS), \
+    check_version.c_CFLAGS := \
+        -I$(OPENJ9_TOPDIR)/runtime/include \
+        -I$(OPENJ9_TOPDIR)/runtime/oti \
+        -I$(OPENJ9OMR_TOPDIR)/include_core \
+        -I$(OPENJ9_VM_BUILD_DIR) \
+        -I$(OPENJ9_TOPDIR)/runtime/jcl \
+        -I$(OPENJ9_TOPDIR)/runtime/util \
+        -I$(OPENJ9_VM_BUILD_DIR)/jcl, \
+    io_util_md.c_CFLAGS := \
+        -I$(OPENJ9OMR_TOPDIR)/include_core \
+        -I$(OPENJ9_VM_BUILD_DIR)/jcl, \
     System.c_CFLAGS := $(VERSION_CFLAGS), \
     jdk_util.c_CFLAGS := $(VERSION_CFLAGS), \
+    UnixFileSystem_md.c_CFLAGS := \
+        -I$(OPENJ9OMR_TOPDIR)/include_core \
+        -I$(OPENJ9_VM_BUILD_DIR)/jcl, \
+    VM.c_CFLAGS := \
+        -I$(OPENJ9_TOPDIR)/runtime/include \
+        -I$(OPENJ9_TOPDIR)/runtime/oti \
+        -I$(OPENJ9OMR_TOPDIR)/include_core \
+        -I$(OPENJ9_VM_BUILD_DIR) \
+        -I$(OPENJ9_TOPDIR)/runtime/jcl \
+        -I$(OPENJ9_TOPDIR)/runtime/util \
+        -I$(OPENJ9_VM_BUILD_DIR)/jcl, \
     EXTRA_HEADER_DIRS := libfdlibm, \
     WARNINGS_AS_ERRORS_xlc := false, \
     DISABLED_WARNINGS_gcc := unused-result, \

--- a/make/lib/Lib-java.base.gmk
+++ b/make/lib/Lib-java.base.gmk
@@ -24,7 +24,7 @@
 #
 
 # ===========================================================================
-# (c) Copyright IBM Corp. 2018, 2023 All Rights Reserved
+# (c) Copyright IBM Corp. 2018, 2025 All Rights Reserved
 # ===========================================================================
 
 include LibCommon.gmk
@@ -47,6 +47,29 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBNET, \
     NAME := net, \
     OPTIMIZATION := LOW, \
     CFLAGS := $(CFLAGS_JDKLIB), \
+    aix_close.c_CFLAGS := \
+        -I$(OPENJ9OMR_TOPDIR)/include_core \
+        -I$(OPENJ9_VM_BUILD_DIR)/jcl, \
+    bsd_close.c_CFLAGS := \
+        -I$(OPENJ9OMR_TOPDIR)/include_core \
+        -I$(OPENJ9_VM_BUILD_DIR)/jcl, \
+    linux_close.c_CFLAGS := \
+        -I$(OPENJ9OMR_TOPDIR)/include_core \
+        -I$(OPENJ9_VM_BUILD_DIR)/jcl, \
+    net_util.c_CFLAGS := \
+        -I$(OPENJ9_TOPDIR)/runtime/include \
+        -I$(OPENJ9_TOPDIR)/runtime/oti \
+        -I$(OPENJ9OMR_TOPDIR)/include_core \
+        -I$(OPENJ9_VM_BUILD_DIR) \
+        -I$(OPENJ9_TOPDIR)/runtime/jcl \
+        -I$(OPENJ9_TOPDIR)/runtime/util \
+        -I$(OPENJ9_VM_BUILD_DIR)/jcl, \
+    net_util_md.c_CFLAGS := \
+        -I$(OPENJ9OMR_TOPDIR)/include_core \
+        -I$(OPENJ9_VM_BUILD_DIR)/jcl, \
+    PlainSocketImpl.c_CFLAGS := \
+        -I$(OPENJ9OMR_TOPDIR)/include_core \
+        -I$(OPENJ9_VM_BUILD_DIR)/jcl, \
     DISABLED_WARNINGS_gcc := format-nonliteral, \
     DISABLED_WARNINGS_clang := parentheses-equality constant-logical-operand, \
     DISABLED_WARNINGS_microsoft := 4244 4047 4133 4996, \
@@ -75,6 +98,23 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBNIO, \
     OPTIMIZATION := HIGH, \
     WARNINGS_AS_ERRORS_xlc := false, \
     CFLAGS := $(CFLAGS_JDKLIB), \
+    FileDispatcherImpl.c_CFLAGS := \
+        -I$(OPENJ9OMR_TOPDIR)/include_core \
+        -I$(OPENJ9_VM_BUILD_DIR)/jcl, \
+    Net.c_CFLAGS := \
+        -I$(OPENJ9OMR_TOPDIR)/include_core \
+        -I$(OPENJ9_VM_BUILD_DIR)/jcl, \
+    nio_util.c_CFLAGS := \
+        -I$(OPENJ9_TOPDIR)/runtime/include \
+        -I$(OPENJ9_TOPDIR)/runtime/oti \
+        -I$(OPENJ9OMR_TOPDIR)/include_core \
+        -I$(OPENJ9_VM_BUILD_DIR) \
+        -I$(OPENJ9_TOPDIR)/runtime/jcl \
+        -I$(OPENJ9_TOPDIR)/runtime/util \
+        -I$(OPENJ9_VM_BUILD_DIR)/jcl, \
+    SocketDispatcher.c_CFLAGS := \
+        -I$(OPENJ9OMR_TOPDIR)/include_core \
+        -I$(OPENJ9_VM_BUILD_DIR)/jcl, \
     EXTRA_HEADER_DIRS := \
         libnio/ch \
         libnio/fs \

--- a/src/java.base/aix/native/libnet/aix_close.c
+++ b/src/java.base/aix/native/libnet/aix_close.c
@@ -25,6 +25,12 @@
  */
 
 /*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2025, 2025 All Rights Reserved
+ * ===========================================================================
+ */
+
+/*
  * This file contains implementations of NET_... functions. The NET_.. functions are
  * wrappers for common file- and socket functions plus provisions for non-blocking IO.
  *
@@ -65,8 +71,11 @@
 #include <unistd.h>
 #include <errno.h>
 #include <poll.h>
+#include <arpa/inet.h>
 #include "jvm.h"
 #include "net_util.h"
+
+#include "ut_jcl_net.h"
 
 /*
  * Stack allocated by thread when doing blocking operation
@@ -382,6 +391,7 @@ int NET_Dup2(int fd, int fd2) {
  * preempted and the I/O system call will return -1/EBADF.
  */
 int NET_SocketClose(int fd) {
+    Trc_NET_SocketClose(fd);
     return closefd(-1, fd);
 }
 
@@ -442,6 +452,16 @@ int NET_Connect(int s, struct sockaddr *addr, int addrlen) {
     if (fdEntry == NULL) {
         errno = EBADF;
         return -1;
+    }
+
+    if (AF_INET == addr->sa_family) {
+        char buf[INET_ADDRSTRLEN];
+        struct sockaddr_in *sa = (struct sockaddr_in *)addr;
+        Trc_NET_Connect4(s, inet_ntop(AF_INET, &sa->sin_addr, buf, sizeof(buf)), ntohs(sa->sin_port), addrlen);
+    } else if (AF_INET6 == addr->sa_family) {
+        char buf[INET6_ADDRSTRLEN];
+        struct sockaddr_in6 *sa = (struct sockaddr_in6 *)addr;
+        Trc_NET_Connect6(s, inet_ntop(AF_INET6, &sa->sin6_addr, buf, sizeof(buf)), ntohs(sa->sin6_port), ntohl(sa->sin6_scope_id), addrlen);
     }
 
     /* On AIX, when the system call connect() is interrupted, the connection

--- a/src/java.base/linux/native/libnet/linux_close.c
+++ b/src/java.base/linux/native/libnet/linux_close.c
@@ -23,6 +23,12 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2025, 2025 All Rights Reserved
+ * ===========================================================================
+ */
+
 #include <assert.h>
 #include <limits.h>
 #include <stdio.h>
@@ -37,8 +43,11 @@
 #include <unistd.h>
 #include <errno.h>
 #include <poll.h>
+#include <arpa/inet.h>
 #include "jvm.h"
 #include "net_util.h"
+
+#include "ut_jcl_net.h"
 
 /*
  * Stack allocated by thread when doing blocking operation
@@ -339,6 +348,7 @@ int NET_Dup2(int fd, int fd2) {
  * preempted and the I/O system call will return -1/EBADF.
  */
 int NET_SocketClose(int fd) {
+    Trc_NET_SocketClose(fd);
     return closefd(-1, fd);
 }
 
@@ -392,6 +402,15 @@ int NET_Accept(int s, struct sockaddr *addr, socklen_t *addrlen) {
 }
 
 int NET_Connect(int s, struct sockaddr *addr, int addrlen) {
+    if (AF_INET == addr->sa_family) {
+        char buf[INET_ADDRSTRLEN];
+        struct sockaddr_in *sa = (struct sockaddr_in *)addr;
+        Trc_NET_Connect4(s, inet_ntop(AF_INET, &sa->sin_addr, buf, sizeof(buf)), ntohs(sa->sin_port), addrlen);
+    } else if (AF_INET6 == addr->sa_family) {
+        char buf[INET6_ADDRSTRLEN];
+        struct sockaddr_in6 *sa = (struct sockaddr_in6 *)addr;
+        Trc_NET_Connect6(s, inet_ntop(AF_INET6, &sa->sin6_addr, buf, sizeof(buf)), ntohs(sa->sin6_port), ntohl(sa->sin6_scope_id), addrlen);
+    }
     BLOCKING_IO_RETURN_INT( s, connect(s, addr, addrlen), JNI_TRUE );
 }
 

--- a/src/java.base/macosx/native/libnet/bsd_close.c
+++ b/src/java.base/macosx/native/libnet/bsd_close.c
@@ -23,6 +23,12 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2025, 2025 All Rights Reserved
+ * ===========================================================================
+ */
+
 #include <assert.h>
 #include <limits.h>
 #include <stdio.h>
@@ -39,8 +45,11 @@
 #include <unistd.h>
 #include <errno.h>
 #include <poll.h>
+#include <arpa/inet.h>
 #include "jvm.h"
 #include "net_util.h"
+
+#include "ut_jcl_net.h"
 
 /*
  * Stack allocated by thread when doing blocking operation
@@ -343,6 +352,7 @@ int NET_Dup2(int fd, int fd2) {
  * preempted and the I/O system call will return -1/EBADF.
  */
 int NET_SocketClose(int fd) {
+    Trc_NET_SocketClose(fd);
     return closefd(-1, fd);
 }
 
@@ -396,6 +406,15 @@ int NET_Accept(int s, struct sockaddr *addr, socklen_t *addrlen) {
 }
 
 int NET_Connect(int s, struct sockaddr *addr, int addrlen) {
+    if (AF_INET == addr->sa_family) {
+        char buf[INET_ADDRSTRLEN];
+        struct sockaddr_in *sa = (struct sockaddr_in *)addr;
+        Trc_NET_Connect4(s, inet_ntop(AF_INET, &sa->sin_addr, buf, sizeof(buf)), ntohs(sa->sin_port), addrlen);
+    } else if (AF_INET6 == addr->sa_family) {
+        char buf[INET6_ADDRSTRLEN];
+        struct sockaddr_in6 *sa = (struct sockaddr_in6 *)addr;
+        Trc_NET_Connect6(s, inet_ntop(AF_INET6, &sa->sin6_addr, buf, sizeof(buf)), ntohs(sa->sin6_port), ntohl(sa->sin6_scope_id), addrlen);
+    }
     BLOCKING_IO_RETURN_INT( s, connect(s, addr, addrlen), JNI_TRUE );
 }
 

--- a/src/java.base/share/native/libjava/VM.c
+++ b/src/java.base/share/native/libjava/VM.c
@@ -23,12 +23,25 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2025, 2025 All Rights Reserved
+ * ===========================================================================
+ */
+
 #include "jni.h"
 #include "jni_util.h"
 #include "jvm.h"
 #include "jdk_util.h"
 
 #include "jdk_internal_misc_VM.h"
+
+#if defined(WIN32)
+#include "j9access.h"
+/* tracehelp.c defines getTraceInterfaceFromVM(), used by J9_UTINTERFACE_FROM_VM(). */
+#include "tracehelp.c"
+#include "ut_jcl_java.c"
+#endif /* defined(WIN32) */
 
 /* Only register the performance-critical methods */
 static JNINativeMethod methods[] = {
@@ -42,6 +55,11 @@ Java_jdk_internal_misc_VM_latestUserDefinedLoader0(JNIEnv *env, jclass cls) {
 
 JNIEXPORT void JNICALL
 Java_jdk_internal_misc_VM_initialize(JNIEnv *env, jclass cls) {
+#if defined(WIN32)
+    /* Other platforms do this in check_version.c JNI_OnLoad. */
+    UT_JCL_JAVA_MODULE_LOADED(J9_UTINTERFACE_FROM_VM(((J9VMThread *) env)->javaVM));
+#endif /* defined(WIN32) */
+
     if (!JDK_InitJvmHandle()) {
         JNU_ThrowInternalError(env, "Handle for JVM not found for symbol lookup");
         return;

--- a/src/java.base/share/native/libjava/check_version.c
+++ b/src/java.base/share/native/libjava/check_version.c
@@ -28,13 +28,31 @@
  * ===========================================================================
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2025, 2025 All Rights Reserved
+ * ===========================================================================
+ */
+
 #include "jni.h"
 #include "jni_util.h"
 #include "jvm.h"
 
+#if !defined(WIN32)
+#include "j9access.h"
+/* tracehelp.c defines getTraceInterfaceFromVM(), used by J9_UTINTERFACE_FROM_VM(). */
+#include "tracehelp.c"
+#include "ut_jcl_java.c"
+#endif /* !defined(WIN32) */
+
 JNIEXPORT jint JNICALL
 DEF_JNI_OnLoad(JavaVM *vm, void *reserved)
 {
+#if !defined(WIN32)
+    /* Windows doesn't call JNI_OnLoad for libjava.dll, initialize the tracepoint elsewhere. */
+    UT_JCL_JAVA_MODULE_LOADED(J9_UTINTERFACE_FROM_VM((J9JavaVM *)vm));
+#endif /* !defined(WIN32) */
+
     jint vm_version = JVM_GetInterfaceVersion();
     if (vm_version != JVM_INTERFACE_VERSION) {
         JNIEnv *env;

--- a/src/java.base/share/native/libnet/net_util.c
+++ b/src/java.base/share/native/libnet/net_util.c
@@ -23,9 +23,20 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2025, 2025 All Rights Reserved
+ * ===========================================================================
+ */
+
 #include "net_util.h"
 
 #include "java_net_InetAddress.h"
+
+#include "j9access.h"
+/* tracehelp.c defines getTraceInterfaceFromVM(), used by J9_UTINTERFACE_FROM_VM(). */
+#include "tracehelp.c"
+#include "ut_jcl_net.c"
 
 int IPv6_supported();
 int reuseport_supported();
@@ -54,6 +65,8 @@ DEF_JNI_OnLoad(JavaVM *vm, void *reserved)
     if ((*vm)->GetEnv(vm, (void**) &env, JNI_VERSION_1_2) != JNI_OK) {
         return JNI_EVERSION; /* JNI version not supported */
     }
+
+    UT_JCL_NET_MODULE_LOADED(J9_UTINTERFACE_FROM_VM((J9JavaVM *)vm));
 
     iCls = (*env)->FindClass(env, "java/lang/Boolean");
     CHECK_NULL_RETURN(iCls, JNI_VERSION_1_2);

--- a/src/java.base/share/native/libnio/nio_util.c
+++ b/src/java.base/share/native/libnio/nio_util.c
@@ -23,9 +23,20 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2025, 2025 All Rights Reserved
+ * ===========================================================================
+ */
+
 #include "jni.h"
 #include "jvm.h"
 #include "jni_util.h"
+
+#include "j9access.h"
+/* tracehelp.c defines getTraceInterfaceFromVM(), used by J9_UTINTERFACE_FROM_VM(). */
+#include "tracehelp.c"
+#include "ut_jcl_nio.c"
 
 JNIEXPORT jint JNICALL
 DEF_JNI_OnLoad(JavaVM *vm, void *reserved)
@@ -35,6 +46,8 @@ DEF_JNI_OnLoad(JavaVM *vm, void *reserved)
     if ((*vm)->GetEnv(vm, (void**) &env, JNI_VERSION_1_2) != JNI_OK) {
         return JNI_EVERSION; /* JNI version not supported */
     }
+
+    UT_JCL_NIO_MODULE_LOADED(J9_UTINTERFACE_FROM_VM((J9JavaVM *)vm));
 
     return JNI_VERSION_1_2;
 }

--- a/src/java.base/unix/native/libjava/UnixFileSystem_md.c
+++ b/src/java.base/unix/native/libjava/UnixFileSystem_md.c
@@ -23,6 +23,12 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2025, 2025 All Rights Reserved
+ * ===========================================================================
+ */
+
 #include <unistd.h>
 #include <assert.h>
 #include <sys/types.h>
@@ -49,6 +55,8 @@
 #include "io_util_md.h"
 #include "java_io_FileSystem.h"
 #include "java_io_UnixFileSystem.h"
+
+#include "ut_jcl_java.h"
 
 #if defined(_AIX)
   #if !defined(NAME_MAX)
@@ -281,6 +289,7 @@ Java_java_io_UnixFileSystem_createFileExclusively(JNIEnv *env, jclass cls,
                 if (errno != EEXIST)
                     JNU_ThrowIOExceptionWithLastError(env, path);
             } else {
+                Trc_io_UnixFileSystem_createFileExclusively_close(fd);
                 if (close(fd) == -1)
                     JNU_ThrowIOExceptionWithLastError(env, path);
                 rv = JNI_TRUE;

--- a/src/java.base/unix/native/libjava/io_util_md.c
+++ b/src/java.base/unix/native/libjava/io_util_md.c
@@ -22,6 +22,13 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2025, 2025 All Rights Reserved
+ * ===========================================================================
+ */
+
 #include "jni.h"
 #include "jni_util.h"
 #include "jvm.h"
@@ -37,6 +44,8 @@
 #if defined(__linux__) || defined(_ALLBSD_SOURCE) || defined(_AIX)
 #include <sys/ioctl.h>
 #endif
+
+#include "ut_jcl_java.h"
 
 #ifdef MACOSX
 
@@ -88,6 +97,11 @@ handleOpen(const char *path, int oflag, int mode) {
             close(fd);
             fd = -1;
         }
+    }
+    if (-1 == fd) {
+        Trc_io_handleOpen_err(path, oflag, mode, 0, 0, errno);
+    } else {
+        Trc_io_handleOpen(path, oflag, mode, 0, 0, (jlong)fd);
     }
     return fd;
 }
@@ -159,7 +173,10 @@ fileDescriptorClose(JNIEnv *env, jobject this)
             close(devnull);
         }
     } else if (close(fd) == -1) {
+        Trc_io_fileDescriptorClose_err((jlong)fd, errno);
         JNU_ThrowIOExceptionWithLastError(env, "close failed");
+    } else {
+        Trc_io_fileDescriptorClose((jlong)fd);
     }
 }
 

--- a/src/java.base/unix/native/libnio/ch/FileDispatcherImpl.c
+++ b/src/java.base/unix/native/libnio/ch/FileDispatcherImpl.c
@@ -23,6 +23,12 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2025, 2025 All Rights Reserved
+ * ===========================================================================
+ */
+
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <fcntl.h>
@@ -58,6 +64,8 @@
 #include "nio_util.h"
 #include "sun_nio_ch_FileDispatcherImpl.h"
 #include "java_lang_Long.h"
+
+#include "ut_jcl_nio.h"
 
 static int preCloseFD = -1;     /* File descriptor to which we dup other fd's
                                    before closing them for real */
@@ -288,6 +296,7 @@ Java_sun_nio_ch_FileDispatcherImpl_release0(JNIEnv *env, jobject this,
 
 static void closeFileDescriptor(JNIEnv *env, int fd) {
     if (fd != -1) {
+        Trc_nio_ch_FileDispatcherImpl_close(fd);
         int result = close(fd);
         if (result < 0)
             JNU_ThrowIOExceptionWithLastError(env, "Close failed");

--- a/src/java.base/unix/native/libnio/ch/Net.c
+++ b/src/java.base/unix/native/libnio/ch/Net.c
@@ -23,6 +23,12 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2025, 2025 All Rights Reserved
+ * ===========================================================================
+ */
+
 #include <poll.h>
 #include <sys/types.h>
 #include <sys/socket.h>
@@ -30,6 +36,7 @@
 #include <netinet/in.h>
 #include <netinet/tcp.h>
 #include <limits.h>
+#include <arpa/inet.h>
 
 #include "jni.h"
 #include "jni_util.h"
@@ -44,6 +51,8 @@
 #ifdef _AIX
 #include <sys/utsname.h>
 #endif
+
+#include "ut_jcl_nio.h"
 
 /**
  * IP_MULTICAST_ALL supported since 2.6.31 but may not be available at
@@ -309,12 +318,22 @@ Java_sun_nio_ch_Net_connect0(JNIEnv *env, jclass clazz, jboolean preferIPv6,
     SOCKETADDRESS sa;
     int sa_len = 0;
     int rv;
+    int fd;
 
     if (NET_InetAddressToSockaddr(env, iao, port, &sa, &sa_len, preferIPv6) != 0) {
         return IOS_THROWN;
     }
 
-    rv = connect(fdval(env, fdo), &sa.sa, sa_len);
+    fd = fdval(env, fdo);
+    if (AF_INET == sa.sa4.sin_family) {
+        char buf[INET_ADDRSTRLEN];
+        Trc_nio_ch_Net_connect4((jlong)fd, inet_ntop(AF_INET, &sa.sa4.sin_addr, buf, sizeof(buf)), port, sa_len);
+    } else if (AF_INET6 == sa.sa6.sin6_family) {
+        char buf[INET6_ADDRSTRLEN];
+        Trc_nio_ch_Net_connect6((jlong)fd, inet_ntop(AF_INET6, &sa.sa6.sin6_addr, buf, sizeof(buf)), port, ntohl(sa.sa6.sin6_scope_id), sa_len);
+    }
+
+    rv = connect(fd, &sa.sa, sa_len);
     if (rv != 0) {
         if (errno == EINPROGRESS) {
             return IOS_UNAVAILABLE;

--- a/src/java.base/windows/native/libjava/io_util_md.c
+++ b/src/java.base/windows/native/libjava/io_util_md.c
@@ -23,6 +23,12 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2025, 2025 All Rights Reserved
+ * ===========================================================================
+ */
+
 #include "jni.h"
 #include "jni_util.h"
 #include "jvm.h"
@@ -41,6 +47,7 @@
 #include <limits.h>
 #include <wincon.h>
 
+#include "ut_jcl_java.h"
 
 static DWORD MAX_INPUT_EVENTS = 2000;
 
@@ -247,12 +254,22 @@ winFileHandleOpen(JNIEnv *env, jstring path, int flags)
         FILE_ATTRIBUTE_NORMAL;
     const DWORD flagsAndAttributes = maybeWriteThrough | maybeDeleteOnClose;
     HANDLE h = NULL;
+    char *pathStr = NULL;
 
     WCHAR *pathbuf = pathToNTPath(env, path, JNI_TRUE);
     if (pathbuf == NULL) {
         /* Exception already pending */
         return -1;
     }
+
+    if (TrcEnabled_Trc_io_handleOpen) {
+        int length = WideCharToMultiByte(CP_UTF8, 0, pathbuf, -1, NULL, 0, NULL, NULL);
+        pathStr = malloc(length);
+        if (NULL != pathStr) {
+            WideCharToMultiByte(CP_UTF8, 0, pathbuf, -1, pathStr, length, NULL, NULL);
+        }
+    }
+
     h = CreateFileW(
         pathbuf,            /* Wide char path name */
         access,             /* Read and/or write permission */
@@ -264,9 +281,13 @@ winFileHandleOpen(JNIEnv *env, jstring path, int flags)
     free(pathbuf);
 
     if (h == INVALID_HANDLE_VALUE) {
+        Trc_io_handleOpen_err(pathStr, access, sharing, disposition, flagsAndAttributes, GetLastError());
+        free(pathStr);
         throwFileNotFoundException(env, path);
         return -1;
     }
+    Trc_io_handleOpen(pathStr, access, sharing, disposition, flagsAndAttributes, (jlong)h);
+    free(pathStr);
     return (jlong) h;
 }
 
@@ -561,7 +582,10 @@ fileDescriptorClose(JNIEnv *env, jobject this)
     }
 
     if (CloseHandle(h) == 0) { /* Returns zero on failure */
+        Trc_io_fileDescriptorClose_err((jlong)fd, GetLastError());
         JNU_ThrowIOExceptionWithLastError(env, "close failed");
+    } else {
+        Trc_io_fileDescriptorClose((jlong)fd);
     }
 }
 

--- a/src/java.base/windows/native/libnet/PlainSocketImpl.c
+++ b/src/java.base/windows/native/libnet/PlainSocketImpl.c
@@ -22,10 +22,19 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2025, 2025 All Rights Reserved
+ * ===========================================================================
+ */
+
 #include "net_util.h"
 
 #include "java_net_PlainSocketImpl.h"
 #include "java_net_SocketOptions.h"
+
+#include "ut_jcl_net.h"
 
 #define SET_BLOCKING     0
 #define SET_NONBLOCKING  1
@@ -136,6 +145,14 @@ JNIEXPORT jint JNICALL Java_java_net_PlainSocketImpl_connect0
      */
     if (so_rv == 0 && type == SOCK_STREAM && IS_LOOPBACK_ADDRESS(&sa)) {
         NET_EnableFastTcpLoopbackConnect(fd);
+    }
+
+    if (AF_INET == sa.sa4.sin_family) {
+        char buf[INET_ADDRSTRLEN];
+        Trc_PlainSocketImpl_socketConnect4("", fd, inet_ntop(AF_INET, &sa.sa4.sin_addr, buf, sizeof(buf)), port, sa_len);
+    } else if (AF_INET6 == sa.sa6.sin6_family) {
+        char buf[INET6_ADDRSTRLEN];
+        Trc_PlainSocketImpl_socketConnect6("", fd, inet_ntop(AF_INET6, &sa.sa6.sin6_addr, buf, sizeof(buf)), port, ntohl(sa.sa6.sin6_scope_id), sa_len);
     }
 
     rv = connect(fd, &sa.sa, sa_len);

--- a/src/java.base/windows/native/libnet/net_util_md.c
+++ b/src/java.base/windows/native/libnet/net_util_md.c
@@ -22,10 +22,19 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2025, 2025 All Rights Reserved
+ * ===========================================================================
+ */
+
 #include "net_util.h"
 
 #include "java_net_InetAddress.h"
 #include "java_net_SocketOptions.h"
+
+#include "ut_jcl_net.h"
 
 // Taken from mstcpip.h in Windows SDK 8.0 or newer.
 #define SIO_LOOPBACK_FAST_PATH              _WSAIOW(IOC_VENDOR,16)
@@ -461,6 +470,7 @@ NET_SocketClose(int fd) {
             shutdown(fd, SD_SEND);
         }
     }
+    Trc_NET_SocketClose(fd);
     ret = closesocket (fd);
     return ret;
 }

--- a/src/java.base/windows/native/libnio/ch/Net.c
+++ b/src/java.base/windows/native/libnio/ch/Net.c
@@ -23,6 +23,12 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2025, 2025 All Rights Reserved
+ * ===========================================================================
+ */
+
 #include <windows.h>
 #include <winsock2.h>
 #include "jni.h"
@@ -36,6 +42,8 @@
 
 #include "sun_nio_ch_Net.h"
 #include "sun_nio_ch_PollArrayWrapper.h"
+
+#include "ut_jcl_nio.h"
 
 /**
  * Definitions to allow for building with older SDK include files.
@@ -211,6 +219,14 @@ Java_sun_nio_ch_Net_connect0(JNIEnv *env, jclass clazz, jboolean preferIPv6, job
      */
     if (so_rv == 0 && type == SOCK_STREAM && IS_LOOPBACK_ADDRESS(&sa)) {
         NET_EnableFastTcpLoopbackConnect((jint)s);
+    }
+
+    if (AF_INET == sa.sa4.sin_family) {
+        char buf[INET_ADDRSTRLEN];
+        Trc_nio_ch_Net_connect4((jlong)s, inet_ntop(AF_INET, &sa.sa4.sin_addr, buf, sizeof(buf)), port, sa_len);
+    } else if (AF_INET6 == sa.sa6.sin6_family) {
+        char buf[INET6_ADDRSTRLEN];
+        Trc_nio_ch_Net_connect6((jlong)s, inet_ntop(AF_INET6, &sa.sa6.sin6_addr, buf, sizeof(buf)), port, ntohl(sa.sa6.sin6_scope_id), sa_len);
     }
 
     rv = connect(s, &sa.sa, sa_len);

--- a/src/java.base/windows/native/libnio/ch/SocketDispatcher.c
+++ b/src/java.base/windows/native/libnio/ch/SocketDispatcher.c
@@ -23,6 +23,12 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2025, 2025 All Rights Reserved
+ * ===========================================================================
+ */
+
 #include <windows.h>
 #include <winsock2.h>
 #include <ctype.h>
@@ -33,6 +39,8 @@
 #include "sun_nio_ch_SocketDispatcher.h"
 #include "nio.h"
 #include "nio_util.h"
+
+#include "ut_jcl_nio.h"
 
 
 /**************************************************************
@@ -282,6 +290,7 @@ Java_sun_nio_ch_SocketDispatcher_close0(JNIEnv *env, jclass clazz,
                                          jobject fdo)
 {
     jint fd = fdval(env, fdo);
+    Trc_nio_ch_SocketDispatcher_close(fd);
     if (closesocket(fd) == SOCKET_ERROR) {
         JNU_ThrowIOExceptionWithLastError(env, "Socket close failed");
     }


### PR DESCRIPTION
Depends on https://github.com/eclipse-openj9/openj9/pull/20936

Issue https://github.ibm.com/runtimes/semeru-requests/issues/46

Linux jcl_java(io) tracepoints
```
12:30:10.360 0x25a00        jcl_java.2         - io_handleOpen(filename=myfile.txt, access=0xc2, sharing=0x1b6, creation=0x0, attributes=0x0, handle=13)
12:30:10.360 0x25a00        jcl_java.4         - io_createFileExclusively_close(handle=13)
12:30:10.360 0x25a00        jcl_java.2         - io_handleOpen(filename=myfile2.txt, access=0x241, sharing=0x1b6, creation=0x0, attributes=0x0, handle=13)
12:30:10.360 0x25a00        jcl_java.0         - io_fileDescriptorClose(handle=13)
```

Linux jcl_net tracepoints
```
12:31:23.052*0x25a00         jcl_net.1         - NET_Connect(descriptor=11, connect_to(AF_INET6: addr=::ffff:127.0.0.1 port=34671 scope_id=0), length=28)
12:31:23.052 0x25a00         jcl_net.2         - NET_SocketClose(descriptor=11)
12:31:23.064*0x147700         jcl_net.2         - NET_SocketClose(descriptor=10)
12:31:23.064 0x147700         jcl_net.2         - NET_SocketClose(descriptor=12)
12:31:23.064 0x147700         jcl_net.2         - NET_SocketClose(descriptor=14)

12:32:06.575*0x25a00         jcl_net.0         - NET_Connect(descriptor=11, connect_to(AF_INET: addr=127.0.0.1 port=43657), length=16)
12:32:06.575 0x25a00         jcl_net.2         - NET_SocketClose(descriptor=11)
12:32:06.586*0x147700         jcl_net.2         - NET_SocketClose(descriptor=14)
12:32:06.586 0x147700         jcl_net.2         - NET_SocketClose(descriptor=10)
12:32:06.586 0x147700         jcl_net.2         - NET_SocketClose(descriptor=12)
```

Linux jcl_nio tracepoints
```
12:32:49.495*0x25a00         jcl_nio.1         - nio_ch_Net_Connect(descriptor=13, connect_to(AF_INET6: addr=::ffff:127.0.0.1 port=35587 scope_id=0), length=28)
12:32:49.495 0x25a00         jcl_nio.5         - nio_ch_FileDispatcherImpl_close(descriptor=13)

12:33:06.587*0x25a00         jcl_nio.0         - nio_ch_Net_Connect(descriptor=13, connect_to(AF_INET: addr=127.0.0.1 port=42109), length=16)
12:33:06.587 0x25a00         jcl_nio.5         - nio_ch_FileDispatcherImpl_close(descriptor=13)
```

Windows jcl_java(io) tracepoints
```
12:29:26.685 0x25a00        jcl_java.2         - io_handleOpen(filename=myfile2.txt, access=0x40000000, sharing=0x3, creation=0x2, attributes=0x80, handle=1996)
12:29:26.685 0x25a00        jcl_java.0         - io_fileDescriptorClose(handle=1996)
```

Windows jcl_net tracepoints
```
12:33:59.527*0x25a00         jcl_net.4         - PlainSocketImpl_socketConnect(descriptor=1804, connect_to(AF_INET6: addr=::ffff:127.0.0.1 port=50161 scope_id=0), length=28)
12:33:59.529 0x25a00         jcl_net.2         - NET_SocketClose(descriptor=1804)

12:34:26.462*0x25a00         jcl_net.3         - PlainSocketImpl_socketConnect(descriptor=1980, connect_to(AF_INET: addr=127.0.0.1 port=50191), length=16)
12:34:26.462 0x25a00         jcl_net.2         - NET_SocketClose(descriptor=1980)
```

Windows jcl_nio tracepoints
```
12:35:31.307*0x25a00         jcl_nio.1         - nio_ch_Net_Connect(descriptor=2008, connect_to(AF_INET6: addr=::ffff:127.0.0.1 port=50199 scope_id=0), length=28)
12:35:31.307 0x25a00         jcl_nio.4         - nio_ch_SocketDispatcher_close(descriptor=2008)

12:35:55.021*0x25a00         jcl_nio.0         - nio_ch_Net_Connect(descriptor=1996, connect_to(AF_INET: addr=127.0.0.1 port=53801), length=16)
12:35:55.021 0x25a00         jcl_nio.4         - nio_ch_SocketDispatcher_close(descriptor=1996)
```

AIX jcl_java(io) tracepoints
```
12:25:36.279 0x30010700        jcl_java.2         - io_handleOpen(filename=myfile.txt, access=0x502, sharing=0x1b6, creation=0x0, attributes=0x0, handle=8)
12:25:36.279 0x30010700        jcl_java.4         - io_createFileExclusively_close(handle=8)
12:25:36.280 0x30010700        jcl_java.2         - io_handleOpen(filename=myfile2.txt, access=0x301, sharing=0x1b6, creation=0x0, attributes=0x0, handle=8)
12:25:36.280 0x30010700        jcl_java.0         - io_fileDescriptorClose(handle=8)
```

AIX jcl_net tracepoints
```
22:32:52.098*0x30010700         jcl_net.1         - NET_Connect(descriptor=7, connect_to(AF_INET6: addr=::ffff:127.0.0.1 port=39935 scope_id=0), length=28)
22:32:52.131 0x30010700         jcl_net.2         - NET_SocketClose(descriptor=7)
22:32:52.265*0x30120800         jcl_net.2         - NET_SocketClose(descriptor=8)

22:33:51.972*0x30010700         jcl_net.0         - NET_Connect(descriptor=8, connect_to(AF_INET: addr=127.0.0.1 port=39938), length=16)
22:33:51.977 0x30010700         jcl_net.2         - NET_SocketClose(descriptor=8)
22:33:52.039*0x30120800         jcl_net.2         - NET_SocketClose(descriptor=9)
```

AIX jcl_nio tracepoints
```
12:26:41.234*0x30010700         jcl_nio.1         - nio_ch_Net_Connect(descriptor=9, connect_to(AF_INET6: addr=::ffff:127.0.0.1 port=39763 scope_id=0), length=28)
12:26:41.236 0x30010700         jcl_nio.5         - nio_ch_FileDispatcherImpl_close(descriptor=9)

12:27:46.464*0x30010700         jcl_nio.0         - nio_ch_Net_Connect(descriptor=5, connect_to(AF_INET: addr=127.0.0.1 port=39766), length=16)
12:27:46.466 0x30010700         jcl_nio.5         - nio_ch_FileDispatcherImpl_close(descriptor=5)
```

amac jcl_java(io) tracepoints
```
12:53:08.590 0x159879f00        jcl_java.2         - io_handleOpen(filename=myfile.txt, access=0xa02, sharing=0x1b6, creation=0x0, attributes=0x0, handle=10)
12:53:08.590 0x159879f00        jcl_java.4         - io_createFileExclusively_close(handle=10)
12:53:08.590 0x159879f00        jcl_java.2         - io_handleOpen(filename=myfile2.txt, access=0x601, sharing=0x1b6, creation=0x0, attributes=0x0, handle=10)
12:53:08.590 0x159879f00        jcl_java.0         - io_fileDescriptorClose(handle=10)
```

amac jcl_net tracepoints
```
12:54:05.780*0x13a887900         jcl_net.1         - NET_Connect(descriptor=10, connect_to(AF_INET6: addr=::ffff:127.0.0.1 port=49157 scope_id=0), length=28)
12:54:05.781 0x13a887900         jcl_net.2         - NET_SocketClose(descriptor=10)
12:54:05.800*0x13a917900         jcl_net.2         - NET_SocketClose(descriptor=12)
12:54:05.800 0x13a917900         jcl_net.2         - NET_SocketClose(descriptor=11)
12:54:05.800 0x13a917900         jcl_net.2         - NET_SocketClose(descriptor=7)

12:54:34.264*0x12408ad00         jcl_net.0         - NET_Connect(descriptor=10, connect_to(AF_INET: addr=127.0.0.1 port=49160), length=16)
12:54:34.265 0x12408ad00         jcl_net.2         - NET_SocketClose(descriptor=10)
12:54:34.274*0x11900c500         jcl_net.2         - NET_SocketClose(descriptor=11)
```

amac jcl_nio tracepoints
```
12:55:29.703*0x13e087d00         jcl_nio.1         - nio_ch_Net_Connect(descriptor=10, connect_to(AF_INET6: addr=::ffff:127.0.0.1 port=49166 scope_id=0), length=28)
12:55:29.705 0x13e087d00         jcl_nio.5         - nio_ch_FileDispatcherImpl_close(descriptor=10)

12:55:14.310*0x124888100         jcl_nio.0         - nio_ch_Net_Connect(descriptor=10, connect_to(AF_INET: addr=127.0.0.1 port=49163), length=16)
12:55:14.312 0x124888100         jcl_nio.5         - nio_ch_FileDispatcherImpl_close(descriptor=10)
```

xmac jcl_java(io) tracepoints
```
12:58:24.198 0xb193000        jcl_java.2         - io_handleOpen(filename=myfile.txt, access=0xa02, sharing=0x1b6, creation=0x0, attributes=0x0, handle=10)
12:58:24.198 0xb193000        jcl_java.4         - io_createFileExclusively_close(handle=10)
12:58:24.198 0xb193000        jcl_java.2         - io_handleOpen(filename=myfile2.txt, access=0x601, sharing=0x1b6, creation=0x0, attributes=0x0, handle=10)
12:58:24.198 0xb193000        jcl_java.0         - io_fileDescriptorClose(handle=10)
```

xmac jcl_net tracepoints
```
12:58:55.941*0x138ee000         jcl_net.1         - NET_Connect(descriptor=10, connect_to(AF_INET6: addr=::ffff:127.0.0.1 port=49157 scope_id=0), length=28)
12:58:55.942 0x138ee000         jcl_net.2         - NET_SocketClose(descriptor=10)

12:59:21.704*0x5844000         jcl_net.0         - NET_Connect(descriptor=10, connect_to(AF_INET: addr=127.0.0.1 port=49160), length=16)
12:59:21.706 0x5844000         jcl_net.2         - NET_SocketClose(descriptor=10)
12:59:21.732*0x5956800         jcl_net.2         - NET_SocketClose(descriptor=7)
12:59:21.732 0x5956800         jcl_net.2         - NET_SocketClose(descriptor=11)
12:59:21.732 0x5956800         jcl_net.2         - NET_SocketClose(descriptor=12)
```

xmac jcl_nio tracepoints
```
13:00:23.007*0xa00a000         jcl_nio.1         - nio_ch_Net_Connect(descriptor=10, connect_to(AF_INET6: addr=::ffff:127.0.0.1 port=49166 scope_id=0), length=28)
13:00:23.008 0xa00a000         jcl_nio.5         - nio_ch_FileDispatcherImpl_close(descriptor=10)

13:00:08.027*0xc153000         jcl_nio.0         - nio_ch_Net_Connect(descriptor=10, connect_to(AF_INET: addr=127.0.0.1 port=49163), length=16)
13:00:08.029 0xc153000         jcl_nio.5         - nio_ch_FileDispatcherImpl_close(descriptor=10)
```