### PR TITLE
Check RestrictedSecurity profile hash after Providers init

### DIFF
--- a/closed/src/java.base/share/classes/openj9/internal/security/RestrictedSecurity.java
+++ b/closed/src/java.base/share/classes/openj9/internal/security/RestrictedSecurity.java
@@ -79,6 +79,8 @@ public final class RestrictedSecurity {
 
     private static ProfileParser profileParser;
 
+    private static boolean enableCheckHashes;
+
     private static RestrictedSecurityProperties restricts;
 
     private static final Set<String> unmodifiableProperties = new HashSet<>();
@@ -93,7 +95,6 @@ public final class RestrictedSecurity {
         supportedPlatformsOpenJCEPlus.put("Arch", List.of("amd64", "ppc64", "s390x"));
         supportedPlatformsOpenJCEPlus.put("OS", List.of("Linux", "AIX", "Windows"));
 
-        @SuppressWarnings("removal")
         String[] props = AccessController.doPrivileged(
                 new PrivilegedAction<>() {
                     @Override
@@ -191,19 +192,27 @@ public final class RestrictedSecurity {
      * extending profiles, instead of altering them, a digest of the profile
      * is calculated and compared to the expected value.
      */
-    @SuppressWarnings("removal")
-    private static void checkHashValues() {
+    public static void checkHashValues() {
+        checkHashValues(true);
+    }
+
+    private static void checkHashValues(boolean fromProviders) {
         ProfileParser parser = profileParser;
         if (parser != null) {
-            boolean isVerifying;
-            if (System.getSecurityManager() == null) {
-                isVerifying = isJarVerifierInStackTrace();
-            } else {
-                isVerifying = AccessController.doPrivileged((PrivilegedAction<Boolean>)(() -> isJarVerifierInStackTrace()));
+            if (fromProviders) {
+                enableCheckHashes = true;
             }
-            if (!isVerifying) {
-                profileParser = null;
-                parser.checkHashValues();
+            if (enableCheckHashes) {
+                boolean isVerifying;
+                if (System.getSecurityManager() == null) {
+                    isVerifying = isJarVerifierInStackTrace();
+                } else {
+                    isVerifying = AccessController.doPrivileged((PrivilegedAction<Boolean>)(() -> isJarVerifierInStackTrace()));
+                }
+                if (!isVerifying) {
+                    profileParser = null;
+                    parser.checkHashValues();
+                }
             }
         }
     }
@@ -277,7 +286,7 @@ public final class RestrictedSecurity {
      */
     public static boolean isServiceAllowed(Service service) {
         if (securityEnabled) {
-            checkHashValues();
+            checkHashValues(false);
             return restricts.isRestrictedServiceAllowed(service, true);
         }
         return true;
@@ -291,7 +300,7 @@ public final class RestrictedSecurity {
      */
     public static boolean canServiceBeRegistered(Service service) {
         if (securityEnabled) {
-            checkHashValues();
+            checkHashValues(false);
             return restricts.isRestrictedServiceAllowed(service, false);
         }
         return true;
@@ -305,7 +314,7 @@ public final class RestrictedSecurity {
      */
     public static boolean isProviderAllowed(String providerName) {
         if (securityEnabled) {
-            checkHashValues();
+            checkHashValues(false);
             // Remove argument, e.g. -NSS-FIPS, if present.
             int pos = providerName.indexOf('-');
             if (pos >= 0) {
@@ -325,7 +334,7 @@ public final class RestrictedSecurity {
      */
     public static boolean isProviderAllowed(Class<?> providerClazz) {
         if (securityEnabled) {
-            checkHashValues();
+            checkHashValues(false);
             String providerClassName = providerClazz.getName();
 
             // Check if the specified class extends java.security.Provider.

--- a/src/java.base/share/classes/sun/security/jca/Providers.java
+++ b/src/java.base/share/classes/sun/security/jca/Providers.java
@@ -110,6 +110,7 @@ public class Providers {
         // triggers a getInstance() call (although that should not happen)
         providerList = ProviderList.EMPTY;
         providerList = ProviderList.fromSecurityProperties();
+        RestrictedSecurity.checkHashValues();
     }
 
     // Return Sun provider.


### PR DESCRIPTION
If the `Providers` class hasn't had a chance to initialize, the required message digest algorithms are not available to check the hash value of the `RestrictedSecurity` profile.

With this change, the check is only allowed after the appropriate initialization has been performed.

Fixes: https://github.com/eclipse-openj9/openj9/issues/21615

Back-ported from: https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/991

Signed-off-by: Kostas Tsiounis <kostas.tsiounis@ibm.com>