### PR TITLE
Backport 8347740: java/io/File/createTempFile/SpecialTempFile.java failing

### DIFF
--- a/test/jdk/java/io/File/createTempFile/SpecialTempFile.java
+++ b/test/jdk/java/io/File/createTempFile/SpecialTempFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,8 +41,12 @@ import jdk.test.lib.Platform;
 import jdk.test.lib.OSVersion;
 
 public class SpecialTempFile {
+    //
+    // If exceptionExpected == null, then any IOException thrown by
+    // File.createTempFile is ignored.
+    //
     private static void test(String name, String[] prefix, String[] suffix,
-                             boolean exceptionExpected) throws IOException
+                             Boolean exceptionExpected) throws IOException
     {
         if (prefix == null || suffix == null
             || prefix.length != suffix.length)
@@ -69,19 +73,21 @@ public class SpecialTempFile {
                     f = File.createTempFile(prefix[i], suffix[i],
                         tempDir.toFile());
                 } catch (IOException e) {
-                    if (exceptionExpected) {
-                        if (e.getMessage().startsWith(exceptionMsg))
-                            exceptionThrown = true;
-                        else
-                            System.out.println("Wrong error message:" +
-                                               e.getMessage());
-                    } else {
-                        throw e;
+                    if (exceptionExpected != null) {
+                        if (exceptionExpected) {
+                            if (e.getMessage().startsWith(exceptionMsg))
+                                exceptionThrown = true;
+                            else
+                                System.out.println("Wrong error message:" +
+                                                   e.getMessage());
+                        } else {
+                            throw e;
+                        }
+
+                        if (exceptionExpected && (!exceptionThrown || f != null))
+                            throw new RuntimeException("IOException expected");
                     }
                 }
-
-                if (exceptionExpected && (!exceptionThrown || f != null))
-                    throw new RuntimeException("IOException is expected");
             }
         }
     }
@@ -110,9 +116,12 @@ public class SpecialTempFile {
         // Test JDK-8013827
         String[] resvPre = { "LPT1.package.zip", "com7.4.package.zip" };
         String[] resvSuf = { ".temp", ".temp" };
-        boolean exceptionExpected =
-            !(System.getProperty("os.name").endsWith("11") ||
-              new OSVersion(10, 0).compareTo(OSVersion.current()) > 0);
-        test("ReservedName", resvPre, resvSuf, exceptionExpected);
+
+        System.out.println("OS name:    " + System.getProperty("os.name") + "\n" +
+                           "OS version: " + OSVersion.current());
+
+        // Here the test is for whether File.createTempFile hangs, so whether
+        // an exception is thrown is ignored: expectedException == null
+        test("ReservedName", resvPre, resvSuf, null);
     }
 }


### PR DESCRIPTION
Fix the test so it doesn't fail on Windows Server 2025 machines, without waiting to see if OpenJDK will backport the test fix.

So far there is no indication of a backport in
https://bugs.openjdk.org/browse/JDK-8345368
https://bugs.openjdk.org/browse/JDK-8347740

https://github.com/ibmruntimes/openj9-openjdk-jdk17/commit/0ff2c3742e