### PR TITLE
OpenJCEPlus KeyDestructionTest Toleration

### DIFF
--- a/test/jdk/ProblemList-FIPS140_3_OpenJCEPlusFIPS.FIPS140-3.txt
+++ b/test/jdk/ProblemList-FIPS140_3_OpenJCEPlusFIPS.FIPS140-3.txt
@@ -674,7 +674,6 @@ javax/net/ssl/templates/SSLEngineTemplate.java https://github.com/eclipse-openj9
 javax/net/ssl/templates/SSLSocketSSLEngineTemplate.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 javax/net/ssl/templates/SSLSocketTemplate.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 javax/rmi/ssl/SocketFactoryTest.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
-javax/security/auth/Destroyable/KeyDestructionTest.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 javax/security/auth/PrivateCredentialPermission/MoreThenOnePrincipals.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 javax/security/auth/Subject/SubjectNullTests.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 javax/security/auth/login/Configuration/GetInstance.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all

--- a/test/jdk/ProblemList-FIPS140_3_OpenJcePlus.txt
+++ b/test/jdk/ProblemList-FIPS140_3_OpenJcePlus.txt
@@ -614,7 +614,6 @@ javax/net/ssl/templates/SSLEngineTemplate.java https://github.com/eclipse-openj9
 javax/net/ssl/templates/SSLSocketSSLEngineTemplate.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
 javax/net/ssl/templates/SSLSocketTemplate.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
 javax/rmi/ssl/SocketFactoryTest.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
-javax/security/auth/Destroyable/KeyDestructionTest.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
 javax/security/auth/PrivateCredentialPermission/MoreThenOnePrincipals.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
 javax/security/auth/login/Configuration/GetInstance.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
 javax/security/sasl/Sasl/ClientServerTest.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all

--- a/test/jdk/javax/security/auth/Destroyable/KeyDestructionTest.java
+++ b/test/jdk/javax/security/auth/Destroyable/KeyDestructionTest.java
@@ -22,6 +22,12 @@
  */
 
 /*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2025, 2025 All Rights Reserved
+ * ===========================================================================
+ */
+
+/*
  * @test
  * @bug 6263419
  * @summary No way to clean the memory for a java.security.Key
@@ -35,15 +41,28 @@ import javax.security.auth.DestroyFailedException;
 
 public class KeyDestructionTest {
     public static void main(String[] args) throws Exception {
-        KeyPair keypair = generateKeyPair("RSA", 1024);
+        String kpgAlgorithm = "RSA";
+        KeyPair keypair = generateKeyPair(kpgAlgorithm, 1024);
 
         // Check keys that support and have implemented key destruction
         testKeyDestruction(new MyDestroyableSecretKey());
         testKeyDestruction(new MyDestroyablePrivateKey());
 
-        // Check keys that support but have not implemented key destruction
-        testNoKeyDestruction(generateSecretKey("AES", 128));
-        testNoKeyDestruction(keypair.getPrivate());
+        // AES key implementations, from providers OpenJCEPlus and OpenJCEPlusFIPS,
+        // do implement destroyable for AES keys, other providers do not.
+        if (KeyGenerator.getInstance("AES").getProvider().getName().startsWith("OpenJCEPlus")) {
+            testKeyDestruction(generateSecretKey("AES", 128));
+        } else {
+            testNoKeyDestruction(generateSecretKey("AES", 128));
+        }
+
+        // RSA key implementations, from providers OpenJCEPlus and OpenJCEPlusFIPS,
+        // do implement destroyable for RSA keys, other providers do not.
+        if (KeyPairGenerator.getInstance(kpgAlgorithm).getProvider().getName().startsWith("OpenJCEPlus")) {
+            testKeyDestruction(keypair.getPrivate());
+        } else {
+            testNoKeyDestruction(keypair.getPrivate());
+        }
 
         // Check keys that do not support key destruction
         try {


### PR DESCRIPTION
OpenJCEPlus and OpenJCEPlusFIPS providers support key destruction for the key material being tested by KeyDestructionTest. The test is being adjusted accordingly.

Back-ported from: https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/981

Signed-off-by: Jason Katonica <katonica@us.ibm.com>