### PR TITLE
Backport 8286694 to jdk11

### DIFF
--- a/src/java.base/share/native/libjli/java.c
+++ b/src/java.base/share/native/libjli/java.c
@@ -25,7 +25,7 @@
 
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2022, 2024 All Rights Reserved
+ * (c) Copyright IBM Corp. 2022, 2025 All Rights Reserved
  * ===========================================================================
  */
 
@@ -1781,7 +1781,7 @@ TranslateApplicationArgs(int jargc, const char **jargv, int *pargc, char ***parg
     for (i = 0; i < jargc; i++) {
         const char *arg = jargv[i];
         if (arg[0] == '-' && arg[1] == 'J') {
-            *nargv++ = ((arg + 2) == NULL) ? NULL : JLI_StringDup(arg + 2);
+            *nargv++ = (arg[2] == '\0') ? NULL : JLI_StringDup(arg + 2);
         }
     }
 


### PR DESCRIPTION
[8286694: Incorrect argument processing in java launcher](https://github.com/ibmruntimes/openj9-openjdk-jdk17/commit/e74e63d034dcba5bdab332fd1f2f8d76e83bd87f
)

Noticed due to a warning from gcc-14.