### PR TITLE
Disable ConfigFileTest

### DIFF
--- a/test/jdk/ProblemList-FIPS140_3_OpenJCEPlusFIPS.FIPS140-3.txt
+++ b/test/jdk/ProblemList-FIPS140_3_OpenJCEPlusFIPS.FIPS140-3.txt
@@ -218,6 +218,7 @@ java/security/SecureRandom/ThreadSafe.java https://github.com/eclipse-openj9/ope
 java/security/Security/AddProvider.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 java/security/Security/CaseInsensitiveAlgNames.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 java/security/Security/ClassLoaderDeadlock/Deadlock.sh https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
+java/security/Security/ConfigFileTest.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 java/security/Security/removing/RemoveProviderByIdentity.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 java/security/Security/removing/RemoveStaticProvider.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 java/security/Security/signedfirst/DynStatic.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all

--- a/test/jdk/ProblemList-FIPS140_3_OpenJcePlus.txt
+++ b/test/jdk/ProblemList-FIPS140_3_OpenJcePlus.txt
@@ -210,6 +210,7 @@ java/security/SecureRandom/SerializedSeedTest.java https://github.com/eclipse-op
 java/security/SecureRandom/ThreadSafe.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
 java/security/Security/CaseInsensitiveAlgNames.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
 java/security/Security/ClassLoaderDeadlock/Deadlock.sh https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
+java/security/Security/ConfigFileTest.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
 java/security/Security/removing/RemoveProviderByIdentity.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
 java/security/Security/signedfirst/DynStatic.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
 java/security/Signature/ByteBuffers.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all


### PR DESCRIPTION
This update ignores results from ConfigFileTest in both strict and weak FIPS 140-3 excludes lists.

Signed-off-by: Jason Katonica <katonica@us.ibm.com>

