### PR TITLE
Update KeyDestructionTest for FIPS 140-3

### DIFF
--- a/test/jdk/javax/security/auth/Destroyable/KeyDestructionTest.java
+++ b/test/jdk/javax/security/auth/Destroyable/KeyDestructionTest.java
@@ -42,7 +42,7 @@ import javax.security.auth.DestroyFailedException;
 public class KeyDestructionTest {
     public static void main(String[] args) throws Exception {
         String kpgAlgorithm = "RSA";
-        KeyPair keypair = generateKeyPair(kpgAlgorithm, 1024);
+        KeyPair keypair = generateKeyPair(kpgAlgorithm, 2048);
 
         // Check keys that support and have implemented key destruction
         testKeyDestruction(new MyDestroyableSecretKey());


### PR DESCRIPTION
This test is failing since the FIPS 140-3 requires RSA key sizes to be 2048 or higher.

Fixes https://github.com/eclipse-openj9/openj9/issues/21921