### PR TITLE
Back-port fix for some compiler warnings

### DIFF
--- a/src/java.desktop/linux/native/libjsound/PLATFORM_API_LinuxOS_ALSA_MidiIn.c
+++ b/src/java.desktop/linux/native/libjsound/PLATFORM_API_LinuxOS_ALSA_MidiIn.c
@@ -218,7 +218,7 @@ MidiMessage* MIDI_IN_GetMessage(MidiDeviceHandle* handle) {
             return NULL;
         }
     }
-    jdk_message = (MidiMessage*) calloc(sizeof(MidiMessage), 1);
+    jdk_message = (MidiMessage*) calloc(1, sizeof(MidiMessage));
     if (!jdk_message) {
         ERROR0("< ERROR: MIDI_IN_GetMessage(): out of memory\n");
         return NULL;

--- a/src/java.desktop/linux/native/libjsound/PLATFORM_API_LinuxOS_ALSA_MidiUtils.c
+++ b/src/java.desktop/linux/native/libjsound/PLATFORM_API_LinuxOS_ALSA_MidiUtils.c
@@ -383,7 +383,7 @@ INT32 openMidiDevice(snd_rawmidi_stream_t direction, INT32 deviceIndex,
 
     TRACE0("> openMidiDevice()\n");
 
-    (*handle) = (MidiDeviceHandle*) calloc(sizeof(MidiDeviceHandle), 1);
+    (*handle) = (MidiDeviceHandle*) calloc(1, sizeof(MidiDeviceHandle));
     if (!(*handle)) {
         ERROR0("ERROR: openDevice: out of memory\n");
         return MIDI_OUT_OF_MEMORY;

--- a/src/java.desktop/share/native/libfontmanager/sunFont.c
+++ b/src/java.desktop/share/native/libfontmanager/sunFont.c
@@ -67,7 +67,7 @@ int isNullScalerContext(void *context) {
  */
 JNIEXPORT jlong JNICALL Java_sun_font_NullFontScaler_getGlyphImage
   (JNIEnv *env, jobject scaler, jlong pContext, jint glyphCode) {
-    void *nullscaler = calloc(sizeof(GlyphInfo), 1);
+    void *nullscaler = calloc(1, sizeof(GlyphInfo));
     return ptr_to_jlong(nullscaler);
 }
 


### PR DESCRIPTION
See [8324243: Compilation failures in java.desktop module with gcc 14](https://github.com/ibmruntimes/openj9-openjdk-jdk17/commit/4755a79111c9907b9c1177496627558188be0dcb).