### PR TITLE
Backport TimestampCheck.java test fix

### DIFF
--- a/test/jdk/sun/security/tools/jarsigner/TimestampCheck.java
+++ b/test/jdk/sun/security/tools/jarsigner/TimestampCheck.java
@@ -865,7 +865,7 @@ public class TimestampCheck {
         }
 
         gencert("tsold", "-ext eku:critical=ts -startdate -40d -validity 500");
-        gencert("tsbefore2019", "-ext eku:critical=ts -startdate 2018/01/01 -validity 3000");
+        gencert("tsbefore2019", "-ext eku:critical=ts -startdate 2018/01/01 -validity 5000");
 
         gencert("tsweak", "-ext eku:critical=ts");
         gencert("tsdisabled", "-ext eku:critical=ts");


### PR DESCRIPTION
This should make it's way via OpenJDK eventually, but avoid the failure now.

See https://github.com/ibmruntimes/openj9-openjdk-jdk24/pull/49