### PR TITLE
Update test exclusion list for FIPS 140-2 and FIPS 140-3

### DIFF
--- a/test/jdk/ProblemList-FIPS140_2.txt
+++ b/test/jdk/ProblemList-FIPS140_2.txt
@@ -933,6 +933,7 @@ sun/security/provider/SecureRandom/AutoReseed.java	https://github.com/ibmruntime
 # javax.net.ssl.SSLHandshakeException: Received fatal alert: handshake_failure.
 # All the below hard coded static String keyStoreFile = "keystore"; in the test codes. In FIPS mode, keystore must be NONE.
 
+javax/rmi/ssl/SocketFactoryTest.java https://github.com/eclipse-openj9/openj9/issues/21756 linux-x64,linux-ppc64le,linux-s390x
 sun/security/util/HostnameMatcher/NullHostnameCheck.java	https://github.com/ibmruntimes/openj9-openjdk-jdk11/issues/547	linux-x64,linux-ppc64le,linux-s390x
 sun/security/ssl/spi/ProviderInit.java	https://github.com/ibmruntimes/openj9-openjdk-jdk11/issues/547	linux-x64,linux-ppc64le,linux-s390x
 sun/security/ssl/SocketCreation/SocketCreation.java	https://github.com/ibmruntimes/openj9-openjdk-jdk11/issues/547	linux-x64,linux-ppc64le,linux-s390x

--- a/test/jdk/ProblemList-FIPS140_3_OpenJCEPlusFIPS.FIPS140-3.txt
+++ b/test/jdk/ProblemList-FIPS140_3_OpenJCEPlusFIPS.FIPS140-3.txt
@@ -428,7 +428,7 @@ java/rmi/MarshalledObject/MOFilterTest.java https://github.com/eclipse-openj9/op
 java/rmi/MarshalledObject/compare/Compare.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 java/rmi/MarshalledObject/compare/HashCode.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 java/rmi/Naming/DefaultRegistryPort.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
-java/rmi/Naming/LookupIPv6.java https://github.com/eclipse-openj9/openj9/issues/20343 aix-all,linux-s390x,linux-x64,windows-all
+java/rmi/Naming/LookupIPv6.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 java/rmi/Naming/LookupNameWithColon.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 java/rmi/Naming/RmiIsNoScheme.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 java/rmi/Naming/UnderscoreHost.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
@@ -974,7 +974,7 @@ sun/security/validator/EndEntityExtensionCheck.java https://github.com/eclipse-o
 sun/security/validator/certreplace.sh https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/validator/samedn.sh https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/x509/AlgorithmId/ExtensibleAlgorithmId.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
-sun/security/x509/AlgorithmId/NonStandardNames.java https://github.com/eclipse-openj9/openj9/issues/21615
+sun/security/x509/AlgorithmId/NonStandardNames.java https://github.com/eclipse-openj9/openj9/issues/21615  generic-all
 sun/security/x509/URICertStore/ExtensionsWithLDAP.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/x509/X509CRLImpl/OrderAndDup.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/x509/X509CRLImpl/Verify.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all

--- a/test/jdk/ProblemList-FIPS140_3_OpenJcePlus.txt
+++ b/test/jdk/ProblemList-FIPS140_3_OpenJcePlus.txt
@@ -1,5 +1,5 @@
 # ===========================================================================
-# (c) Copyright IBM Corp. 2023, 2024 All Rights Reserved
+# (c) Copyright IBM Corp. 2023, 2025 All Rights Reserved
 # ===========================================================================
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
@@ -394,6 +394,7 @@ sun/security/krb5/runNameEquals.sh https://github.com/eclipse-openj9/openj9/issu
 #
 # Exclude tests list from extended.openjdk
 #
+com/sun/crypto/provider/KDF/HKDFDelayedPRK.java https://github.com/eclipse-openj9/openj9/issues/21754 generic-all
 com/sun/jndi/ldap/DeadSSLLdapTimeoutTest.java https://github.com/eclipse-openj9/openj9/issues/20978 aix-all,linux-ppc64le,linux-s390x,linux-x64
 com/sun/jndi/ldap/LdapCBPropertiesTest.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
 com/sun/jndi/ldap/LdapSSLHandshakeFailureTest.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
@@ -458,6 +459,7 @@ java/rmi/server/RMISocketFactory/useSocketFactory/unicast/UseCustomSocketFactory
 java/rmi/server/clientStackTrace/ClientStackTrace.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
 java/rmi/server/useCustomRef/UseCustomRef.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
 java/rmi/transport/dgcDeadLock/DGCDeadLock.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
+javax/crypto/KDF/KDFDelayedProviderTest.java https://github.com/eclipse-openj9/openj9/issues/21754 generic-all
 javax/imageio/CachePremissionsTest/CachePermissionsTest.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
 javax/imageio/plugins/png/ReadPngGrayImageWithTRNSChunk.java https://github.com/eclipse-openj9/openj9/issues/20978 linux-s390x
 javax/imageio/plugins/wbmp/ValidWbmpTest.java https://github.com/eclipse-openj9/openj9/issues/20978 linux-s390x


### PR DESCRIPTION
This is a back-port PR from JDK Next PR: https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/1019

This commit updates the test exclude list for FIPS140-2, FIPS140-3 strict and weakly enforced profile.