### PR TITLE
Preprocess HKDF.java so OPENJCEPLUS_SUPPORT is considered

### DIFF
--- a/closed/GensrcJ9JCL.gmk
+++ b/closed/GensrcJ9JCL.gmk
@@ -1,5 +1,5 @@
 # ===========================================================================
-# (c) Copyright IBM Corp. 2020, 2024 All Rights Reserved
+# (c) Copyright IBM Corp. 2020, 2025 All Rights Reserved
 # ===========================================================================
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
@@ -56,6 +56,7 @@ $(eval $(call SetupCopyFiles,COPY_OVERLAY_FILES, \
 		src/java.base/share/classes/sun/security/jca/ProviderList.java \
 		src/java.base/share/classes/sun/security/provider/DigestBase.java \
 		src/java.base/share/classes/sun/security/provider/SecureRandom.java \
+		src/java.base/share/classes/sun/security/ssl/HKDF.java \
 		src/java.base/unix/classes/java/lang/ProcessEnvironment.java \
 		src/java.base/unix/classes/sun/security/provider/NativePRNG.java \
 		src/jdk.jdi/share/classes/com/sun/tools/example/debug/tty/EventHandler.java \


### PR DESCRIPTION
This should have been included in https://github.com/ibmruntimes/openj9-openjdk-jdk11/pull/916.