### PR TITLE
Allow OpenJCEPlus ciphers to pass decryption tests

### DIFF
--- a/src/utils/LogCompilation/target/test-classes/hotspot_pid23756.log
+++ b/src/utils/LogCompilation/target/test-classes/hotspot_pid23756.log
@@ -1,0 +1,12986 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<hotspot_log version='160 1' process='23756' time_ms='1516226614992'>
+<vm_version>
+<name>
+Java HotSpot(TM) 64-Bit Server VM
+</name>
+<release>
+9+181
+</release>
+<info>
+Java HotSpot(TM) 64-Bit Server VM (9+181) for linux-amd64 JRE (9+181), built on Aug  3 2017 04:03:00 by &quot;javare&quot; with gcc 4.9.2
+</info>
+</vm_version>
+<vm_arguments>
+<args>
+-XX:+UnlockDiagnosticVMOptions -XX:+LogCompilation </args>
+<command>
+target/LogCompilation-1.0-SNAPSHOT.jar
+</command>
+<launcher>
+SUN_STANDARD
+</launcher>
+<properties>
+java.vm.specification.name=Java Virtual Machine Specification
+java.vm.version=9+181
+java.vm.name=Java HotSpot(TM) 64-Bit Server VM
+java.vm.info=mixed mode, aot, sharing
+jdk.debug=release
+sun.boot.library.path=/opt/jdk-9/lib
+java.library.path=/usr/java/packages/lib:/usr/lib64:/lib64:/lib:/usr/lib
+java.home=/opt/jdk-9
+java.class.path=target/LogCompilation-1.0-SNAPSHOT.jar
+jdk.boot.class.path.append=
+java.vm.specification.vendor=Oracle Corporation
+java.vm.specification.version=9
+java.vm.vendor=Oracle Corporation
+sun.java.command=target/LogCompilation-1.0-SNAPSHOT.jar
+sun.java.launcher=SUN_STANDARD
+</properties>
+</vm_arguments>
+<tty>
+<writer thread='23757'/>
+<blob name='MethodHandlesAdapterBlob' size='32000'>
+<sect index='1' size='32000' free='31628'/>
+</blob>
+<writer thread='23805'/>
+<thread_logfile thread='23805' filename='/tmp/hs_c23805_pid23756.log'/>
+<writer thread='23806'/>
+<thread_logfile thread='23806' filename='/tmp/hs_c23806_pid23756.log'/>
+<writer thread='23807'/>
+<thread_logfile thread='23807' filename='/tmp/hs_c23807_pid23756.log'/>
+<writer thread='23808'/>
+<thread_logfile thread='23808' filename='/tmp/hs_c23808_pid23756.log'/>
+<writer thread='23809'/>
+<thread_logfile thread='23809' filename='/tmp/hs_c23809_pid23756.log'/>
+<writer thread='23810'/>
+<thread_logfile thread='23810' filename='/tmp/hs_c23810_pid23756.log'/>
+<writer thread='23811'/>
+<thread_logfile thread='23811' filename='/tmp/hs_c23811_pid23756.log'/>
+<writer thread='23812'/>
+<thread_logfile thread='23812' filename='/tmp/hs_c23812_pid23756.log'/>
+<writer thread='23813'/>
+<thread_logfile thread='23813' filename='/tmp/hs_c23813_pid23756.log'/>
+<writer thread='23814'/>
+<thread_logfile thread='23814' filename='/tmp/hs_c23814_pid23756.log'/>
+<writer thread='23815'/>
+<thread_logfile thread='23815' filename='/tmp/hs_c23815_pid23756.log'/>
+<writer thread='23816'/>
+<thread_logfile thread='23816' filename='/tmp/hs_c23816_pid23756.log'/>
+<writer thread='23817'/>
+<sweeper state='finished' traversals='0'  total_blobs='221' nmethods='0' adapters='129' free_code_cache='248794752' stamp='0.181'/>
+<writer thread='23757'/>
+<task_queued compile_id='1' method='java.lang.StringUTF16 getChar ([BI)C' bytes='60' count='256' iicount='256' level='3' stamp='0.182' comment='tiered' hot_count='256'/>
+<task_queued compile_id='2' method='java.lang.StringLatin1 hashCode ([B)I' bytes='42' count='110' backedge_count='2048' iicount='110' level='3' stamp='0.182' comment='tiered' hot_count='110'/>
+<writer thread='23813'/>
+<nmethod compile_id='1' compiler='c1' level='3' entry='0x00007f5ae96121c0' size='1048' address='0x00007f5ae9612010' relocation_offset='368' insts_offset='432' stub_offset='720' scopes_data_offset='872' scopes_pcs_offset='904' dependencies_offset='1016' nul_chk_table_offset='1024' metadata_offset='864' method='java.lang.StringUTF16 getChar ([BI)C' bytes='60' count='512' iicount='512' stamp='0.184'/>
+<writer thread='23814'/>
+<nmethod compile_id='2' compiler='c1' level='3' entry='0x00007f5ae9612640' size='1152' address='0x00007f5ae9612490' relocation_offset='368' insts_offset='432' stub_offset='816' scopes_data_offset='968' scopes_pcs_offset='1032' dependencies_offset='1128' nul_chk_table_offset='1136' metadata_offset='960' method='java.lang.StringLatin1 hashCode ([B)I' bytes='42' count='115' backedge_count='2260' iicount='115' stamp='0.184'/>
+<writer thread='23757'/>
+<task_queued compile_id='3' method='java.lang.StringLatin1 equals ([B[B)Z' bytes='36' count='256' backedge_count='316' iicount='256' level='3' stamp='0.185' comment='tiered' hot_count='256'/>
+<writer thread='23815'/>
+<nmethod compile_id='3' compiler='c1' level='3' entry='0x00007f5ae9612b40' size='1344' address='0x00007f5ae9612990' relocation_offset='368' insts_offset='432' stub_offset='976' scopes_data_offset='1128' scopes_pcs_offset='1184' dependencies_offset='1312' nul_chk_table_offset='1320' metadata_offset='1120' method='java.lang.StringLatin1 equals ([B[B)Z' bytes='36' count='256' backedge_count='325' iicount='256' stamp='0.186'/>
+<writer thread='23757'/>
+<task_queued compile_id='4' method='java.lang.String coder ()B' bytes='15' count='640' iicount='640' level='3' stamp='0.188' comment='tiered' hot_count='640'/>
+<writer thread='23816'/>
+<nmethod compile_id='4' compiler='c1' level='3' entry='0x00007f5ae96130c0' size='880' address='0x00007f5ae9612f10' relocation_offset='368' insts_offset='432' stub_offset='656' scopes_data_offset='808' scopes_pcs_offset='824' dependencies_offset='872' metadata_offset='800' method='java.lang.String coder ()B' bytes='15' count='646' iicount='646' stamp='0.189'/>
+<writer thread='23757'/>
+<task_queued compile_id='5' method='java.lang.String isLatin1 ()Z' bytes='19' count='896' iicount='896' level='3' stamp='0.189' comment='tiered' hot_count='896'/>
+<writer thread='23813'/>
+<nmethod compile_id='5' compiler='c1' level='3' entry='0x00007f5ae9613440' size='976' address='0x00007f5ae9613290' relocation_offset='368' insts_offset='432' stub_offset='752' scopes_data_offset='904' scopes_pcs_offset='920' dependencies_offset='968' metadata_offset='896' method='java.lang.String isLatin1 ()Z' bytes='19' count='935' iicount='935' stamp='0.190'/>
+<writer thread='23757'/>
+<task_queued compile_id='6' method='java.lang.String charAt (I)C' bytes='25' count='512' iicount='512' level='3' stamp='0.195' comment='tiered' hot_count='512'/>
+<task_queued compile_id='7' method='java.lang.StringLatin1 charAt ([BI)C' bytes='28' count='512' iicount='512' level='3' stamp='0.195' comment='tiered' hot_count='512'/>
+<writer thread='23815'/>
+<nmethod compile_id='7' compiler='c1' level='3' entry='0x00007f5ae9613860' size='1240' address='0x00007f5ae9613690' relocation_offset='368' insts_offset='464' stub_offset='880' scopes_data_offset='1056' scopes_pcs_offset='1104' dependencies_offset='1216' nul_chk_table_offset='1224' metadata_offset='1048' method='java.lang.StringLatin1 charAt ([BI)C' bytes='28' count='622' iicount='622' stamp='0.196'/>
+<writer thread='23814'/>
+<nmethod compile_id='6' compiler='c1' level='3' entry='0x00007f5ae9613da0' size='2400' address='0x00007f5ae9613b90' relocation_offset='368' insts_offset='528' stub_offset='1744' scopes_data_offset='1976' scopes_pcs_offset='2144' dependencies_offset='2368' nul_chk_table_offset='2376' metadata_offset='1928' method='java.lang.String charAt (I)C' bytes='25' count='660' iicount='660' stamp='0.196'/>
+<writer thread='23757'/>
+<task_queued compile_id='8' method='java.lang.String equals (Ljava/lang/Object;)Z' bytes='65' count='384' iicount='384' level='3' stamp='0.200' comment='tiered' hot_count='384'/>
+<writer thread='23816'/>
+<nmethod compile_id='8' compiler='c1' level='3' entry='0x00007f5ae9614720' size='2784' address='0x00007f5ae9614510' relocation_offset='368' insts_offset='528' stub_offset='2288' scopes_data_offset='2496' scopes_pcs_offset='2600' dependencies_offset='2760' nul_chk_table_offset='2768' metadata_offset='2472' method='java.lang.String equals (Ljava/lang/Object;)Z' bytes='65' count='429' iicount='429' stamp='0.201'/>
+<writer thread='23757'/>
+<task_queued compile_id='9' method='java.lang.Object &lt;init&gt; ()V' bytes='1' count='768' iicount='768' level='3' stamp='0.203' comment='tiered' hot_count='768'/>
+<writer thread='23813'/>
+<nmethod compile_id='9' compiler='c1' level='3' entry='0x00007f5ae96151c0' size='872' address='0x00007f5ae9615010' relocation_offset='368' insts_offset='432' stub_offset='624' scopes_data_offset='776' scopes_pcs_offset='800' dependencies_offset='864' metadata_offset='768' method='java.lang.Object &lt;init&gt; ()V' bytes='1' count='776' iicount='776' stamp='0.204'/>
+<writer thread='23757'/>
+<task_queued compile_id='10' method='java.lang.String hashCode ()I' bytes='49' count='256' iicount='256' level='3' stamp='0.207' comment='tiered' hot_count='256'/>
+<task_queued compile_id='11' method='java.lang.Math floorMod (II)I' bytes='10' count='256' iicount='256' level='3' stamp='0.207' comment='tiered' hot_count='256'/>
+<task_queued compile_id='12' method='java.lang.Math floorDiv (II)I' bytes='22' count='256' iicount='256' level='3' stamp='0.207' comment='tiered' hot_count='256'/>
+<task_queued compile_id='13' method='java.util.ImmutableCollections$SetN probe (Ljava/lang/Object;)I' bytes='60' count='256' backedge_count='125' iicount='256' level='3' stamp='0.208' comment='tiered' hot_count='256'/>
+<writer thread='23815'/>
+<nmethod compile_id='10' compiler='c1' level='3' entry='0x00007f5ae9615580' size='1912' address='0x00007f5ae9615390' relocation_offset='368' insts_offset='496' stub_offset='1456' scopes_data_offset='1648' scopes_pcs_offset='1744' dependencies_offset='1888' nul_chk_table_offset='1896' metadata_offset='1624' method='java.lang.String hashCode ()I' bytes='49' count='635' iicount='635' stamp='0.208'/>
+<writer thread='23814'/>
+<nmethod compile_id='11' compiler='c1' level='3' entry='0x00007f5ae9615d40' size='1176' address='0x00007f5ae9615b90' relocation_offset='368' insts_offset='432' stub_offset='848' scopes_data_offset='1008' scopes_pcs_offset='1072' dependencies_offset='1152' nul_chk_table_offset='1160' metadata_offset='992' method='java.lang.Math floorMod (II)I' bytes='10' count='317' iicount='317' stamp='0.208'/>
+<writer thread='23813'/>
+<nmethod compile_id='12' compiler='c1' level='3' entry='0x00007f5ae9616240' size='1024' address='0x00007f5ae9616090' relocation_offset='368' insts_offset='432' stub_offset='752' scopes_data_offset='904' scopes_pcs_offset='936' dependencies_offset='1000' nul_chk_table_offset='1008' metadata_offset='896' method='java.lang.Math floorDiv (II)I' bytes='22' count='317' iicount='317' stamp='0.208'/>
+<writer thread='23816'/>
+<nmethod compile_id='13' compiler='c1' level='3' entry='0x00007f5ae9616700' size='2520' address='0x00007f5ae9616510' relocation_offset='368' insts_offset='496' stub_offset='1840' scopes_data_offset='2048' scopes_pcs_offset='2224' dependencies_offset='2464' nul_chk_table_offset='2472' metadata_offset='2024' method='java.util.ImmutableCollections$SetN probe (Ljava/lang/Object;)I' bytes='60' count='426' backedge_count='285' iicount='426' stamp='0.209'/>
+<writer thread='23757'/>
+<task_queued compile_id='14' method='java.util.ImmutableCollections$Set0 hashCode ()I' bytes='2' count='128' iicount='128' level='1' stamp='0.210' comment='tiered' hot_count='128'/>
+<task_queued compile_id='15' method='java.util.Objects equals (Ljava/lang/Object;Ljava/lang/Object;)Z' bytes='23' count='256' iicount='256' level='3' stamp='0.210' comment='tiered' hot_count='256'/>
+<writer thread='23815'/>
+<nmethod compile_id='14' compiler='c1' level='1' entry='0x00007f5af0a731c0' size='752' address='0x00007f5af0a73010' relocation_offset='368' insts_offset='432' stub_offset='560' scopes_data_offset='704' scopes_pcs_offset='712' dependencies_offset='744' method='java.util.ImmutableCollections$Set0 hashCode ()I' bytes='2' count='177' iicount='177' stamp='0.211'/>
+<writer thread='23757'/>
+<task_queued compile_id='16' method='java.util.Collections emptySet ()Ljava/util/Set;' bytes='4' count='256' iicount='256' level='3' stamp='0.211' comment='tiered' hot_count='256'/>
+<writer thread='23815'/>
+<nmethod compile_id='15' compiler='c1' level='3' entry='0x00007f5ae96170c0' size='1280' address='0x00007f5ae9616f10' relocation_offset='368' insts_offset='432' stub_offset='976' scopes_data_offset='1152' scopes_pcs_offset='1176' dependencies_offset='1256' nul_chk_table_offset='1264' metadata_offset='1144' method='java.util.Objects equals (Ljava/lang/Object;Ljava/lang/Object;)Z' bytes='23' count='289' iicount='289' stamp='0.211'/>
+<writer thread='23757'/>
+<task_queued compile_id='17' method='java.util.Collections$EmptySet hashCode ()I' bytes='2' count='128' iicount='128' level='1' stamp='0.211' comment='tiered' hot_count='128'/>
+<writer thread='23815'/>
+<nmethod compile_id='16' compiler='c1' level='3' entry='0x00007f5ae9617640' size='808' address='0x00007f5ae9617490' relocation_offset='368' insts_offset='432' stub_offset='592' scopes_data_offset='744' scopes_pcs_offset='752' dependencies_offset='800' metadata_offset='736' method='java.util.Collections emptySet ()Ljava/util/Set;' bytes='4' count='268' iicount='268' stamp='0.211'/>
+<nmethod compile_id='17' compiler='c1' level='1' entry='0x00007f5af0a734c0' size='752' address='0x00007f5af0a73310' relocation_offset='368' insts_offset='432' stub_offset='560' scopes_data_offset='704' scopes_pcs_offset='712' dependencies_offset='744' method='java.util.Collections$EmptySet hashCode ()I' bytes='2' count='151' iicount='151' stamp='0.212'/>
+<writer thread='23757'/>
+<task_queued compile_id='18' method='java.lang.module.ModuleDescriptor$Exports &lt;init&gt; (Ljava/util/Set;Ljava/lang/String;Ljava/util/Set;ZLjava/lang/module/ModuleDescriptor$1;)V' bytes='10' count='256' iicount='256' level='3' stamp='0.212' comment='tiered' hot_count='256'/>
+<task_queued compile_id='19' method='java.lang.module.ModuleDescriptor$Exports &lt;init&gt; (Ljava/util/Set;Ljava/lang/String;Ljava/util/Set;Z)V' bytes='20' count='256' iicount='256' level='3' stamp='0.212' comment='tiered' hot_count='256'/>
+<task_queued compile_id='20' method='java.lang.StringLatin1 hashCode ([B)I' bytes='42' count='782' backedge_count='18626' iicount='782' stamp='0.212' comment='tiered' hot_count='782'/>
+<task_queued compile_id='21' method='java.util.Objects requireNonNull (Ljava/lang/Object;)Ljava/lang/Object;' bytes='14' count='256' iicount='256' level='3' stamp='0.212' comment='tiered' hot_count='256'/>
+<task_queued compile_id='22' method='java.lang.module.ModuleDescriptor$Exports hashCode ()I' bytes='38' count='256' iicount='256' level='3' stamp='0.212' comment='tiered' hot_count='256'/>
+<writer thread='23813'/>
+<nmethod compile_id='19' compiler='c1' level='3' entry='0x00007f5ae96179c0' size='1328' address='0x00007f5ae9617810' relocation_offset='368' insts_offset='432' stub_offset='1040' scopes_data_offset='1200' scopes_pcs_offset='1256' dependencies_offset='1320' metadata_offset='1184' method='java.lang.module.ModuleDescriptor$Exports &lt;init&gt; (Ljava/util/Set;Ljava/lang/String;Ljava/util/Set;Z)V' bytes='20' count='331' iicount='331' stamp='0.213'/>
+<writer thread='23814'/>
+<nmethod compile_id='18' compiler='c1' level='3' entry='0x00007f5ae9617f60' size='1504' address='0x00007f5ae9617d90' relocation_offset='368' insts_offset='464' stub_offset='1168' scopes_data_offset='1336' scopes_pcs_offset='1416' dependencies_offset='1496' metadata_offset='1312' method='java.lang.module.ModuleDescriptor$Exports &lt;init&gt; (Ljava/util/Set;Ljava/lang/String;Ljava/util/Set;ZLjava/lang/module/ModuleDescriptor$1;)V' bytes='10' count='331' iicount='331' stamp='0.213'/>
+<writer thread='23816'/>
+<nmethod compile_id='21' compiler='c1' level='3' entry='0x00007f5ae9618540' size='1128' address='0x00007f5ae9618390' relocation_offset='368' insts_offset='432' stub_offset='816' scopes_data_offset='992' scopes_pcs_offset='1024' dependencies_offset='1120' metadata_offset='984' method='java.util.Objects requireNonNull (Ljava/lang/Object;)Ljava/lang/Object;' bytes='14' count='346' iicount='346' stamp='0.213'/>
+<writer thread='23815'/>
+<nmethod compile_id='22' compiler='c1' level='3' entry='0x00007f5ae96189e0' size='1728' address='0x00007f5ae9618810' relocation_offset='368' insts_offset='464' stub_offset='1264' scopes_data_offset='1472' scopes_pcs_offset='1544' dependencies_offset='1688' nul_chk_table_offset='1696' metadata_offset='1464' method='java.lang.module.ModuleDescriptor$Exports hashCode ()I' bytes='38' count='316' iicount='316' stamp='0.213'/>
+<writer thread='23757'/>
+<task_queued compile_id='23' method='java.util.AbstractCollection &lt;init&gt; ()V' bytes='5' count='256' iicount='256' level='3' stamp='0.213' comment='tiered' hot_count='256'/>
+<writer thread='23814'/>
+<nmethod compile_id='23' compiler='c1' level='3' entry='0x00007f5ae96190c0' size='992' address='0x00007f5ae9618f10' relocation_offset='368' insts_offset='432' stub_offset='720' scopes_data_offset='888' scopes_pcs_offset='920' dependencies_offset='984' metadata_offset='864' method='java.util.AbstractCollection &lt;init&gt; ()V' bytes='5' count='294' iicount='295' stamp='0.214'/>
+<writer thread='23757'/>
+<task_queued compile_id='24' method='java.util.AbstractSet &lt;init&gt; ()V' bytes='5' count='256' iicount='256' level='3' stamp='0.214' comment='tiered' hot_count='256'/>
+<task_queued compile_id='25' method='java.util.ImmutableCollections$AbstractImmutableSet &lt;init&gt; ()V' bytes='5' count='256' iicount='256' level='3' stamp='0.214' comment='tiered' hot_count='256'/>
+<writer thread='23813'/>
+<nmethod compile_id='24' compiler='c1' level='3' entry='0x00007f5ae96194c0' size='1120' address='0x00007f5ae9619310' relocation_offset='368' insts_offset='432' stub_offset='816' scopes_data_offset='992' scopes_pcs_offset='1032' dependencies_offset='1112' metadata_offset='960' method='java.util.AbstractSet &lt;init&gt; ()V' bytes='5' count='298' iicount='298' stamp='0.214'/>
+<writer thread='23816'/>
+<nmethod compile_id='25' compiler='c1' level='3' entry='0x00007f5ae9619940' size='1256' address='0x00007f5ae9619790' relocation_offset='368' insts_offset='432' stub_offset='912' scopes_data_offset='1096' scopes_pcs_offset='1152' dependencies_offset='1248' metadata_offset='1056' method='java.util.ImmutableCollections$AbstractImmutableSet &lt;init&gt; ()V' bytes='5' count='312' iicount='312' stamp='0.214'/>
+<writer thread='23757'/>
+<task_queued compile_id='26' method='java.util.Set of ([Ljava/lang/Object;)Ljava/util/Set;' bytes='66' count='256' iicount='256' level='3' stamp='0.214' comment='tiered' hot_count='256'/>
+<task_queued compile_id='27' method='jdk.internal.module.Builder newExports (Ljava/util/Set;Ljava/lang/String;Ljava/util/Set;)Ljava/lang/module/ModuleDescriptor$Exports;' bytes='12' count='256' iicount='256' level='3' stamp='0.215' comment='tiered' hot_count='256'/>
+<task_queued compile_id='28' method='java.lang.module.ModuleDescriptor$1 newExports (Ljava/util/Set;Ljava/lang/String;Ljava/util/Set;)Ljava/lang/module/ModuleDescriptor$Exports;' bytes='13' count='256' iicount='256' level='3' stamp='0.215' comment='tiered' hot_count='256'/>
+<task_queued compile_id='29' method='java.util.Collections$EmptySet contains (Ljava/lang/Object;)Z' bytes='2' count='128' iicount='128' level='1' stamp='0.215' comment='tiered' hot_count='128'/>
+<task_queued compile_id='30' method='java.util.ImmutableCollections$SetN &lt;init&gt; ([Ljava/lang/Object;)V' bytes='90' count='161' backedge_count='2048' iicount='161' level='3' stamp='0.215' comment='tiered' hot_count='161'/>
+<task_queued compile_id='31' method='java.lang.module.ModuleDescriptor$Exports equals (Ljava/lang/Object;)Z' bytes='62' count='256' iicount='256' level='3' stamp='0.215' comment='tiered' hot_count='256'/>
+<writer thread='23816'/>
+<nmethod compile_id='28' compiler='c1' level='3' entry='0x00007f5ae9619e60' size='1792' address='0x00007f5ae9619c90' relocation_offset='368' insts_offset='464' stub_offset='1360' scopes_data_offset='1536' scopes_pcs_offset='1672' dependencies_offset='1784' metadata_offset='1504' method='java.lang.module.ModuleDescriptor$1 newExports (Ljava/util/Set;Ljava/lang/String;Ljava/util/Set;)Ljava/lang/module/ModuleDescriptor$Exports;' bytes='13' count='305' iicount='305' stamp='0.215'/>
+<writer thread='23814'/>
+<nmethod compile_id='29' compiler='c1' level='1' entry='0x00007f5af0a737c0' size='752' address='0x00007f5af0a73610' relocation_offset='368' insts_offset='432' stub_offset='560' scopes_data_offset='704' scopes_pcs_offset='712' dependencies_offset='744' method='java.util.Collections$EmptySet contains (Ljava/lang/Object;)Z' bytes='2' count='132' iicount='132' stamp='0.215'/>
+<writer thread='23813'/>
+<nmethod compile_id='27' compiler='c1' level='3' entry='0x00007f5ae961a5e0' size='1904' address='0x00007f5ae961a410' relocation_offset='368' insts_offset='464' stub_offset='1424' scopes_data_offset='1616' scopes_pcs_offset='1768' dependencies_offset='1896' metadata_offset='1568' method='jdk.internal.module.Builder newExports (Ljava/util/Set;Ljava/lang/String;Ljava/util/Set;)Ljava/lang/module/ModuleDescriptor$Exports;' bytes='12' count='305' iicount='305' stamp='0.215'/>
+<writer thread='23757'/>
+<task_queued compile_id='32' method='jdk.internal.module.Builder newExports (Ljava/util/Set;Ljava/lang/String;)Ljava/lang/module/ModuleDescriptor$Exports;' bytes='11' count='256' iicount='256' level='3' stamp='0.215' comment='tiered' hot_count='256'/>
+<task_queued compile_id='33' method='java.lang.module.ModuleDescriptor$1 newExports (Ljava/util/Set;Ljava/lang/String;)Ljava/lang/module/ModuleDescriptor$Exports;' bytes='15' count='256' iicount='256' level='3' stamp='0.215' comment='tiered' hot_count='256'/>
+<writer thread='23815'/>
+<nmethod compile_id='26' compiler='c1' level='3' entry='0x00007f5ae961adc0' size='3104' address='0x00007f5ae961ab90' relocation_offset='368' insts_offset='560' stub_offset='2256' scopes_data_offset='2520' scopes_pcs_offset='2728' dependencies_offset='3080' nul_chk_table_offset='3088' metadata_offset='2456' method='java.util.Set of ([Ljava/lang/Object;)Ljava/util/Set;' bytes='66' count='309' iicount='309' stamp='0.216'/>
+<writer thread='23757'/>
+<task_queued compile_id='34' method='java.util.ImmutableCollections$Set1 hashCode ()I' bytes='8' count='256' iicount='256' level='3' stamp='0.216' comment='tiered' hot_count='256'/>
+<writer thread='23813'/>
+<nmethod compile_id='32' compiler='c1' level='3' entry='0x00007f5ae961ba00' size='2104' address='0x00007f5ae961b810' relocation_offset='368' insts_offset='496' stub_offset='1584' scopes_data_offset='1792' scopes_pcs_offset='1952' dependencies_offset='2096' oops_offset='1728' metadata_offset='1736' method='jdk.internal.module.Builder newExports (Ljava/util/Set;Ljava/lang/String;)Ljava/lang/module/ModuleDescriptor$Exports;' bytes='11' count='303' iicount='303' stamp='0.216'/>
+<writer thread='23812'/>
+<nmethod compile_id='20' compiler='c2' level='4' entry='0x00007f5af0a73aa0' size='856' address='0x00007f5af0a73910' relocation_offset='368' insts_offset='400' stub_offset='688' scopes_data_offset='720' scopes_pcs_offset='768' dependencies_offset='832' nul_chk_table_offset='840' metadata_offset='712' method='java.lang.StringLatin1 hashCode ([B)I' bytes='42' count='2097' backedge_count='65738' iicount='2097' stamp='0.216'/>
+<make_not_entrant thread='23812' compile_id='2' compiler='c1' level='3' stamp='0.216'/>
+<writer thread='23815'/>
+<nmethod compile_id='33' compiler='c1' level='3' entry='0x00007f5ae961c260' size='1928' address='0x00007f5ae961c090' relocation_offset='368' insts_offset='464' stub_offset='1456' scopes_data_offset='1648' scopes_pcs_offset='1792' dependencies_offset='1920' oops_offset='1600' metadata_offset='1608' method='java.lang.module.ModuleDescriptor$1 newExports (Ljava/util/Set;Ljava/lang/String;)Ljava/lang/module/ModuleDescriptor$Exports;' bytes='15' count='306' iicount='306' stamp='0.216'/>
+<writer thread='23757'/>
+<task_queued compile_id='35' method='jdk.internal.module.Builder newRequires (Ljava/util/Set;Ljava/lang/String;)Ljava/lang/module/ModuleDescriptor$Requires;' bytes='7' count='256' iicount='256' level='3' stamp='0.216' comment='tiered' hot_count='256'/>
+<writer thread='23813'/>
+<nmethod compile_id='34' compiler='c1' level='3' entry='0x00007f5ae961ca40' size='1120' address='0x00007f5ae961c890' relocation_offset='368' insts_offset='432' stub_offset='816' scopes_data_offset='992' scopes_pcs_offset='1016' dependencies_offset='1096' nul_chk_table_offset='1104' metadata_offset='984' method='java.util.ImmutableCollections$Set1 hashCode ()I' bytes='8' count='284' iicount='284' stamp='0.216'/>
+<writer thread='23814'/>
+<nmethod compile_id='31' compiler='c1' level='3' entry='0x00007f5ae961cf40' size='3488' address='0x00007f5ae961cd10' relocation_offset='368' insts_offset='560' stub_offset='2864' scopes_data_offset='3080' scopes_pcs_offset='3216' dependencies_offset='3440' nul_chk_table_offset='3448' metadata_offset='3064' method='java.lang.module.ModuleDescriptor$Exports equals (Ljava/lang/Object;)Z' bytes='62' count='296' iicount='296' stamp='0.216'/>
+<writer thread='23757'/>
+<task_queued compile_id='36' method='jdk.internal.module.Builder newRequires (Ljava/util/Set;Ljava/lang/String;Ljava/lang/String;)Ljava/lang/module/ModuleDescriptor$Requires;' bytes='51' count='256' iicount='256' level='3' stamp='0.217' comment='tiered' hot_count='256'/>
+<task_queued compile_id='37' method='java.lang.module.ModuleDescriptor$1 newRequires (Ljava/util/Set;Ljava/lang/String;Ljava/lang/module/ModuleDescriptor$Version;)Ljava/lang/module/ModuleDescriptor$Requires;' bytes='13' count='256' iicount='256' level='3' stamp='0.217' comment='tiered' hot_count='256'/>
+<task_queued compile_id='38' method='java.lang.module.ModuleDescriptor$Requires &lt;init&gt; (Ljava/util/Set;Ljava/lang/String;Ljava/lang/module/ModuleDescriptor$Version;ZLjava/lang/module/ModuleDescriptor$1;)V' bytes='10' count='256' iicount='256' level='3' stamp='0.217' comment='tiered' hot_count='256'/>
+<task_queued compile_id='39' method='java.lang.module.ModuleDescriptor$Requires &lt;init&gt; (Ljava/util/Set;Ljava/lang/String;Ljava/lang/module/ModuleDescriptor$Version;Z)V' bytes='25' count='256' iicount='256' level='3' stamp='0.217' comment='tiered' hot_count='256'/>
+<writer thread='23814'/>
+<nmethod compile_id='35' compiler='c1' level='3' entry='0x00007f5ae961dcc0' size='896' address='0x00007f5ae961db10' relocation_offset='368' insts_offset='432' stub_offset='624' scopes_data_offset='800' scopes_pcs_offset='824' dependencies_offset='888' metadata_offset='792' method='jdk.internal.module.Builder newRequires (Ljava/util/Set;Ljava/lang/String;)Ljava/lang/module/ModuleDescriptor$Requires;' bytes='7' count='262' iicount='262' stamp='0.217'/>
+<writer thread='23757'/>
+<task_queued compile_id='40' method='java.lang.module.ModuleDescriptor$Requires hashCode ()I' bytes='63' count='256' iicount='256' level='3' stamp='0.217' comment='tiered' hot_count='256'/>
+<writer thread='23814'/>
+<nmethod compile_id='38' compiler='c1' level='3' entry='0x00007f5ae961e0e0' size='1536' address='0x00007f5ae961df10' relocation_offset='368' insts_offset='464' stub_offset='1200' scopes_data_offset='1368' scopes_pcs_offset='1448' dependencies_offset='1528' metadata_offset='1344' method='java.lang.module.ModuleDescriptor$Requires &lt;init&gt; (Ljava/util/Set;Ljava/lang/String;Ljava/lang/module/ModuleDescriptor$Version;ZLjava/lang/module/ModuleDescriptor$1;)V' bytes='10' count='338' iicount='339' stamp='0.217'/>
+<writer thread='23813'/>
+<nmethod compile_id='37' compiler='c1' level='3' entry='0x00007f5ae961e760' size='1792' address='0x00007f5ae961e590' relocation_offset='368' insts_offset='464' stub_offset='1360' scopes_data_offset='1536' scopes_pcs_offset='1672' dependencies_offset='1784' metadata_offset='1504' method='java.lang.module.ModuleDescriptor$1 newRequires (Ljava/util/Set;Ljava/lang/String;Ljava/lang/module/ModuleDescriptor$Version;)Ljava/lang/module/ModuleDescriptor$Requires;' bytes='13' count='349' iicount='349' stamp='0.217'/>
+<writer thread='23816'/>
+<nmethod compile_id='30' compiler='c1' level='3' entry='0x00007f5ae961f000' size='6744' address='0x00007f5ae961ed10' relocation_offset='368' insts_offset='752' stub_offset='5168' scopes_data_offset='5560' scopes_pcs_offset='6072' dependencies_offset='6696' nul_chk_table_offset='6704' oops_offset='5448' metadata_offset='5456' method='java.util.ImmutableCollections$SetN &lt;init&gt; ([Ljava/lang/Object;)V' bytes='90' count='219' backedge_count='3037' iicount='219' stamp='0.217'/>
+<writer thread='23814'/>
+<nmethod compile_id='39' compiler='c1' level='3' entry='0x00007f5ae9620940' size='1360' address='0x00007f5ae9620790' relocation_offset='368' insts_offset='432' stub_offset='1072' scopes_data_offset='1232' scopes_pcs_offset='1288' dependencies_offset='1352' metadata_offset='1216' method='java.lang.module.ModuleDescriptor$Requires &lt;init&gt; (Ljava/util/Set;Ljava/lang/String;Ljava/lang/module/ModuleDescriptor$Version;Z)V' bytes='25' count='349' iicount='349' stamp='0.218'/>
+<writer thread='23815'/>
+<nmethod compile_id='36' compiler='c1' level='3' entry='0x00007f5ae9620f20' size='3088' address='0x00007f5ae9620d10' relocation_offset='368' insts_offset='528' stub_offset='2352' scopes_data_offset='2592' scopes_pcs_offset='2832' dependencies_offset='3056' nul_chk_table_offset='3064' metadata_offset='2536' method='jdk.internal.module.Builder newRequires (Ljava/util/Set;Ljava/lang/String;Ljava/lang/String;)Ljava/lang/module/ModuleDescriptor$Requires;' bytes='51' count='349' iicount='349' stamp='0.218'/>
+<writer thread='23813'/>
+<nmethod compile_id='40' compiler='c1' level='3' entry='0x00007f5ae9621b80' size='2424' address='0x00007f5ae9621990' relocation_offset='368' insts_offset='496' stub_offset='1808' scopes_data_offset='2040' scopes_pcs_offset='2160' dependencies_offset='2368' nul_chk_table_offset='2376' metadata_offset='2024' method='java.lang.module.ModuleDescriptor$Requires hashCode ()I' bytes='63' count='283' iicount='283' stamp='0.218'/>
+<writer thread='23757'/>
+<task_queued compile_id='41' method='java.lang.module.ModuleDescriptor name ()Ljava/lang/String;' bytes='5' count='128' iicount='128' level='1' stamp='0.221' comment='tiered' hot_count='128'/>
+<task_queued compile_id='42' method='java.nio.Buffer checkIndex (I)I' bytes='22' count='256' iicount='256' level='3' stamp='0.221' comment='tiered' hot_count='256'/>
+<task_queued compile_id='43' method='java.nio.DirectLongBufferU ix (I)J' bytes='10' count='256' iicount='256' level='3' stamp='0.221' comment='tiered' hot_count='256'/>
+<writer thread='23815'/>
+<nmethod compile_id='41' compiler='c1' level='1' entry='0x00007f5af0a73e40' size='752' address='0x00007f5af0a73c90' relocation_offset='368' insts_offset='432' stub_offset='560' scopes_data_offset='704' scopes_pcs_offset='712' dependencies_offset='744' method='java.lang.module.ModuleDescriptor name ()Ljava/lang/String;' bytes='5' count='168' iicount='168' stamp='0.221'/>
+<writer thread='23814'/>
+<nmethod compile_id='43' compiler='c1' level='3' entry='0x00007f5ae9622540' size='880' address='0x00007f5ae9622390' relocation_offset='368' insts_offset='432' stub_offset='656' scopes_data_offset='808' scopes_pcs_offset='824' dependencies_offset='872' metadata_offset='800' method='java.nio.DirectLongBufferU ix (I)J' bytes='10' count='350' iicount='350' stamp='0.221'/>
+<writer thread='23816'/>
+<nmethod compile_id='42' compiler='c1' level='3' entry='0x00007f5ae96228e0' size='1200' address='0x00007f5ae9622710' relocation_offset='368' insts_offset='464' stub_offset='880' scopes_data_offset='1056' scopes_pcs_offset='1096' dependencies_offset='1192' metadata_offset='1048' method='java.nio.Buffer checkIndex (I)I' bytes='22' count='370' iicount='370' stamp='0.221'/>
+<writer thread='23757'/>
+<nmethod compile_id='44' compile_kind='c2n' compiler='' level='0' entry='0x00007f5af0a74160' size='984' address='0x00007f5af0a73f90' relocation_offset='368' consts_offset='984' insts_offset='464' method='java.lang.System arraycopy (Ljava/lang/Object;ILjava/lang/Object;II)V' bytes='0' count='256' iicount='256' stamp='0.221'/>
+<task_queued compile_id='45' method='java.lang.String length ()I' bytes='11' count='256' iicount='256' level='3' stamp='0.221' comment='tiered' hot_count='256'/>
+<task_queued compile_id='46' method='java.lang.module.ModuleReference descriptor ()Ljava/lang/module/ModuleDescriptor;' bytes='5' count='128' iicount='128' level='1' stamp='0.222' comment='tiered' hot_count='128'/>
+<writer thread='23813'/>
+<nmethod compile_id='45' compiler='c1' level='3' entry='0x00007f5ae9622dc0' size='1216' address='0x00007f5ae9622c10' relocation_offset='368' insts_offset='432' stub_offset='912' scopes_data_offset='1072' scopes_pcs_offset='1112' dependencies_offset='1192' nul_chk_table_offset='1200' metadata_offset='1056' method='java.lang.String length ()I' bytes='11' count='311' iicount='311' stamp='0.222'/>
+<writer thread='23757'/>
+<task_queued compile_id='47' method='java.net.URI hash (ILjava/lang/String;)I' bytes='33' count='256' iicount='256' level='3' stamp='0.222' comment='tiered' hot_count='256'/>
+<writer thread='23815'/>
+<nmethod compile_id='46' compiler='c1' level='1' entry='0x00007f5af0a74540' size='752' address='0x00007f5af0a74390' relocation_offset='368' insts_offset='432' stub_offset='560' scopes_data_offset='704' scopes_pcs_offset='712' dependencies_offset='744' method='java.lang.module.ModuleReference descriptor ()Ljava/lang/module/ModuleDescriptor;' bytes='5' count='243' iicount='243' stamp='0.222'/>
+<writer thread='23757'/>
+<task_queued compile_id='48' method='java.net.URI toLower (C)I' bytes='19' count='256' iicount='256' level='3' stamp='0.222' comment='tiered' hot_count='256'/>
+<writer thread='23815'/>
+<nmethod compile_id='48' compiler='c1' level='3' entry='0x00007f5ae96232c0' size='944' address='0x00007f5ae9623110' relocation_offset='368' insts_offset='432' stub_offset='720' scopes_data_offset='872' scopes_pcs_offset='888' dependencies_offset='936' metadata_offset='864' method='java.net.URI toLower (C)I' bytes='19' count='297' iicount='297' stamp='0.222'/>
+<writer thread='23814'/>
+<nmethod compile_id='47' compiler='c1' level='3' entry='0x00007f5ae9623720' size='2488' address='0x00007f5ae9623510' relocation_offset='368' insts_offset='528' stub_offset='1904' scopes_data_offset='2152' scopes_pcs_offset='2288' dependencies_offset='2464' nul_chk_table_offset='2472' metadata_offset='2120' method='java.net.URI hash (ILjava/lang/String;)I' bytes='33' count='396' iicount='396' stamp='0.223'/>
+<writer thread='23757'/>
+<task_queued compile_id='49' method='java.lang.StringLatin1 canEncode (I)Z' bytes='13' count='256' iicount='256' level='3' stamp='0.225' comment='tiered' hot_count='256'/>
+<writer thread='23816'/>
+<nmethod compile_id='49' compiler='c1' level='3' entry='0x00007f5ae96240c0' size='912' address='0x00007f5ae9623f10' relocation_offset='368' insts_offset='432' stub_offset='688' scopes_data_offset='840' scopes_pcs_offset='856' dependencies_offset='904' metadata_offset='832' method='java.lang.StringLatin1 canEncode (I)Z' bytes='13' count='283' iicount='283' stamp='0.225'/>
+<writer thread='23757'/>
+<task_queued compile_id='50' method='java.lang.Object &lt;init&gt; ()V' bytes='1' count='3584' iicount='3584' level='1' stamp='0.227' comment='tiered' hot_count='3584'/>
+<writer thread='23813'/>
+<nmethod compile_id='50' compiler='c1' level='1' entry='0x00007f5af0a74840' size='784' address='0x00007f5af0a74690' relocation_offset='368' insts_offset='432' stub_offset='560' scopes_data_offset='712' scopes_pcs_offset='728' dependencies_offset='776' metadata_offset='704' method='java.lang.Object &lt;init&gt; ()V' bytes='1' count='3673' iicount='3673' stamp='0.227'/>
+<make_not_entrant thread='23813' compile_id='9' compiler='c1' level='3' stamp='0.227'/>
+<writer thread='23757'/>
+<task_queued compile_id='51' method='java.util.concurrent.ConcurrentHashMap tabAt ([Ljava/util/concurrent/ConcurrentHashMap$Node;I)Ljava/util/concurrent/ConcurrentHashMap$Node;' bytes='22' count='640' iicount='640' level='3' stamp='0.230' comment='tiered' hot_count='640'/>
+<task_queued compile_id='52' method='jdk.internal.misc.Unsafe getObjectAcquire (Ljava/lang/Object;J)Ljava/lang/Object;' bytes='7' count='640' iicount='640' level='3' stamp='0.230' comment='tiered' hot_count='640'/>
+<nmethod compile_id='53' compile_kind='c2n' compiler='' level='0' entry='0x00007f5af0a74be0' size='1104' address='0x00007f5af0a74a10' relocation_offset='368' consts_offset='1104' insts_offset='464' method='jdk.internal.misc.Unsafe getObjectVolatile (Ljava/lang/Object;J)Ljava/lang/Object;' bytes='0' count='640' iicount='640' stamp='0.230'/>
+<writer thread='23814'/>
+<nmethod compile_id='52' compiler='c1' level='3' entry='0x00007f5ae96244c0' size='952' address='0x00007f5ae9624310' relocation_offset='368' insts_offset='432' stub_offset='720' scopes_data_offset='872' scopes_pcs_offset='896' dependencies_offset='944' metadata_offset='864' method='jdk.internal.misc.Unsafe getObjectAcquire (Ljava/lang/Object;J)Ljava/lang/Object;' bytes='7' count='640' iicount='640' stamp='0.230'/>
+<writer thread='23815'/>
+<nmethod compile_id='51' compiler='c1' level='3' entry='0x00007f5ae96248c0' size='1376' address='0x00007f5ae9624710' relocation_offset='368' insts_offset='432' stub_offset='1072' scopes_data_offset='1240' scopes_pcs_offset='1288' dependencies_offset='1368' oops_offset='1216' metadata_offset='1224' method='java.util.concurrent.ConcurrentHashMap tabAt ([Ljava/util/concurrent/ConcurrentHashMap$Node;I)Ljava/util/concurrent/ConcurrentHashMap$Node;' bytes='22' count='641' iicount='642' stamp='0.230'/>
+<writer thread='23757'/>
+<task_queued compile_id='54' method='java.util.concurrent.ConcurrentHashMap spread (I)I' bytes='10' count='256' iicount='256' level='3' stamp='0.230' comment='tiered' hot_count='256'/>
+<task_queued compile_id='55' method='java.util.ImmutableCollections$SetN$1 hasNext ()Z' bytes='47' count='256' backedge_count='139' iicount='256' level='3' stamp='0.230' comment='tiered' hot_count='256'/>
+<nmethod compile_id='56' compile_kind='c2n' compiler='' level='0' entry='0x00007f5af0a75060' size='1016' address='0x00007f5af0a74e90' relocation_offset='368' consts_offset='1016' insts_offset='464' method='jdk.internal.misc.Unsafe compareAndSetObject (Ljava/lang/Object;JLjava/lang/Object;Ljava/lang/Object;)Z' bytes='0' count='256' iicount='256' stamp='0.231'/>
+<task_queued compile_id='57' method='java.util.concurrent.ConcurrentHashMap$Node &lt;init&gt; (ILjava/lang/Object;Ljava/lang/Object;)V' bytes='20' count='256' iicount='256' level='3' stamp='0.231' comment='tiered' hot_count='256'/>
+<task_queued compile_id='58' method='java.util.concurrent.ConcurrentHashMap casTabAt ([Ljava/util/concurrent/ConcurrentHashMap$Node;ILjava/util/concurrent/ConcurrentHashMap$Node;Ljava/util/concurrent/ConcurrentHashMap$Node;)Z' bytes='21' count='256' iicount='256' level='3' stamp='0.231' comment='tiered' hot_count='256'/>
+<writer thread='23816'/>
+<nmethod compile_id='54' compiler='c1' level='3' entry='0x00007f5ae9624e40' size='848' address='0x00007f5ae9624c90' relocation_offset='368' insts_offset='432' stub_offset='624' scopes_data_offset='776' scopes_pcs_offset='792' dependencies_offset='840' metadata_offset='768' method='java.util.concurrent.ConcurrentHashMap spread (I)I' bytes='10' count='344' iicount='344' stamp='0.231'/>
+<writer thread='23757'/>
+<task_queued compile_id='59' method='java.util.concurrent.ConcurrentHashMap putVal (Ljava/lang/Object;Ljava/lang/Object;Z)Ljava/lang/Object;' bytes='432' count='256' backedge_count='23' iicount='256' level='3' stamp='0.231' comment='tiered' hot_count='256'/>
+<task_queued compile_id='60' method='java.util.concurrent.ConcurrentHashMap addCount (JI)V' bytes='289' count='256' backedge_count='3' iicount='256' level='3' stamp='0.231' comment='tiered' hot_count='256'/>
+<nmethod compile_id='61' compile_kind='c2n' compiler='' level='0' entry='0x00007f5af0a754e0' size='976' address='0x00007f5af0a75310' relocation_offset='368' consts_offset='976' insts_offset='464' method='jdk.internal.misc.Unsafe compareAndSetLong (Ljava/lang/Object;JJJ)Z' bytes='0' count='256' iicount='256' stamp='0.231'/>
+<writer thread='23814'/>
+<nmethod compile_id='55' compiler='c1' level='3' entry='0x00007f5ae96251c0' size='1296' address='0x00007f5ae9625010' relocation_offset='368' insts_offset='432' stub_offset='944' scopes_data_offset='1096' scopes_pcs_offset='1136' dependencies_offset='1264' nul_chk_table_offset='1272' metadata_offset='1088' method='java.util.ImmutableCollections$SetN$1 hasNext ()Z' bytes='47' count='321' backedge_count='160' iicount='321' stamp='0.231'/>
+<writer thread='23813'/>
+<nmethod compile_id='57' compiler='c1' level='3' entry='0x00007f5ae9625740' size='1224' address='0x00007f5ae9625590' relocation_offset='368' insts_offset='432' stub_offset='944' scopes_data_offset='1112' scopes_pcs_offset='1152' dependencies_offset='1216' metadata_offset='1088' method='java.util.concurrent.ConcurrentHashMap$Node &lt;init&gt; (ILjava/lang/Object;Ljava/lang/Object;)V' bytes='20' count='277' iicount='277' stamp='0.231'/>
+<writer thread='23815'/>
+<nmethod compile_id='58' compiler='c1' level='3' entry='0x00007f5ae9625c40' size='984' address='0x00007f5ae9625a90' relocation_offset='368' insts_offset='432' stub_offset='752' scopes_data_offset='904' scopes_pcs_offset='928' dependencies_offset='976' metadata_offset='896' method='java.util.concurrent.ConcurrentHashMap casTabAt ([Ljava/util/concurrent/ConcurrentHashMap$Node;ILjava/util/concurrent/ConcurrentHashMap$Node;Ljava/util/concurrent/ConcurrentHashMap$Node;)Z' bytes='21' count='274' iicount='274' stamp='0.231'/>
+<writer thread='23757'/>
+<task_queued compile_id='62' method='java.util.ImmutableCollections$SetN$1 next ()Ljava/lang/Object;' bytes='35' count='256' iicount='256' level='3' stamp='0.231' comment='tiered' hot_count='256'/>
+<writer thread='23815'/>
+<nmethod compile_id='62' compiler='c1' level='3' entry='0x00007f5ae9626060' size='1392' address='0x00007f5ae9625e90' relocation_offset='368' insts_offset='464' stub_offset='944' scopes_data_offset='1144' scopes_pcs_offset='1200' dependencies_offset='1360' nul_chk_table_offset='1368' metadata_offset='1128' method='java.util.ImmutableCollections$SetN$1 next ()Ljava/lang/Object;' bytes='35' count='320' iicount='320' stamp='0.232'/>
+<writer thread='23757'/>
+<task_queued compile_id='63' method='java.util.ImmutableCollections$SetN size ()I' bytes='5' count='128' iicount='128' level='1' stamp='0.232' comment='tiered' hot_count='128'/>
+<task_queued compile_id='64' method='java.lang.module.ModuleDescriptor exports ()Ljava/util/Set;' bytes='5' count='128' iicount='128' level='1' stamp='0.232' comment='tiered' hot_count='128'/>
+<writer thread='23814'/>
+<nmethod compile_id='63' compiler='c1' level='1' entry='0x00007f5af0a758c0' size='752' address='0x00007f5af0a75710' relocation_offset='368' insts_offset='432' stub_offset='560' scopes_data_offset='704' scopes_pcs_offset='712' dependencies_offset='744' method='java.util.ImmutableCollections$SetN size ()I' bytes='5' count='136' iicount='136' stamp='0.233'/>
+<writer thread='23815'/>
+<nmethod compile_id='64' compiler='c1' level='1' entry='0x00007f5af0a75bc0' size='752' address='0x00007f5af0a75a10' relocation_offset='368' insts_offset='432' stub_offset='560' scopes_data_offset='704' scopes_pcs_offset='712' dependencies_offset='744' method='java.lang.module.ModuleDescriptor exports ()Ljava/util/Set;' bytes='5' count='169' iicount='169' stamp='0.233'/>
+<writer thread='23813'/>
+<nmethod compile_id='60' compiler='c1' level='3' entry='0x00007f5ae9626660' size='4016' address='0x00007f5ae9626410' relocation_offset='368' insts_offset='592' stub_offset='3088' scopes_data_offset='3376' scopes_pcs_offset='3704' dependencies_offset='3976' nul_chk_table_offset='3984' metadata_offset='3352' method='java.util.concurrent.ConcurrentHashMap addCount (JI)V' bytes='289' count='259' backedge_count='3' iicount='259' stamp='0.233'/>
+<writer thread='23816'/>
+<nmethod compile_id='59' compiler='c1' level='3' entry='0x00007f5ae96277a0' size='12584' address='0x00007f5ae9627410' relocation_offset='368' insts_offset='912' stub_offset='9584' scopes_data_offset='9968' scopes_pcs_offset='11456' dependencies_offset='12192' handler_table_offset='12200' nul_chk_table_offset='12536' oops_offset='9896' metadata_offset='9904' method='java.util.concurrent.ConcurrentHashMap putVal (Ljava/lang/Object;Ljava/lang/Object;Z)Ljava/lang/Object;' bytes='432' count='259' backedge_count='23' iicount='259' stamp='0.235'/>
+<writer thread='23757'/>
+<task_queued compile_id='65' method='java.util.HashMap hash (Ljava/lang/Object;)I' bytes='20' count='256' iicount='256' level='3' stamp='0.235' comment='tiered' hot_count='256'/>
+<writer thread='23816'/>
+<nmethod compile_id='65' compiler='c1' level='3' entry='0x00007f5ae962a740' size='1152' address='0x00007f5ae962a590' relocation_offset='368' insts_offset='432' stub_offset='848' scopes_data_offset='1024' scopes_pcs_offset='1048' dependencies_offset='1128' nul_chk_table_offset='1136' metadata_offset='1016' method='java.util.HashMap hash (Ljava/lang/Object;)I' bytes='20' count='297' iicount='297' stamp='0.235'/>
+<writer thread='23757'/>
+<task_queued compile_id='66' method='java.util.ImmutableCollections$MapN probe (Ljava/lang/Object;)I' bytes='64' count='256' backedge_count='132' iicount='256' level='3' stamp='0.235' comment='tiered' hot_count='256'/>
+<task_queued compile_id='67' method='java.lang.module.ModuleDescriptor$Requires modifiers ()Ljava/util/Set;' bytes='5' count='128' iicount='128' level='1' stamp='0.236' comment='tiered' hot_count='128'/>
+<task_queued compile_id='68' method='java.lang.module.ModuleDescriptor$Requires name ()Ljava/lang/String;' bytes='5' count='128' iicount='128' level='1' stamp='0.236' comment='tiered' hot_count='128'/>
+<task_queued compile_id='69' method='java.util.HashMap getNode (ILjava/lang/Object;)Ljava/util/HashMap$Node;' bytes='148' count='256' backedge_count='14' iicount='256' level='3' stamp='0.236' comment='tiered' hot_count='256'/>
+<task_queued compile_id='70' method='java.util.HashMap containsKey (Ljava/lang/Object;)Z' bytes='18' count='256' iicount='256' level='3' stamp='0.236' comment='tiered' hot_count='256'/>
+<writer thread='23813'/>
+<nmethod compile_id='68' compiler='c1' level='1' entry='0x00007f5af0a75ec0' size='752' address='0x00007f5af0a75d10' relocation_offset='368' insts_offset='432' stub_offset='560' scopes_data_offset='704' scopes_pcs_offset='712' dependencies_offset='744' method='java.lang.module.ModuleDescriptor$Requires name ()Ljava/lang/String;' bytes='5' count='162' iicount='162' stamp='0.236'/>
+<writer thread='23815'/>
+<nmethod compile_id='67' compiler='c1' level='1' entry='0x00007f5af0a761c0' size='752' address='0x00007f5af0a76010' relocation_offset='368' insts_offset='432' stub_offset='560' scopes_data_offset='704' scopes_pcs_offset='712' dependencies_offset='744' method='java.lang.module.ModuleDescriptor$Requires modifiers ()Ljava/util/Set;' bytes='5' count='175' iicount='175' stamp='0.236'/>
+<writer thread='23757'/>
+<task_queued compile_id='71' method='java.util.HashMap put (Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;' bytes='13' count='256' iicount='256' level='3' stamp='0.236' comment='tiered' hot_count='256'/>
+<task_queued compile_id='72' method='java.util.HashMap putVal (ILjava/lang/Object;Ljava/lang/Object;ZZ)Ljava/lang/Object;' bytes='300' count='256' backedge_count='38' iicount='256' level='3' stamp='0.236' comment='tiered' hot_count='256'/>
+<task_queued compile_id='73' method='java.util.HashMap$Node &lt;init&gt; (ILjava/lang/Object;Ljava/lang/Object;Ljava/util/HashMap$Node;)V' bytes='26' count='256' iicount='256' level='3' stamp='0.236' comment='tiered' hot_count='256'/>
+<writer thread='23814'/>
+<nmethod compile_id='66' compiler='c1' level='3' entry='0x00007f5ae962ac80' size='2520' address='0x00007f5ae962aa90' relocation_offset='368' insts_offset='496' stub_offset='1840' scopes_data_offset='2048' scopes_pcs_offset='2224' dependencies_offset='2464' nul_chk_table_offset='2472' metadata_offset='2024' method='java.util.ImmutableCollections$MapN probe (Ljava/lang/Object;)I' bytes='64' count='371' backedge_count='154' iicount='371' stamp='0.236'/>
+<writer thread='23757'/>
+<task_queued compile_id='74' method='java.util.ImmutableCollections$Set1 size ()I' bytes='2' count='128' iicount='128' level='1' stamp='0.236' comment='tiered' hot_count='128'/>
+<task_queued compile_id='75' method='java.util.HashMap newNode (ILjava/lang/Object;Ljava/lang/Object;Ljava/util/HashMap$Node;)Ljava/util/HashMap$Node;' bytes='13' count='256' iicount='256' level='3' stamp='0.236' comment='tiered' hot_count='256'/>
+<task_queued compile_id='76' method='java.util.HashMap afterNodeInsertion (Z)V' bytes='1' count='256' iicount='256' level='3' stamp='0.236' comment='tiered' hot_count='256'/>
+<writer thread='23815'/>
+<nmethod compile_id='70' compiler='c1' level='3' entry='0x00007f5ae962b660' size='1720' address='0x00007f5ae962b490' relocation_offset='368' insts_offset='464' stub_offset='1296' scopes_data_offset='1496' scopes_pcs_offset='1584' dependencies_offset='1696' nul_chk_table_offset='1704' metadata_offset='1480' method='java.util.HashMap containsKey (Ljava/lang/Object;)Z' bytes='18' count='281' iicount='281' stamp='0.237'/>
+<writer thread='23816'/>
+<nmethod compile_id='69' compiler='c1' level='3' entry='0x00007f5ae962bdc0' size='3536' address='0x00007f5ae962bb90' relocation_offset='368' insts_offset='560' stub_offset='2832' scopes_data_offset='3040' scopes_pcs_offset='3216' dependencies_offset='3472' nul_chk_table_offset='3480' metadata_offset='3032' method='java.util.HashMap getNode (ILjava/lang/Object;)Ljava/util/HashMap$Node;' bytes='148' count='362' backedge_count='14' iicount='362' stamp='0.237'/>
+<writer thread='23813'/>
+<nmethod compile_id='71' compiler='c1' level='3' entry='0x00007f5ae962cb60' size='1680' address='0x00007f5ae962c990' relocation_offset='368' insts_offset='464' stub_offset='1232' scopes_data_offset='1432' scopes_pcs_offset='1544' dependencies_offset='1656' nul_chk_table_offset='1664' metadata_offset='1416' method='java.util.HashMap put (Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;' bytes='13' count='364' iicount='364' stamp='0.237'/>
+<writer thread='23757'/>
+<task_queued compile_id='77' method='java.lang.module.ModuleDescriptor provides ()Ljava/util/Set;' bytes='5' count='128' iicount='128' level='1' stamp='0.237' comment='tiered' hot_count='128'/>
+<task_queued compile_id='78' method='java.util.Collections$1 hasNext ()Z' bytes='5' count='128' iicount='128' level='1' stamp='0.237' comment='tiered' hot_count='128'/>
+<writer thread='23813'/>
+<nmethod compile_id='76' compiler='c1' level='3' entry='0x00007f5ae962d240' size='848' address='0x00007f5ae962d090' relocation_offset='368' insts_offset='432' stub_offset='624' scopes_data_offset='776' scopes_pcs_offset='792' dependencies_offset='840' metadata_offset='768' method='java.util.HashMap afterNodeInsertion (Z)V' bytes='1' count='378' iicount='378' stamp='0.237'/>
+<writer thread='23815'/>
+<nmethod compile_id='73' compiler='c1' level='3' entry='0x00007f5ae962d5c0' size='1320' address='0x00007f5ae962d410' relocation_offset='368' insts_offset='432' stub_offset='1040' scopes_data_offset='1208' scopes_pcs_offset='1248' dependencies_offset='1312' metadata_offset='1184' method='java.util.HashMap$Node &lt;init&gt; (ILjava/lang/Object;Ljava/lang/Object;Ljava/util/HashMap$Node;)V' bytes='26' count='381' iicount='381' stamp='0.237'/>
+<writer thread='23813'/>
+<nmethod compile_id='74' compiler='c1' level='1' entry='0x00007f5af0a764c0' size='752' address='0x00007f5af0a76310' relocation_offset='368' insts_offset='432' stub_offset='560' scopes_data_offset='704' scopes_pcs_offset='712' dependencies_offset='744' method='java.util.ImmutableCollections$Set1 size ()I' bytes='2' count='155' iicount='155' stamp='0.237'/>
+<writer thread='23816'/>
+<nmethod compile_id='75' compiler='c1' level='3' entry='0x00007f5ae962db60' size='1640' address='0x00007f5ae962d990' relocation_offset='368' insts_offset='464' stub_offset='1264' scopes_data_offset='1432' scopes_pcs_offset='1536' dependencies_offset='1632' metadata_offset='1408' method='java.util.HashMap newNode (ILjava/lang/Object;Ljava/lang/Object;Ljava/util/HashMap$Node;)Ljava/util/HashMap$Node;' bytes='13' count='378' iicount='378' stamp='0.237'/>
+<writer thread='23813'/>
+<nmethod compile_id='77' compiler='c1' level='1' entry='0x00007f5af0a767c0' size='752' address='0x00007f5af0a76610' relocation_offset='368' insts_offset='432' stub_offset='560' scopes_data_offset='704' scopes_pcs_offset='712' dependencies_offset='744' method='java.lang.module.ModuleDescriptor provides ()Ljava/util/Set;' bytes='5' count='142' iicount='142' stamp='0.238'/>
+<writer thread='23815'/>
+<nmethod compile_id='78' compiler='c1' level='1' entry='0x00007f5af0a76ac0' size='752' address='0x00007f5af0a76910' relocation_offset='368' insts_offset='432' stub_offset='560' scopes_data_offset='704' scopes_pcs_offset='712' dependencies_offset='744' method='java.util.Collections$1 hasNext ()Z' bytes='5' count='128' iicount='128' stamp='0.238'/>
+<writer thread='23814'/>
+<nmethod compile_id='72' compiler='c1' level='3' entry='0x00007f5ae962e2e0' size='6888' address='0x00007f5ae962e010' relocation_offset='368' insts_offset='720' stub_offset='5424' scopes_data_offset='5744' scopes_pcs_offset='6280' dependencies_offset='6776' nul_chk_table_offset='6784' metadata_offset='5736' method='java.util.HashMap putVal (ILjava/lang/Object;Ljava/lang/Object;ZZ)Ljava/lang/Object;' bytes='300' count='448' backedge_count='51' iicount='448' stamp='0.238'/>
+<writer thread='23757'/>
+<task_queued compile_id='79' method='java.util.AbstractCollection isEmpty ()Z' bytes='13' count='256' iicount='256' level='3' stamp='0.238' comment='tiered' hot_count='256'/>
+<task_queued compile_id='80' method='java.lang.module.Resolver isTracing ()Z' bytes='13' count='256' iicount='256' level='3' stamp='0.238' comment='tiered' hot_count='256'/>
+<task_queued compile_id='81' method='java.lang.String hashCode ()I' bytes='49' count='5493' iicount='5493' stamp='0.238' comment='tiered' hot_count='5493'/>
+<writer thread='23814'/>
+<nmethod compile_id='79' compiler='c1' level='3' entry='0x00007f5ae962fcc0' size='1152' address='0x00007f5ae962fb10' relocation_offset='368' insts_offset='432' stub_offset='880' scopes_data_offset='1056' scopes_pcs_offset='1080' dependencies_offset='1144' metadata_offset='1048' method='java.util.AbstractCollection isEmpty ()Z' bytes='13' count='291' iicount='291' stamp='0.239'/>
+<writer thread='23757'/>
+<task_queued compile_id='82' method='java.util.HashMap$HashIterator hasNext ()Z' bytes='13' count='256' iicount='256' level='3' stamp='0.239' comment='tiered' hot_count='256'/>
+<writer thread='23815'/>
+<nmethod compile_id='80' compiler='c1' level='3' entry='0x00007f5ae96301c0' size='944' address='0x00007f5ae9630010' relocation_offset='368' insts_offset='432' stub_offset='720' scopes_data_offset='872' scopes_pcs_offset='888' dependencies_offset='936' metadata_offset='864' method='java.lang.module.Resolver isTracing ()Z' bytes='13' count='314' iicount='314' stamp='0.239'/>
+<writer thread='23757'/>
+<task_queued compile_id='83' method='java.util.Optional ofNullable (Ljava/lang/Object;)Ljava/util/Optional;' bytes='15' count='256' iicount='256' level='3' stamp='0.239' comment='tiered' hot_count='256'/>
+<writer thread='23813'/>
+<nmethod compile_id='82' compiler='c1' level='3' entry='0x00007f5ae96305c0' size='944' address='0x00007f5ae9630410' relocation_offset='368' insts_offset='432' stub_offset='720' scopes_data_offset='872' scopes_pcs_offset='888' dependencies_offset='936' metadata_offset='864' method='java.util.HashMap$HashIterator hasNext ()Z' bytes='13' count='265' iicount='265' stamp='0.239'/>
+<writer thread='23757'/>
+<task_queued compile_id='84' method='java.util.Optional of (Ljava/lang/Object;)Ljava/util/Optional;' bytes='9' count='256' iicount='256' level='3' stamp='0.239' comment='tiered' hot_count='256'/>
+<task_queued compile_id='85' method='java.util.Optional &lt;init&gt; (Ljava/lang/Object;)V' bytes='13' count='256' iicount='256' level='3' stamp='0.239' comment='tiered' hot_count='256'/>
+<task_queued compile_id='86' method='java.util.ImmutableCollections$MapN get (Ljava/lang/Object;)Ljava/lang/Object;' bytes='21' count='256' iicount='256' level='3' stamp='0.239' comment='tiered' hot_count='256'/>
+<task_queued compile_id='87' method='java.util.Optional orElse (Ljava/lang/Object;)Ljava/lang/Object;' bytes='16' count='256' iicount='256' level='3' stamp='0.239' comment='tiered' hot_count='256'/>
+<task_queued compile_id='88' method='jdk.internal.module.SystemModuleFinder find (Ljava/lang/String;)Ljava/util/Optional;' bytes='22' count='256' iicount='256' level='3' stamp='0.239' comment='tiered' hot_count='256'/>
+<task_queued compile_id='89' method='java.lang.module.Resolver findWithBeforeFinder (Ljava/lang/String;)Ljava/lang/module/ModuleReference;' bytes='18' count='256' iicount='256' level='3' stamp='0.239' comment='tiered' hot_count='256'/>
+<task_queued compile_id='90' method='java.util.ImmutableCollections$Set0 size ()I' bytes='2' count='128' iicount='128' level='1' stamp='0.239' comment='tiered' hot_count='128'/>
+<task_queued compile_id='91' method='java.util.HashSet add (Ljava/lang/Object;)Z' bytes='20' count='256' iicount='256' level='3' stamp='0.239' comment='tiered' hot_count='256'/>
+<writer thread='23816'/>
+<nmethod compile_id='85' compiler='c1' level='3' entry='0x00007f5ae96309e0' size='1576' address='0x00007f5ae9630810' relocation_offset='368' insts_offset='464' stub_offset='1168' scopes_data_offset='1360' scopes_pcs_offset='1440' dependencies_offset='1568' metadata_offset='1336' method='java.util.Optional &lt;init&gt; (Ljava/lang/Object;)V' bytes='13' count='277' iicount='277' stamp='0.239'/>
+<writer thread='23814'/>
+<nmethod compile_id='83' compiler='c1' level='3' entry='0x00007f5ae9631080' size='2160' address='0x00007f5ae9630e90' relocation_offset='368' insts_offset='496' stub_offset='1616' scopes_data_offset='1832' scopes_pcs_offset='1960' dependencies_offset='2152' metadata_offset='1784' method='java.util.Optional ofNullable (Ljava/lang/Object;)Ljava/util/Optional;' bytes='15' count='277' iicount='277' stamp='0.239'/>
+<writer thread='23757'/>
+<task_queued compile_id='92' method='java.util.HashMap get (Ljava/lang/Object;)Ljava/lang/Object;' bytes='23' count='256' iicount='256' level='3' stamp='0.239' comment='tiered' hot_count='256'/>
+<writer thread='23815'/>
+<nmethod compile_id='86' compiler='c1' level='3' entry='0x00007f5ae96318c0' size='1128' address='0x00007f5ae9631710' relocation_offset='368' insts_offset='432' stub_offset='784' scopes_data_offset='960' scopes_pcs_offset='1008' dependencies_offset='1104' nul_chk_table_offset='1112' metadata_offset='952' method='java.util.ImmutableCollections$MapN get (Ljava/lang/Object;)Ljava/lang/Object;' bytes='21' count='275' iicount='275' stamp='0.239'/>
+<writer thread='23757'/>
+<nmethod compile_id='93' compile_kind='c2n' compiler='' level='0' entry='0x00007f5af0a76de0' size='984' address='0x00007f5af0a76c10' relocation_offset='368' consts_offset='984' insts_offset='464' method='java.lang.Object hashCode ()I' bytes='0' count='256' iicount='256' stamp='0.239'/>
+<writer thread='23813'/>
+<nmethod compile_id='84' compiler='c1' level='3' entry='0x00007f5ae9631d60' size='1800' address='0x00007f5ae9631b90' relocation_offset='368' insts_offset='464' stub_offset='1328' scopes_data_offset='1528' scopes_pcs_offset='1632' dependencies_offset='1792' metadata_offset='1496' method='java.util.Optional of (Ljava/lang/Object;)Ljava/util/Optional;' bytes='9' count='277' iicount='277' stamp='0.240'/>
+<writer thread='23757'/>
+<task_queued compile_id='94' method='java.util.HashMap$HashIterator nextNode ()Ljava/util/HashMap$Node;' bytes='100' count='256' backedge_count='523' iicount='256' level='3' stamp='0.240' comment='tiered' hot_count='256'/>
+<writer thread='23814'/>
+<nmethod compile_id='87' compiler='c1' level='3' entry='0x00007f5ae96324c0' size='944' address='0x00007f5ae9632310' relocation_offset='368' insts_offset='432' stub_offset='720' scopes_data_offset='872' scopes_pcs_offset='888' dependencies_offset='936' metadata_offset='864' method='java.util.Optional orElse (Ljava/lang/Object;)Ljava/lang/Object;' bytes='16' count='274' iicount='274' stamp='0.240'/>
+<writer thread='23757'/>
+<task_queued compile_id='95' method='jdk.internal.module.ModuleReferenceImpl hashCode ()I' bytes='56' count='384' iicount='384' level='3' stamp='0.240' comment='tiered' hot_count='384'/>
+<writer thread='23816'/>
+<nmethod compile_id='89' compiler='c1' level='3' entry='0x00007f5ae96328e0' size='1784' address='0x00007f5ae9632710' relocation_offset='368' insts_offset='464' stub_offset='1392' scopes_data_offset='1576' scopes_pcs_offset='1624' dependencies_offset='1752' nul_chk_table_offset='1760' metadata_offset='1560' method='java.lang.module.Resolver findWithBeforeFinder (Ljava/lang/String;)Ljava/lang/module/ModuleReference;' bytes='18' count='271' iicount='271' stamp='0.240'/>
+<writer thread='23757'/>
+<task_queued compile_id='96' method='java.lang.module.ResolvedModule hashCode ()I' bytes='16' count='256' iicount='256' level='3' stamp='0.240' comment='tiered' hot_count='256'/>
+<writer thread='23813'/>
+<nmethod compile_id='91' compiler='c1' level='3' entry='0x00007f5ae9633080' size='2128' address='0x00007f5ae9632e90' relocation_offset='368' insts_offset='496' stub_offset='1616' scopes_data_offset='1832' scopes_pcs_offset='1952' dependencies_offset='2096' nul_chk_table_offset='2104' oops_offset='1800' metadata_offset='1808' method='java.util.HashSet add (Ljava/lang/Object;)Z' bytes='20' count='478' iicount='478' stamp='0.240'/>
+<writer thread='23757'/>
+<task_queued compile_id='97' method='java.lang.module.ModuleDescriptor requires ()Ljava/util/Set;' bytes='5' count='128' iicount='128' level='1' stamp='0.240' comment='tiered' hot_count='128'/>
+<task_queued compile_id='98' method='java.lang.module.ModuleDescriptor isAutomatic ()Z' bytes='5' count='128' iicount='128' level='1' stamp='0.240' comment='tiered' hot_count='128'/>
+<task_queued compile_id='99' method='java.lang.module.Resolver computeIfAbsent (Ljava/util/Map;Ljava/lang/String;Ljava/lang/module/Configuration;Ljava/lang/module/ModuleReference;)Ljava/lang/module/ResolvedModule;' bytes='42' count='256' iicount='256' level='3' stamp='0.240' comment='tiered' hot_count='256'/>
+<writer thread='23814'/>
+<nmethod compile_id='94' compiler='c1' level='3' entry='0x00007f5ae9633900' size='2312' address='0x00007f5ae9633710' relocation_offset='368' insts_offset='496' stub_offset='1744' scopes_data_offset='1936' scopes_pcs_offset='2032' dependencies_offset='2272' nul_chk_table_offset='2280' metadata_offset='1928' method='java.util.HashMap$HashIterator nextNode ()Ljava/util/HashMap$Node;' bytes='100' count='298' backedge_count='566' iicount='298' stamp='0.240'/>
+<writer thread='23757'/>
+<task_queued compile_id='100' method='java.util.ImmutableCollections$Set1 contains (Ljava/lang/Object;)Z' bytes='9' count='256' iicount='256' level='3' stamp='0.240' comment='tiered' hot_count='256'/>
+<task_queued compile_id='101' method='java.lang.Enum equals (Ljava/lang/Object;)Z' bytes='11' count='256' iicount='256' level='3' stamp='0.240' comment='tiered' hot_count='256'/>
+<writer thread='23813'/>
+<nmethod compile_id='92' compiler='c1' level='3' entry='0x00007f5ae9634260' size='1760' address='0x00007f5ae9634090' relocation_offset='368' insts_offset='464' stub_offset='1296' scopes_data_offset='1496' scopes_pcs_offset='1600' dependencies_offset='1728' nul_chk_table_offset='1736' metadata_offset='1480' method='java.util.HashMap get (Ljava/lang/Object;)Ljava/lang/Object;' bytes='23' count='679' iicount='679' stamp='0.240'/>
+<writer thread='23815'/>
+<nmethod compile_id='88' compiler='c1' level='3' entry='0x00007f5ae96349c0' size='3344' address='0x00007f5ae9634790' relocation_offset='368' insts_offset='560' stub_offset='2544' scopes_data_offset='2800' scopes_pcs_offset='3000' dependencies_offset='3320' nul_chk_table_offset='3328' metadata_offset='2744' method='jdk.internal.module.SystemModuleFinder find (Ljava/lang/String;)Ljava/util/Optional;' bytes='22' count='273' iicount='273' stamp='0.240'/>
+<writer thread='23816'/>
+<nmethod compile_id='95' compiler='c1' level='3' entry='0x00007f5ae9635700' size='2240' address='0x00007f5ae9635510' relocation_offset='368' insts_offset='496' stub_offset='1680' scopes_data_offset='1912' scopes_pcs_offset='2024' dependencies_offset='2200' nul_chk_table_offset='2208' metadata_offset='1880' method='jdk.internal.module.ModuleReferenceImpl hashCode ()I' bytes='56' count='632' iicount='632' stamp='0.241'/>
+<writer thread='23814'/>
+<nmethod compile_id='96' compiler='c1' level='3' entry='0x00007f5ae9635fe0' size='1424' address='0x00007f5ae9635e10' relocation_offset='368' insts_offset='464' stub_offset='1040' scopes_data_offset='1232' scopes_pcs_offset='1280' dependencies_offset='1392' nul_chk_table_offset='1400' metadata_offset='1224' method='java.lang.module.ResolvedModule hashCode ()I' bytes='16' count='458' iicount='458' stamp='0.241'/>
+<writer thread='23813'/>
+<nmethod compile_id='97' compiler='c1' level='1' entry='0x00007f5af0a771c0' size='752' address='0x00007f5af0a77010' relocation_offset='368' insts_offset='432' stub_offset='560' scopes_data_offset='704' scopes_pcs_offset='712' dependencies_offset='744' method='java.lang.module.ModuleDescriptor requires ()Ljava/util/Set;' bytes='5' count='154' iicount='154' stamp='0.241'/>
+<writer thread='23816'/>
+<nmethod compile_id='98' compiler='c1' level='1' entry='0x00007f5af0a774c0' size='752' address='0x00007f5af0a77310' relocation_offset='368' insts_offset='432' stub_offset='560' scopes_data_offset='704' scopes_pcs_offset='712' dependencies_offset='744' method='java.lang.module.ModuleDescriptor isAutomatic ()Z' bytes='5' count='154' iicount='154' stamp='0.241'/>
+<writer thread='23757'/>
+<task_queued compile_id='102' method='java.util.HashMap$KeyIterator next ()Ljava/lang/Object;' bytes='8' count='256' iicount='256' level='3' stamp='0.241' comment='tiered' hot_count='256'/>
+<writer thread='23816'/>
+<nmethod compile_id='90' compiler='c1' level='1' entry='0x00007f5af0a777c0' size='752' address='0x00007f5af0a77610' relocation_offset='368' insts_offset='432' stub_offset='560' scopes_data_offset='704' scopes_pcs_offset='712' dependencies_offset='744' method='java.util.ImmutableCollections$Set0 size ()I' bytes='2' count='130' iicount='130' stamp='0.241'/>
+<writer thread='23813'/>
+<nmethod compile_id='101' compiler='c1' level='3' entry='0x00007f5ae96365c0' size='944' address='0x00007f5ae9636410' relocation_offset='368' insts_offset='432' stub_offset='720' scopes_data_offset='872' scopes_pcs_offset='888' dependencies_offset='936' metadata_offset='864' method='java.lang.Enum equals (Ljava/lang/Object;)Z' bytes='11' count='274' iicount='274' stamp='0.241'/>
+<writer thread='23814'/>
+<nmethod compile_id='100' compiler='c1' level='3' entry='0x00007f5ae96369c0' size='1128' address='0x00007f5ae9636810' relocation_offset='368' insts_offset='432' stub_offset='816' scopes_data_offset='992' scopes_pcs_offset='1024' dependencies_offset='1104' nul_chk_table_offset='1112' metadata_offset='984' method='java.util.ImmutableCollections$Set1 contains (Ljava/lang/Object;)Z' bytes='9' count='274' iicount='274' stamp='0.241'/>
+<writer thread='23757'/>
+<task_queued compile_id='103' method='java.util.HashMap$HashIterator &lt;init&gt; (Ljava/util/HashMap;)V' bytes='79' count='256' backedge_count='595' iicount='256' level='3' stamp='0.241' comment='tiered' hot_count='256'/>
+<task_queued compile_id='104' method='java.util.HashSet iterator ()Ljava/util/Iterator;' bytes='13' count='256' iicount='256' level='3' stamp='0.241' comment='tiered' hot_count='256'/>
+<task_queued compile_id='105' method='java.util.HashMap keySet ()Ljava/util/Set;' bytes='25' count='256' iicount='256' level='3' stamp='0.241' comment='tiered' hot_count='256'/>
+<task_queued compile_id='106' method='java.util.HashMap$KeySet iterator ()Ljava/util/Iterator;' bytes='12' count='256' iicount='256' level='3' stamp='0.241' comment='tiered' hot_count='256'/>
+<task_queued compile_id='107' method='java.util.HashMap$KeyIterator &lt;init&gt; (Ljava/util/HashMap;)V' bytes='11' count='256' iicount='256' level='3' stamp='0.241' comment='tiered' hot_count='256'/>
+<writer thread='23813'/>
+<nmethod compile_id='102' compiler='c1' level='3' entry='0x00007f5ae9636e40' size='1096' address='0x00007f5ae9636c90' relocation_offset='368' insts_offset='432' stub_offset='784' scopes_data_offset='960' scopes_pcs_offset='992' dependencies_offset='1072' nul_chk_table_offset='1080' metadata_offset='952' method='java.util.HashMap$KeyIterator next ()Ljava/lang/Object;' bytes='8' count='439' iicount='439' stamp='0.241'/>
+<writer thread='23815'/>
+<nmethod compile_id='99' compiler='c1' level='3' entry='0x00007f5ae9637340' size='3432' address='0x00007f5ae9637110' relocation_offset='368' insts_offset='560' stub_offset='2576' scopes_data_offset='2824' scopes_pcs_offset='3120' dependencies_offset='3408' nul_chk_table_offset='3416' metadata_offset='2792' method='java.lang.module.Resolver computeIfAbsent (Ljava/util/Map;Ljava/lang/String;Ljava/lang/module/Configuration;Ljava/lang/module/ModuleReference;)Ljava/lang/module/ResolvedModule;' bytes='42' count='312' iicount='312' stamp='0.241'/>
+<writer thread='23814'/>
+<nmethod compile_id='104' compiler='c1' level='3' entry='0x00007f5ae9638060' size='1376' address='0x00007f5ae9637e90' relocation_offset='368' insts_offset='464' stub_offset='1008' scopes_data_offset='1200' scopes_pcs_offset='1232' dependencies_offset='1344' nul_chk_table_offset='1352' metadata_offset='1192' method='java.util.HashSet iterator ()Ljava/util/Iterator;' bytes='13' count='496' iicount='496' stamp='0.242'/>
+<writer thread='23757'/>
+<task_queued compile_id='108' method='java.util.HashMap$ValueIterator next ()Ljava/lang/Object;' bytes='8' count='256' iicount='256' level='3' stamp='0.242' comment='tiered' hot_count='256'/>
+<writer thread='23813'/>
+<nmethod compile_id='105' compiler='c1' level='3' entry='0x00007f5ae96385e0' size='1800' address='0x00007f5ae9638410' relocation_offset='368' insts_offset='464' stub_offset='1392' scopes_data_offset='1576' scopes_pcs_offset='1664' dependencies_offset='1792' metadata_offset='1536' method='java.util.HashMap keySet ()Ljava/util/Set;' bytes='25' count='581' iicount='582' stamp='0.242'/>
+<writer thread='23814'/>
+<nmethod compile_id='107' compiler='c1' level='3' entry='0x00007f5ae9638d40' size='1024' address='0x00007f5ae9638b90' relocation_offset='368' insts_offset='432' stub_offset='752' scopes_data_offset='928' scopes_pcs_offset='952' dependencies_offset='1016' metadata_offset='920' method='java.util.HashMap$KeyIterator &lt;init&gt; (Ljava/util/HashMap;)V' bytes='11' count='593' iicount='593' stamp='0.242'/>
+<writer thread='23816'/>
+<nmethod compile_id='103' compiler='c1' level='3' entry='0x00007f5ae96391e0' size='1880' address='0x00007f5ae9639010' relocation_offset='368' insts_offset='464' stub_offset='1456' scopes_data_offset='1624' scopes_pcs_offset='1704' dependencies_offset='1848' nul_chk_table_offset='1856' metadata_offset='1600' method='java.util.HashMap$HashIterator &lt;init&gt; (Ljava/util/HashMap;)V' bytes='79' count='619' backedge_count='1054' iicount='620' stamp='0.242'/>
+<writer thread='23815'/>
+<nmethod compile_id='106' compiler='c1' level='3' entry='0x00007f5ae9639960' size='1360' address='0x00007f5ae9639790' relocation_offset='368' insts_offset='464' stub_offset='1008' scopes_data_offset='1192' scopes_pcs_offset='1256' dependencies_offset='1352' metadata_offset='1176' method='java.util.HashMap$KeySet iterator ()Ljava/util/Iterator;' bytes='12' count='651' iicount='651' stamp='0.242'/>
+<writer thread='23814'/>
+<nmethod compile_id='108' compiler='c1' level='3' entry='0x00007f5ae9639ec0' size='1096' address='0x00007f5ae9639d10' relocation_offset='368' insts_offset='432' stub_offset='784' scopes_data_offset='960' scopes_pcs_offset='992' dependencies_offset='1072' nul_chk_table_offset='1080' metadata_offset='952' method='java.util.HashMap$ValueIterator next ()Ljava/lang/Object;' bytes='8' count='293' iicount='293' stamp='0.242'/>
+<writer thread='23757'/>
+<task_queued compile_id='109' method='java.util.KeyValueHolder getKey ()Ljava/lang/Object;' bytes='5' count='128' iicount='128' level='1' stamp='0.243' comment='tiered' hot_count='128'/>
+<task_queued compile_id='110' method='java.util.KeyValueHolder getValue ()Ljava/lang/Object;' bytes='5' count='128' iicount='128' level='1' stamp='0.243' comment='tiered' hot_count='128'/>
+<writer thread='23813'/>
+<nmethod compile_id='109' compiler='c1' level='1' entry='0x00007f5af0a77ac0' size='752' address='0x00007f5af0a77910' relocation_offset='368' insts_offset='432' stub_offset='560' scopes_data_offset='704' scopes_pcs_offset='712' dependencies_offset='744' method='java.util.KeyValueHolder getKey ()Ljava/lang/Object;' bytes='5' count='176' iicount='176' stamp='0.243'/>
+<writer thread='23816'/>
+<nmethod compile_id='110' compiler='c1' level='1' entry='0x00007f5af0a77dc0' size='752' address='0x00007f5af0a77c10' relocation_offset='368' insts_offset='432' stub_offset='560' scopes_data_offset='704' scopes_pcs_offset='712' dependencies_offset='744' method='java.util.KeyValueHolder getValue ()Ljava/lang/Object;' bytes='5' count='176' iicount='176' stamp='0.243'/>
+<writer thread='23811'/>
+<nmethod compile_id='81' compiler='c2' level='4' entry='0x00007f5af0a780a0' size='1024' address='0x00007f5af0a77f10' relocation_offset='368' insts_offset='400' stub_offset='816' scopes_data_offset='856' scopes_pcs_offset='920' dependencies_offset='1000' nul_chk_table_offset='1008' metadata_offset='840' method='java.lang.String hashCode ()I' bytes='49' count='6415' iicount='6415' stamp='0.243'/>
+<make_not_entrant thread='23811' compile_id='10' compiler='c1' level='3' stamp='0.243'/>
+<writer thread='23757'/>
+<task_queued compile_id='111' method='java.lang.module.ResolvedModule reference ()Ljava/lang/module/ModuleReference;' bytes='5' count='128' iicount='128' level='1' stamp='0.243' comment='tiered' hot_count='128'/>
+<task_queued compile_id='112' method='java.util.HashSet contains (Ljava/lang/Object;)Z' bytes='9' count='256' iicount='256' level='3' stamp='0.243' comment='tiered' hot_count='256'/>
+<writer thread='23815'/>
+<nmethod compile_id='111' compiler='c1' level='1' entry='0x00007f5af0a78540' size='752' address='0x00007f5af0a78390' relocation_offset='368' insts_offset='432' stub_offset='560' scopes_data_offset='704' scopes_pcs_offset='712' dependencies_offset='744' method='java.lang.module.ResolvedModule reference ()Ljava/lang/module/ModuleReference;' bytes='5' count='156' iicount='156' stamp='0.243'/>
+<writer thread='23757'/>
+<task_queued compile_id='113' method='java.lang.String indexOf (II)I' bytes='29' count='255' iicount='255' level='3' stamp='0.243' comment='tiered' hot_count='255'/>
+<task_queued compile_id='114' method='java.lang.StringLatin1 indexOf ([BII)I' bytes='61' count='255' backedge_count='2241' iicount='255' level='3' stamp='0.243' comment='tiered' hot_count='255'/>
+<task_queued compile_id='115' method='java.lang.String indexOf (I)I' bytes='7' count='247' iicount='247' level='3' stamp='0.243' comment='tiered' hot_count='247'/>
+<task_queued compile_id='116' method='java.util.concurrent.ConcurrentHashMap putIfAbsent (Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;' bytes='8' count='256' iicount='256' level='3' stamp='0.243' comment='tiered' hot_count='256'/>
+<writer thread='23814'/>
+<nmethod compile_id='112' compiler='c1' level='3' entry='0x00007f5ae963a380' size='2072' address='0x00007f5ae963a190' relocation_offset='368' insts_offset='496' stub_offset='1584' scopes_data_offset='1792' scopes_pcs_offset='1896' dependencies_offset='2040' nul_chk_table_offset='2048' metadata_offset='1768' method='java.util.HashSet contains (Ljava/lang/Object;)Z' bytes='9' count='264' iicount='264' stamp='0.244'/>
+<writer thread='23816'/>
+<nmethod compile_id='113' compiler='c1' level='3' entry='0x00007f5ae963abe0' size='1368' address='0x00007f5ae963aa10' relocation_offset='368' insts_offset='464' stub_offset='1008' scopes_data_offset='1208' scopes_pcs_offset='1264' dependencies_offset='1360' metadata_offset='1192' method='java.lang.String indexOf (II)I' bytes='29' count='295' iicount='295' stamp='0.244'/>
+<writer thread='23813'/>
+<nmethod compile_id='114' compiler='c1' level='3' entry='0x00007f5ae963b160' size='1728' address='0x00007f5ae963af90' relocation_offset='368' insts_offset='464' stub_offset='1328' scopes_data_offset='1488' scopes_pcs_offset='1576' dependencies_offset='1704' nul_chk_table_offset='1712' metadata_offset='1472' method='java.lang.StringLatin1 indexOf ([BII)I' bytes='61' count='295' backedge_count='2559' iicount='295' stamp='0.244'/>
+<writer thread='23815'/>
+<nmethod compile_id='116' compiler='c1' level='3' entry='0x00007f5ae963b840' size='1072' address='0x00007f5ae963b690' relocation_offset='368' insts_offset='432' stub_offset='784' scopes_data_offset='968' scopes_pcs_offset='1000' dependencies_offset='1064' metadata_offset='952' method='java.util.concurrent.ConcurrentHashMap putIfAbsent (Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;' bytes='8' count='577' iicount='577' stamp='0.244'/>
+<writer thread='23757'/>
+<task_queued compile_id='117' method='java.lang.module.ModuleDescriptor packages ()Ljava/util/Set;' bytes='5' count='128' iicount='128' level='1' stamp='0.244' comment='tiered' hot_count='128'/>
+<writer thread='23813'/>
+<nmethod compile_id='117' compiler='c1' level='1' entry='0x00007f5af0a78840' size='752' address='0x00007f5af0a78690' relocation_offset='368' insts_offset='432' stub_offset='560' scopes_data_offset='704' scopes_pcs_offset='712' dependencies_offset='744' method='java.lang.module.ModuleDescriptor packages ()Ljava/util/Set;' bytes='5' count='135' iicount='135' stamp='0.244'/>
+<writer thread='23814'/>
+<nmethod compile_id='115' compiler='c1' level='3' entry='0x00007f5ae963bce0' size='1640' address='0x00007f5ae963bb10' relocation_offset='368' insts_offset='464' stub_offset='1232' scopes_data_offset='1440' scopes_pcs_offset='1520' dependencies_offset='1632' metadata_offset='1416' method='java.lang.String indexOf (I)I' bytes='7' count='316' iicount='316' stamp='0.244'/>
+<writer thread='23757'/>
+<task_queued compile_id='118' method='java.lang.Math min (II)I' bytes='11' count='256' iicount='256' level='3' stamp='0.244' comment='tiered' hot_count='256'/>
+<task_queued compile_id='119' method='java.lang.String isLatin1 ()Z' bytes='19' count='6656' iicount='6656' stamp='0.244' comment='tiered' hot_count='6656'/>
+<writer thread='23815'/>
+<nmethod compile_id='118' compiler='c1' level='3' entry='0x00007f5ae963c340' size='912' address='0x00007f5ae963c190' relocation_offset='368' insts_offset='432' stub_offset='688' scopes_data_offset='840' scopes_pcs_offset='856' dependencies_offset='904' metadata_offset='832' method='java.lang.Math min (II)I' bytes='11' count='264' iicount='264' stamp='0.244'/>
+<writer thread='23757'/>
+<task_queued compile_id='120' method='jdk.internal.misc.Unsafe putObjectRelease (Ljava/lang/Object;JLjava/lang/Object;)V' bytes='9' count='256' iicount='256' level='3' stamp='0.244' comment='tiered' hot_count='256'/>
+<nmethod compile_id='121' compile_kind='c2n' compiler='' level='0' entry='0x00007f5af0a78b60' size='960' address='0x00007f5af0a78990' relocation_offset='368' consts_offset='960' insts_offset='464' method='jdk.internal.misc.Unsafe putObjectVolatile (Ljava/lang/Object;JLjava/lang/Object;)V' bytes='0' count='256' iicount='256' stamp='0.244'/>
+<task_queued compile_id='122' method='java.util.concurrent.ConcurrentHashMap setTabAt ([Ljava/util/concurrent/ConcurrentHashMap$Node;ILjava/util/concurrent/ConcurrentHashMap$Node;)V' bytes='20' count='256' iicount='256' level='3' stamp='0.245' comment='tiered' hot_count='256'/>
+<writer thread='23814'/>
+<nmethod compile_id='120' compiler='c1' level='3' entry='0x00007f5ae963c740' size='952' address='0x00007f5ae963c590' relocation_offset='368' insts_offset='432' stub_offset='720' scopes_data_offset='872' scopes_pcs_offset='896' dependencies_offset='944' metadata_offset='864' method='jdk.internal.misc.Unsafe putObjectRelease (Ljava/lang/Object;JLjava/lang/Object;)V' bytes='9' count='296' iicount='296' stamp='0.245'/>
+<writer thread='23811'/>
+<nmethod compile_id='119' compiler='c2' level='4' entry='0x00007f5af0a78f20' size='568' address='0x00007f5af0a78d90' relocation_offset='368' insts_offset='400' stub_offset='496' scopes_data_offset='520' scopes_pcs_offset='528' dependencies_offset='560' method='java.lang.String isLatin1 ()Z' bytes='19' count='6717' iicount='6717' stamp='0.245'/>
+<make_not_entrant thread='23811' compile_id='5' compiler='c1' level='3' stamp='0.245'/>
+<writer thread='23815'/>
+<nmethod compile_id='122' compiler='c1' level='3' entry='0x00007f5ae963cb40' size='1232' address='0x00007f5ae963c990' relocation_offset='368' insts_offset='432' stub_offset='944' scopes_data_offset='1112' scopes_pcs_offset='1160' dependencies_offset='1224' oops_offset='1088' metadata_offset='1096' method='java.util.concurrent.ConcurrentHashMap setTabAt ([Ljava/util/concurrent/ConcurrentHashMap$Node;ILjava/util/concurrent/ConcurrentHashMap$Node;)V' bytes='20' count='294' iicount='294' stamp='0.245'/>
+<writer thread='23757'/>
+<task_queued compile_id='123' method='java.lang.CharacterData of (I)Ljava/lang/CharacterData;' bytes='120' count='256' iicount='256' level='3' stamp='0.245' comment='tiered' hot_count='256'/>
+<task_queued compile_id='124' method='java.lang.CharacterDataLatin1 getProperties (I)I' bytes='11' count='256' iicount='256' level='3' stamp='0.245' comment='tiered' hot_count='256'/>
+<task_queued compile_id='125' method='java.lang.module.ResolvedModule name ()Ljava/lang/String;' bytes='11' count='256' iicount='256' level='3' stamp='0.245' comment='tiered' hot_count='256'/>
+<writer thread='23816'/>
+<nmethod compile_id='124' compiler='c1' level='3' entry='0x00007f5ae963d040' size='1000' address='0x00007f5ae963ce90' relocation_offset='368' insts_offset='432' stub_offset='688' scopes_data_offset='840' scopes_pcs_offset='872' dependencies_offset='968' nul_chk_table_offset='976' metadata_offset='832' method='java.lang.CharacterDataLatin1 getProperties (I)I' bytes='11' count='260' iicount='260' stamp='0.245'/>
+<writer thread='23813'/>
+<nmethod compile_id='123' compiler='c1' level='3' entry='0x00007f5ae963d4a0' size='2480' address='0x00007f5ae963d290' relocation_offset='368' insts_offset='528' stub_offset='1872' scopes_data_offset='2024' scopes_pcs_offset='2080' dependencies_offset='2416' nul_chk_table_offset='2424' metadata_offset='2016' method='java.lang.CharacterData of (I)Ljava/lang/CharacterData;' bytes='120' count='260' iicount='260' stamp='0.245'/>
+<writer thread='23816'/>
+<nmethod compile_id='125' compiler='c1' level='3' entry='0x00007f5ae963de40' size='1312' address='0x00007f5ae963dc90' relocation_offset='368' insts_offset='432' stub_offset='1008' scopes_data_offset='1168' scopes_pcs_offset='1200' dependencies_offset='1280' nul_chk_table_offset='1288' metadata_offset='1152' method='java.lang.module.ResolvedModule name ()Ljava/lang/String;' bytes='11' count='316' iicount='316' stamp='0.245'/>
+<writer thread='23757'/>
+<task_queued compile_id='126' method='java.util.ImmutableCollections$SetN$1 hasNext ()Z' bytes='47' count='5378' backedge_count='2610' iicount='5378' stamp='0.246' comment='tiered' hot_count='5378'/>
+<task_queued compile_id='127' method='java.lang.module.ModuleDescriptor$Version toString ()Ljava/lang/String;' bytes='5' count='128' iicount='128' level='1' stamp='0.246' comment='tiered' hot_count='128'/>
+<writer thread='23813'/>
+<nmethod compile_id='127' compiler='c1' level='1' entry='0x00007f5af0a791c0' size='752' address='0x00007f5af0a79010' relocation_offset='368' insts_offset='432' stub_offset='560' scopes_data_offset='704' scopes_pcs_offset='712' dependencies_offset='744' method='java.lang.module.ModuleDescriptor$Version toString ()Ljava/lang/String;' bytes='5' count='136' iicount='136' stamp='0.246'/>
+<writer thread='23757'/>
+<task_queued compile_id='128' method='java.util.ImmutableCollections$Set2$1 hasNext ()Z' bytes='14' count='256' iicount='256' level='3' stamp='0.247' comment='tiered' hot_count='256'/>
+<task_queued compile_id='129' method='java.lang.AbstractStringBuilder ensureCapacityInternal (I)V' bytes='39' count='256' iicount='256' level='3' stamp='0.247' comment='tiered' hot_count='256'/>
+<writer thread='23814'/>
+<nmethod compile_id='128' compiler='c1' level='3' entry='0x00007f5ae963e3c0' size='944' address='0x00007f5ae963e210' relocation_offset='368' insts_offset='432' stub_offset='720' scopes_data_offset='872' scopes_pcs_offset='888' dependencies_offset='936' metadata_offset='864' method='java.util.ImmutableCollections$Set2$1 hasNext ()Z' bytes='14' count='256' iicount='256' stamp='0.247'/>
+<writer thread='23805'/>
+<nmethod compile_id='126' compiler='c2' level='4' entry='0x00007f5af0a794a0' size='768' address='0x00007f5af0a79310' relocation_offset='368' insts_offset='400' stub_offset='592' scopes_data_offset='624' scopes_pcs_offset='656' dependencies_offset='736' nul_chk_table_offset='744' metadata_offset='616' method='java.util.ImmutableCollections$SetN$1 hasNext ()Z' bytes='47' count='6514' backedge_count='3168' iicount='6514' stamp='0.247'/>
+<make_not_entrant thread='23805' compile_id='55' compiler='c1' level='3' stamp='0.247'/>
+<writer thread='23815'/>
+<nmethod compile_id='129' compiler='c1' level='3' entry='0x00007f5ae963e800' size='2040' address='0x00007f5ae963e610' relocation_offset='368' insts_offset='496' stub_offset='1520' scopes_data_offset='1728' scopes_pcs_offset='1872' dependencies_offset='2016' nul_chk_table_offset='2024' metadata_offset='1704' method='java.lang.AbstractStringBuilder ensureCapacityInternal (I)V' bytes='39' count='301' iicount='301' stamp='0.248'/>
+<writer thread='23757'/>
+<task_queued compile_id='130' method='java.util.HashMap &lt;init&gt; ()V' bytes='11' count='256' iicount='256' level='3' stamp='0.248' comment='tiered' hot_count='256'/>
+<task_queued compile_id='131' method='java.util.Collections$EmptyMap get (Ljava/lang/Object;)Ljava/lang/Object;' bytes='2' count='128' iicount='128' level='1' stamp='0.248' comment='tiered' hot_count='128'/>
+<task_queued compile_id='132' method='java.util.HashMap afterNodeInsertion (Z)V' bytes='1' count='1385' iicount='1385' level='1' stamp='0.248' comment='tiered' hot_count='1385'/>
+<writer thread='23813'/>
+<nmethod compile_id='131' compiler='c1' level='1' entry='0x00007f5af0a79840' size='752' address='0x00007f5af0a79690' relocation_offset='368' insts_offset='432' stub_offset='560' scopes_data_offset='704' scopes_pcs_offset='712' dependencies_offset='744' method='java.util.Collections$EmptyMap get (Ljava/lang/Object;)Ljava/lang/Object;' bytes='2' count='134' iicount='134' stamp='0.248'/>
+<writer thread='23757'/>
+<task_queued compile_id='133' method='java.util.HashSet &lt;init&gt; ()V' bytes='16' count='256' iicount='256' level='3' stamp='0.248' comment='tiered' hot_count='256'/>
+<writer thread='23816'/>
+<nmethod compile_id='130' compiler='c1' level='3' entry='0x00007f5ae963f040' size='1120' address='0x00007f5ae963ee90' relocation_offset='368' insts_offset='432' stub_offset='816' scopes_data_offset='992' scopes_pcs_offset='1032' dependencies_offset='1112' metadata_offset='960' method='java.util.HashMap &lt;init&gt; ()V' bytes='11' count='302' iicount='302' stamp='0.248'/>
+<writer thread='23814'/>
+<nmethod compile_id='132' compiler='c1' level='1' entry='0x00007f5af0a79b40' size='752' address='0x00007f5af0a79990' relocation_offset='368' insts_offset='432' stub_offset='560' scopes_data_offset='704' scopes_pcs_offset='712' dependencies_offset='744' method='java.util.HashMap afterNodeInsertion (Z)V' bytes='1' count='1482' iicount='1482' stamp='0.248'/>
+<make_not_entrant thread='23814' compile_id='76' compiler='c1' level='3' stamp='0.248'/>
+<writer thread='23757'/>
+<task_queued compile_id='134' method='java.util.HashMap resize ()[Ljava/util/HashMap$Node;' bytes='356' count='282' backedge_count='1174' iicount='282' level='3' stamp='0.249' comment='tiered' hot_count='282'/>
+<task_queued compile_id='135' method='java.lang.module.ModuleDescriptor$Exports isQualified ()Z' bytes='18' count='256' iicount='256' level='3' stamp='0.249' comment='tiered' hot_count='256'/>
+<writer thread='23815'/>
+<nmethod compile_id='133' compiler='c1' level='3' entry='0x00007f5ae963f4e0' size='1896' address='0x00007f5ae963f310' relocation_offset='368' insts_offset='464' stub_offset='1424' scopes_data_offset='1624' scopes_pcs_offset='1728' dependencies_offset='1888' metadata_offset='1568' method='java.util.HashSet &lt;init&gt; ()V' bytes='16' count='288' iicount='288' stamp='0.249'/>
+<writer thread='23757'/>
+<task_queued compile_id='136' method='java.lang.module.ModuleDescriptor$Exports source ()Ljava/lang/String;' bytes='5' count='128' iicount='128' level='1' stamp='0.249' comment='tiered' hot_count='128'/>
+<writer thread='23813'/>
+<nmethod compile_id='135' compiler='c1' level='3' entry='0x00007f5ae963fc40' size='1216' address='0x00007f5ae963fa90' relocation_offset='368' insts_offset='432' stub_offset='912' scopes_data_offset='1088' scopes_pcs_offset='1112' dependencies_offset='1192' nul_chk_table_offset='1200' metadata_offset='1080' method='java.lang.module.ModuleDescriptor$Exports isQualified ()Z' bytes='18' count='311' iicount='311' stamp='0.249'/>
+<writer thread='23757'/>
+<task_queued compile_id='137' method='java.util.Collections$EmptySet isEmpty ()Z' bytes='2' count='128' iicount='128' level='1' stamp='0.249' comment='tiered' hot_count='128'/>
+<writer thread='23814'/>
+<nmethod compile_id='136' compiler='c1' level='1' entry='0x00007f5af0a79e40' size='752' address='0x00007f5af0a79c90' relocation_offset='368' insts_offset='432' stub_offset='560' scopes_data_offset='704' scopes_pcs_offset='712' dependencies_offset='744' method='java.lang.module.ModuleDescriptor$Exports source ()Ljava/lang/String;' bytes='5' count='152' iicount='152' stamp='0.249'/>
+<nmethod compile_id='137' compiler='c1' level='1' entry='0x00007f5af0a7a140' size='752' address='0x00007f5af0a79f90' relocation_offset='368' insts_offset='432' stub_offset='560' scopes_data_offset='704' scopes_pcs_offset='712' dependencies_offset='744' method='java.util.Collections$EmptySet isEmpty ()Z' bytes='2' count='163' iicount='163' stamp='0.249'/>
+<writer thread='23757'/>
+<task_queued compile_id='138' method='java.lang.module.ResolvedModule configuration ()Ljava/lang/module/Configuration;' bytes='5' count='128' iicount='128' level='1' stamp='0.250' comment='tiered' hot_count='128'/>
+<task_queued compile_id='139' method='java.util.ArrayList access$000 (Ljava/util/ArrayList;)I' bytes='5' count='128' iicount='128' level='1' stamp='0.250' comment='tiered' hot_count='128'/>
+<task_queued compile_id='140' method='java.util.ImmutableCollections$Set2$1 next ()Ljava/lang/Object;' bytes='49' count='256' iicount='256' level='3' stamp='0.250' comment='tiered' hot_count='256'/>
+<writer thread='23816'/>
+<nmethod compile_id='134' compiler='c1' level='3' entry='0x00007f5ae9640260' size='7136' address='0x00007f5ae963ff90' relocation_offset='368' consts_offset='688' insts_offset='720' stub_offset='5872' scopes_data_offset='6048' scopes_pcs_offset='6384' dependencies_offset='6976' nul_chk_table_offset='6984' metadata_offset='6040' method='java.util.HashMap resize ()[Ljava/util/HashMap$Node;' bytes='356' count='386' backedge_count='1394' iicount='386' stamp='0.250'/>
+<nmethod compile_id='139' compiler='c1' level='1' entry='0x00007f5af0a7a440' size='768' address='0x00007f5af0a7a290' relocation_offset='368' insts_offset='432' stub_offset='528' scopes_data_offset='680' scopes_pcs_offset='696' dependencies_offset='744' nul_chk_table_offset='752' metadata_offset='672' method='java.util.ArrayList access$000 (Ljava/util/ArrayList;)I' bytes='5' count='167' iicount='167' stamp='0.250'/>
+<writer thread='23815'/>
+<nmethod compile_id='138' compiler='c1' level='1' entry='0x00007f5af0a7a7c0' size='752' address='0x00007f5af0a7a610' relocation_offset='368' insts_offset='432' stub_offset='560' scopes_data_offset='704' scopes_pcs_offset='712' dependencies_offset='744' method='java.lang.module.ResolvedModule configuration ()Ljava/lang/module/Configuration;' bytes='5' count='169' iicount='169' stamp='0.250'/>
+<writer thread='23813'/>
+<nmethod compile_id='140' compiler='c1' level='3' entry='0x00007f5ae9641d60' size='1328' address='0x00007f5ae9641b90' relocation_offset='368' insts_offset='464' stub_offset='944' scopes_data_offset='1120' scopes_pcs_offset='1168' dependencies_offset='1296' nul_chk_table_offset='1304' metadata_offset='1112' method='java.util.ImmutableCollections$Set2$1 next ()Ljava/lang/Object;' bytes='49' count='270' iicount='270' stamp='0.250'/>
+<writer thread='23757'/>
+<task_queued compile_id='141' method='java.lang.module.ModuleDescriptor$Exports targets ()Ljava/util/Set;' bytes='5' count='128' iicount='128' level='1' stamp='0.250' comment='tiered' hot_count='128'/>
+<task_queued compile_id='142' method='java.util.ImmutableCollections$SetN iterator ()Ljava/util/Iterator;' bytes='9' count='256' iicount='256' level='3' stamp='0.250' comment='tiered' hot_count='256'/>
+<task_queued compile_id='143' method='java.util.ImmutableCollections$SetN$1 &lt;init&gt; (Ljava/util/ImmutableCollections$SetN;)V' bytes='15' count='256' iicount='256' level='3' stamp='0.250' comment='tiered' hot_count='256'/>
+<task_queued compile_id='144' method='java.lang.Module findModule (Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;Ljava/util/List;)Ljava/lang/Module;' bytes='93' count='256' backedge_count='36' iicount='256' level='3' stamp='0.250' comment='tiered' hot_count='256'/>
+<writer thread='23813'/>
+<nmethod compile_id='141' compiler='c1' level='1' entry='0x00007f5af0a7aac0' size='752' address='0x00007f5af0a7a910' relocation_offset='368' insts_offset='432' stub_offset='560' scopes_data_offset='704' scopes_pcs_offset='712' dependencies_offset='744' method='java.lang.module.ModuleDescriptor$Exports targets ()Ljava/util/Set;' bytes='5' count='146' iicount='146' stamp='0.250'/>
+<writer thread='23757'/>
+<nmethod compile_id='145' compile_kind='c2n' compiler='' level='0' entry='0x00007f5af0a7ade0' size='984' address='0x00007f5af0a7ac10' relocation_offset='368' consts_offset='984' insts_offset='464' method='java.lang.Module addExports0 (Ljava/lang/Module;Ljava/lang/String;Ljava/lang/Module;)V' bytes='0' count='256' iicount='256' stamp='0.250'/>
+<writer thread='23815'/>
+<nmethod compile_id='143' compiler='c1' level='3' entry='0x00007f5ae96422c0' size='1128' address='0x00007f5ae9642110' relocation_offset='368' insts_offset='432' stub_offset='848' scopes_data_offset='1016' scopes_pcs_offset='1056' dependencies_offset='1120' metadata_offset='992' method='java.util.ImmutableCollections$SetN$1 &lt;init&gt; (Ljava/util/ImmutableCollections$SetN;)V' bytes='15' count='262' iicount='262' stamp='0.250'/>
+<writer thread='23816'/>
+<nmethod compile_id='142' compiler='c1' level='3' entry='0x00007f5ae9642740' size='1344' address='0x00007f5ae9642590' relocation_offset='368' insts_offset='432' stub_offset='1008' scopes_data_offset='1176' scopes_pcs_offset='1240' dependencies_offset='1336' metadata_offset='1152' method='java.util.ImmutableCollections$SetN iterator ()Ljava/util/Iterator;' bytes='9' count='263' iicount='263' stamp='0.250'/>
+<writer thread='23757'/>
+<task_queued compile_id='146' method='java.util.HashMap isEmpty ()Z' bytes='13' count='256' iicount='256' level='3' stamp='0.250' comment='tiered' hot_count='256'/>
+<task_queued compile_id='147' method='java.lang.module.ModuleDescriptor isOpen ()Z' bytes='5' count='128' iicount='128' level='1' stamp='0.250' comment='tiered' hot_count='128'/>
+<writer thread='23815'/>
+<nmethod compile_id='146' compiler='c1' level='3' entry='0x00007f5ae9642cc0' size='944' address='0x00007f5ae9642b10' relocation_offset='368' insts_offset='432' stub_offset='720' scopes_data_offset='872' scopes_pcs_offset='888' dependencies_offset='936' metadata_offset='864' method='java.util.HashMap isEmpty ()Z' bytes='13' count='279' iicount='279' stamp='0.251'/>
+<writer thread='23813'/>
+<nmethod compile_id='147' compiler='c1' level='1' entry='0x00007f5af0a7b1c0' size='752' address='0x00007f5af0a7b010' relocation_offset='368' insts_offset='432' stub_offset='560' scopes_data_offset='704' scopes_pcs_offset='712' dependencies_offset='744' method='java.lang.module.ModuleDescriptor isOpen ()Z' bytes='5' count='131' iicount='131' stamp='0.251'/>
+<writer thread='23757'/>
+<task_queued compile_id='148' method='java.util.Collections$UnmodifiableCollection$1 hasNext ()Z' bytes='10' count='256' iicount='256' level='3' stamp='0.251' comment='tiered' hot_count='256'/>
+<task_queued compile_id='149' method='java.util.ImmutableCollections$Set1 iterator ()Ljava/util/Iterator;' bytes='8' count='256' iicount='256' level='3' stamp='0.251' comment='tiered' hot_count='256'/>
+<task_queued compile_id='150' method='java.util.Collections singletonIterator (Ljava/lang/Object;)Ljava/util/Iterator;' bytes='9' count='256' iicount='256' level='3' stamp='0.251' comment='tiered' hot_count='256'/>
+<task_queued compile_id='151' method='java.util.Collections$1 &lt;init&gt; (Ljava/lang/Object;)V' bytes='15' count='256' iicount='256' level='3' stamp='0.251' comment='tiered' hot_count='256'/>
+<task_queued compile_id='152' method='java.util.Collections$1 next ()Ljava/lang/Object;' bytes='25' count='256' iicount='256' level='3' stamp='0.251' comment='tiered' hot_count='256'/>
+<writer thread='23816'/>
+<nmethod compile_id='148' compiler='c1' level='3' entry='0x00007f5ae96430c0' size='1120' address='0x00007f5ae9642f10' relocation_offset='368' insts_offset='432' stub_offset='816' scopes_data_offset='992' scopes_pcs_offset='1016' dependencies_offset='1096' nul_chk_table_offset='1104' metadata_offset='984' method='java.util.Collections$UnmodifiableCollection$1 hasNext ()Z' bytes='10' count='280' iicount='280' stamp='0.251'/>
+<writer thread='23814'/>
+<nmethod compile_id='144' compiler='c1' level='3' entry='0x00007f5ae96435e0' size='4456' address='0x00007f5ae9643390' relocation_offset='368' insts_offset='592' stub_offset='3504' scopes_data_offset='3768' scopes_pcs_offset='4040' dependencies_offset='4392' nul_chk_table_offset='4400' metadata_offset='3752' method='java.lang.Module findModule (Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;Ljava/util/List;)Ljava/lang/Module;' bytes='93' count='477' backedge_count='82' iicount='477' stamp='0.251'/>
+<writer thread='23813'/>
+<nmethod compile_id='150' compiler='c1' level='3' entry='0x00007f5ae96446c0' size='1312' address='0x00007f5ae9644510' relocation_offset='368' insts_offset='432' stub_offset='976' scopes_data_offset='1144' scopes_pcs_offset='1208' dependencies_offset='1304' metadata_offset='1120' method='java.util.Collections singletonIterator (Ljava/lang/Object;)Ljava/util/Iterator;' bytes='9' count='273' iicount='273' stamp='0.251'/>
+<writer thread='23757'/>
+<nmethod compile_id='153' compile_kind='c2n' compiler='' level='0' entry='0x00007f5af0a7b4e0' size='960' address='0x00007f5af0a7b310' relocation_offset='368' consts_offset='960' insts_offset='464' method='java.lang.Module addExportsToAll0 (Ljava/lang/Module;Ljava/lang/String;)V' bytes='0' count='256' iicount='256' stamp='0.251'/>
+<writer thread='23816'/>
+<nmethod compile_id='151' compiler='c1' level='3' entry='0x00007f5ae9644c40' size='1096' address='0x00007f5ae9644a90' relocation_offset='368' insts_offset='432' stub_offset='816' scopes_data_offset='984' scopes_pcs_offset='1024' dependencies_offset='1088' metadata_offset='960' method='java.util.Collections$1 &lt;init&gt; (Ljava/lang/Object;)V' bytes='15' count='273' iicount='273' stamp='0.251'/>
+<writer thread='23814'/>
+<nmethod compile_id='152' compiler='c1' level='3' entry='0x00007f5ae96450c0' size='1096' address='0x00007f5ae9644f10' relocation_offset='368' insts_offset='432' stub_offset='784' scopes_data_offset='960' scopes_pcs_offset='992' dependencies_offset='1088' metadata_offset='952' method='java.util.Collections$1 next ()Ljava/lang/Object;' bytes='25' count='276' iicount='276' stamp='0.251'/>
+<writer thread='23815'/>
+<nmethod compile_id='149' compiler='c1' level='3' entry='0x00007f5ae9645560' size='1512' address='0x00007f5ae9645390' relocation_offset='368' insts_offset='464' stub_offset='1136' scopes_data_offset='1312' scopes_pcs_offset='1392' dependencies_offset='1504' metadata_offset='1280' method='java.util.ImmutableCollections$Set1 iterator ()Ljava/util/Iterator;' bytes='8' count='278' iicount='278' stamp='0.251'/>
+<writer thread='23757'/>
+<task_queued compile_id='154' method='java.util.Collections$UnmodifiableCollection$1 next ()Ljava/lang/Object;' bytes='10' count='256' iicount='256' level='3' stamp='0.251' comment='tiered' hot_count='256'/>
+<nmethod compile_id='155' compile_kind='c2n' compiler='' level='0' entry='0x00007f5af0a7b8e0' size='960' address='0x00007f5af0a7b710' relocation_offset='368' consts_offset='960' insts_offset='464' method='java.lang.Module addReads0 (Ljava/lang/Module;Ljava/lang/Module;)V' bytes='0' count='256' iicount='256' stamp='0.251'/>
+<writer thread='23815'/>
+<nmethod compile_id='154' compiler='c1' level='3' entry='0x00007f5ae9645b40' size='1120' address='0x00007f5ae9645990' relocation_offset='368' insts_offset='432' stub_offset='816' scopes_data_offset='992' scopes_pcs_offset='1016' dependencies_offset='1096' nul_chk_table_offset='1104' metadata_offset='984' method='java.util.Collections$UnmodifiableCollection$1 next ()Ljava/lang/Object;' bytes='10' count='257' iicount='257' stamp='0.252'/>
+<writer thread='23757'/>
+<task_queued compile_id='156' method='java.util.ImmutableCollections$Set2 size ()I' bytes='2' count='128' iicount='128' level='1' stamp='0.252' comment='tiered' hot_count='128'/>
+<task_queued compile_id='157' method='java.lang.reflect.Field getName ()Ljava/lang/String;' bytes='5' count='256' iicount='256' level='1' stamp='0.252' comment='tiered' hot_count='256'/>
+<writer thread='23814'/>
+<nmethod compile_id='156' compiler='c1' level='1' entry='0x00007f5af0a7bcc0' size='752' address='0x00007f5af0a7bb10' relocation_offset='368' insts_offset='432' stub_offset='560' scopes_data_offset='704' scopes_pcs_offset='712' dependencies_offset='744' method='java.util.ImmutableCollections$Set2 size ()I' bytes='2' count='130' iicount='130' stamp='0.252'/>
+<writer thread='23757'/>
+<task_queued compile_id='158' method='jdk.internal.module.ModuleReferenceImpl moduleResolution ()Ljdk/internal/module/ModuleResolution;' bytes='5' count='128' iicount='128' level='1' stamp='0.253' comment='tiered' hot_count='128'/>
+<writer thread='23815'/>
+<nmethod compile_id='157' compiler='c1' level='1' entry='0x00007f5af0a7bfc0' size='752' address='0x00007f5af0a7be10' relocation_offset='368' insts_offset='432' stub_offset='560' scopes_data_offset='704' scopes_pcs_offset='712' dependencies_offset='744' method='java.lang.reflect.Field getName ()Ljava/lang/String;' bytes='5' count='270' iicount='270' stamp='0.253'/>
+<writer thread='23816'/>
+<nmethod compile_id='158' compiler='c1' level='1' entry='0x00007f5af0a7c2c0' size='752' address='0x00007f5af0a7c110' relocation_offset='368' insts_offset='432' stub_offset='560' scopes_data_offset='704' scopes_pcs_offset='712' dependencies_offset='744' method='jdk.internal.module.ModuleReferenceImpl moduleResolution ()Ljdk/internal/module/ModuleResolution;' bytes='5' count='148' iicount='148' stamp='0.253'/>
+<writer thread='23757'/>
+<task_queued compile_id='159' method='java.util.Map entry (Ljava/lang/Object;Ljava/lang/Object;)Ljava/util/Map$Entry;' bytes='10' count='256' iicount='256' level='3' stamp='0.253' comment='tiered' hot_count='256'/>
+<task_queued compile_id='160' method='java.util.KeyValueHolder &lt;init&gt; (Ljava/lang/Object;Ljava/lang/Object;)V' bytes='21' count='256' iicount='256' level='3' stamp='0.253' comment='tiered' hot_count='256'/>
+<task_queued compile_id='161' method='java.util.HashMap hash (Ljava/lang/Object;)I' bytes='20' count='6402' iicount='6402' stamp='0.253' comment='tiered' hot_count='6402'/>
+<writer thread='23813'/>
+<nmethod compile_id='160' compiler='c1' level='3' entry='0x00007f5ae9646000' size='2160' address='0x00007f5ae9645e10' relocation_offset='368' insts_offset='496' stub_offset='1616' scopes_data_offset='1824' scopes_pcs_offset='1960' dependencies_offset='2152' metadata_offset='1800' method='java.util.KeyValueHolder &lt;init&gt; (Ljava/lang/Object;Ljava/lang/Object;)V' bytes='21' count='280' iicount='280' stamp='0.254'/>
+<writer thread='23814'/>
+<nmethod compile_id='159' compiler='c1' level='3' entry='0x00007f5ae96468a0' size='2440' address='0x00007f5ae9646690' relocation_offset='368' insts_offset='528' stub_offset='1808' scopes_data_offset='2024' scopes_pcs_offset='2208' dependencies_offset='2432' metadata_offset='1992' method='java.util.Map entry (Ljava/lang/Object;Ljava/lang/Object;)Ljava/util/Map$Entry;' bytes='10' count='280' iicount='280' stamp='0.254'/>
+<writer thread='23757'/>
+<task_queued compile_id='162' method='java.util.Collections$EmptyIterator hasNext ()Z' bytes='2' count='128' iicount='128' level='1' stamp='0.254' comment='tiered' hot_count='128'/>
+<task_queued compile_id='163' method='jdk.internal.module.ModuleBootstrap$2 hasNext ()Z' bytes='30' count='256' iicount='256' level='3' stamp='0.254' comment='tiered' hot_count='256'/>
+<writer thread='23813'/>
+<nmethod compile_id='162' compiler='c1' level='1' entry='0x00007f5af0a7c5c0' size='752' address='0x00007f5af0a7c410' relocation_offset='368' insts_offset='432' stub_offset='560' scopes_data_offset='704' scopes_pcs_offset='712' dependencies_offset='744' method='java.util.Collections$EmptyIterator hasNext ()Z' bytes='2' count='132' iicount='132' stamp='0.254'/>
+<writer thread='23757'/>
+<task_queued compile_id='164' method='jdk.internal.module.ModuleBootstrap$2 next ()Ljava/lang/Object;' bytes='52' count='256' iicount='256' level='3' stamp='0.254' comment='tiered' hot_count='256'/>
+<task_queued compile_id='165' method='java.util.HashMap putIfAbsent (Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;' bytes='13' count='256' iicount='256' level='3' stamp='0.254' comment='tiered' hot_count='256'/>
+<nmethod compile_id='166' compile_kind='c2n' compiler='' level='0' entry='0x00007f5af0a7c8e0' size='960' address='0x00007f5af0a7c710' relocation_offset='368' consts_offset='960' insts_offset='464' method='java.lang.Module addExportsToAllUnnamed0 (Ljava/lang/Module;Ljava/lang/String;)V' bytes='0' count='256' iicount='256' stamp='0.254'/>
+<task_queued compile_id='167' method='java.lang.Module getDescriptor ()Ljava/lang/module/ModuleDescriptor;' bytes='5' count='128' iicount='128' level='1' stamp='0.254' comment='tiered' hot_count='128'/>
+<writer thread='23805'/>
+<nmethod compile_id='161' compiler='c2' level='4' entry='0x00007f5af0a7cca0' size='736' address='0x00007f5af0a7cb10' relocation_offset='368' insts_offset='400' stub_offset='560' scopes_data_offset='592' scopes_pcs_offset='624' dependencies_offset='688' handler_table_offset='696' nul_chk_table_offset='720' metadata_offset='584' method='java.util.HashMap hash (Ljava/lang/Object;)I' bytes='20' count='6692' iicount='6692' stamp='0.255'/>
+<make_not_entrant thread='23805' compile_id='65' compiler='c1' level='3' stamp='0.255'/>
+<writer thread='23757'/>
+<task_queued compile_id='168' method='java.util.ImmutableCollections$Set0 instance ()Ljava/util/ImmutableCollections$Set0;' bytes='4' count='232' iicount='232' level='3' stamp='0.255' comment='tiered' hot_count='232'/>
+<writer thread='23813'/>
+<nmethod compile_id='163' compiler='c1' level='3' entry='0x00007f5ae9647260' size='1544' address='0x00007f5ae9647090' relocation_offset='368' insts_offset='464' stub_offset='1168' scopes_data_offset='1360' scopes_pcs_offset='1400' dependencies_offset='1512' nul_chk_table_offset='1520' metadata_offset='1352' method='jdk.internal.module.ModuleBootstrap$2 hasNext ()Z' bytes='30' count='457' iicount='457' stamp='0.255'/>
+<writer thread='23815'/>
+<nmethod compile_id='164' compiler='c1' level='3' entry='0x00007f5ae9647920' size='2264' address='0x00007f5ae9647710' relocation_offset='368' insts_offset='528' stub_offset='1680' scopes_data_offset='1920' scopes_pcs_offset='1992' dependencies_offset='2216' nul_chk_table_offset='2224' metadata_offset='1912' method='jdk.internal.module.ModuleBootstrap$2 next ()Ljava/lang/Object;' bytes='52' count='460' iicount='460' stamp='0.255'/>
+<writer thread='23816'/>
+<nmethod compile_id='165' compiler='c1' level='3' entry='0x00007f5ae96481e0' size='1680' address='0x00007f5ae9648010' relocation_offset='368' insts_offset='464' stub_offset='1232' scopes_data_offset='1432' scopes_pcs_offset='1544' dependencies_offset='1656' nul_chk_table_offset='1664' metadata_offset='1416' method='java.util.HashMap putIfAbsent (Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;' bytes='13' count='492' iicount='492' stamp='0.255'/>
+<writer thread='23814'/>
+<nmethod compile_id='168' compiler='c1' level='3' entry='0x00007f5ae96488c0' size='808' address='0x00007f5ae9648710' relocation_offset='368' insts_offset='432' stub_offset='592' scopes_data_offset='744' scopes_pcs_offset='752' dependencies_offset='800' metadata_offset='736' method='java.util.ImmutableCollections$Set0 instance ()Ljava/util/ImmutableCollections$Set0;' bytes='4' count='238' iicount='238' stamp='0.255'/>
+<writer thread='23816'/>
+<nmethod compile_id='167' compiler='c1' level='1' entry='0x00007f5af0a7cfc0' size='752' address='0x00007f5af0a7ce10' relocation_offset='368' insts_offset='432' stub_offset='560' scopes_data_offset='704' scopes_pcs_offset='712' dependencies_offset='744' method='java.lang.Module getDescriptor ()Ljava/lang/module/ModuleDescriptor;' bytes='5' count='146' iicount='146' stamp='0.255'/>
+<writer thread='23757'/>
+<task_queued compile_id='169' method='java.lang.Character toLowerCase (I)I' bytes='9' count='256' iicount='256' level='3' stamp='0.258' comment='tiered' hot_count='256'/>
+<task_queued compile_id='170' method='java.lang.CharacterDataLatin1 toLowerCase (I)I' bytes='39' count='256' iicount='256' level='3' stamp='0.258' comment='tiered' hot_count='256'/>
+<writer thread='23813'/>
+<nmethod compile_id='169' compiler='c1' level='3' entry='0x00007f5ae9648c60' size='1192' address='0x00007f5ae9648a90' relocation_offset='368' insts_offset='464' stub_offset='848' scopes_data_offset='1040' scopes_pcs_offset='1072' dependencies_offset='1168' nul_chk_table_offset='1176' metadata_offset='1032' method='java.lang.Character toLowerCase (I)I' bytes='9' count='256' iicount='256' stamp='0.258'/>
+<writer thread='23815'/>
+<nmethod compile_id='170' compiler='c1' level='3' entry='0x00007f5ae9649140' size='1328' address='0x00007f5ae9648f90' relocation_offset='368' insts_offset='432' stub_offset='944' scopes_data_offset='1112' scopes_pcs_offset='1184' dependencies_offset='1296' nul_chk_table_offset='1304' metadata_offset='1088' method='java.lang.CharacterDataLatin1 toLowerCase (I)I' bytes='39' count='256' iicount='256' stamp='0.258'/>
+<writer thread='23757'/>
+<task_queued compile_id='171' method='java.util.zip.ZipUtils SH ([BI)I' bytes='21' count='256' iicount='256' level='3' stamp='0.279' comment='tiered' hot_count='256'/>
+<writer thread='23814'/>
+<nmethod compile_id='171' compiler='c1' level='3' entry='0x00007f5ae96496c0' size='1016' address='0x00007f5ae9649510' relocation_offset='368' insts_offset='432' stub_offset='688' scopes_data_offset='840' scopes_pcs_offset='872' dependencies_offset='984' nul_chk_table_offset='992' metadata_offset='832' method='java.util.zip.ZipUtils SH ([BI)I' bytes='21' count='259' iicount='259' stamp='0.280'/>
+<writer thread='23757'/>
+<task_queued compile_id='172' method='java.util.jar.Attributes$Name isValid (C)Z' bytes='32' count='256' iicount='256' level='3' stamp='0.281' comment='tiered' hot_count='256'/>
+<task_queued compile_id='173' method='java.util.jar.Attributes$Name isAlpha (C)Z' bytes='30' count='256' iicount='256' level='3' stamp='0.281' comment='tiered' hot_count='256'/>
+<writer thread='23813'/>
+<nmethod compile_id='173' compiler='c1' level='3' entry='0x00007f5ae9649b40' size='1072' address='0x00007f5ae9649990' relocation_offset='368' insts_offset='432' stub_offset='848' scopes_data_offset='1000' scopes_pcs_offset='1016' dependencies_offset='1064' metadata_offset='992' method='java.util.jar.Attributes$Name isAlpha (C)Z' bytes='30' count='368' iicount='368' stamp='0.281'/>
+<writer thread='23816'/>
+<nmethod compile_id='172' compiler='c1' level='3' entry='0x00007f5ae9649fe0' size='1784' address='0x00007f5ae9649e10' relocation_offset='368' insts_offset='464' stub_offset='1488' scopes_data_offset='1656' scopes_pcs_offset='1696' dependencies_offset='1776' metadata_offset='1632' method='java.util.jar.Attributes$Name isValid (C)Z' bytes='32' count='368' iicount='368' stamp='0.281'/>
+<writer thread='23757'/>
+<task_queued compile_id='174' method='java.lang.String &lt;init&gt; ([BB)V' bytes='15' count='284' iicount='284' level='3' stamp='0.283' comment='tiered' hot_count='284'/>
+<nmethod compile_id='175' compile_kind='c2n' compiler='' level='0' entry='0x00007f5af0a7d2a0' size='424' address='0x00007f5af0a7d110' relocation_offset='368' consts_offset='424' insts_offset='400' method='java.lang.invoke.MethodHandle linkToStatic (Ljava/lang/Object;Ljava/lang/Object;IILjava/lang/invoke/MemberName;)I' bytes='0' count='0' iicount='0' stamp='0.283'/>
+<writer thread='23815'/>
+<nmethod compile_id='174' compiler='c1' level='3' entry='0x00007f5ae964a740' size='1080' address='0x00007f5ae964a590' relocation_offset='368' insts_offset='432' stub_offset='816' scopes_data_offset='976' scopes_pcs_offset='1008' dependencies_offset='1072' metadata_offset='960' method='java.lang.String &lt;init&gt; ([BB)V' bytes='15' count='285' iicount='285' stamp='0.284'/>
+<writer thread='23757'/>
+<task_queued compile_id='176' method='sun.nio.fs.UnixPath checkNotNul (Ljava/lang/String;C)V' bytes='16' count='256' iicount='256' level='3' stamp='0.286' comment='tiered' hot_count='256'/>
+<writer thread='23814'/>
+<nmethod compile_id='176' compiler='c1' level='3' entry='0x00007f5ae964abc0' size='1104' address='0x00007f5ae964aa10' relocation_offset='368' insts_offset='432' stub_offset='784' scopes_data_offset='960' scopes_pcs_offset='1000' dependencies_offset='1096' metadata_offset='952' method='sun.nio.fs.UnixPath checkNotNul (Ljava/lang/String;C)V' bytes='16' count='266' iicount='266' stamp='0.287'/>
+<writer thread='23757'/>
+<task_queued compile_id='177' method='java.lang.System getSecurityManager ()Ljava/lang/SecurityManager;' bytes='4' count='256' iicount='256' level='3' stamp='0.307' comment='tiered' hot_count='256'/>
+<writer thread='23813'/>
+<nmethod compile_id='177' compiler='c1' level='3' entry='0x00007f5ae964b040' size='840' address='0x00007f5ae964ae90' relocation_offset='368' insts_offset='432' stub_offset='624' scopes_data_offset='776' scopes_pcs_offset='784' dependencies_offset='832' metadata_offset='768' method='java.lang.System getSecurityManager ()Ljava/lang/SecurityManager;' bytes='4' count='259' iicount='259' stamp='0.308'/>
+<writer thread='23757'/>
+<task_queued compile_id='178' method='java.lang.AbstractStringBuilder putStringAt (ILjava/lang/String;)V' bytes='29' count='256' iicount='256' level='3' stamp='0.309' comment='tiered' hot_count='256'/>
+<task_queued compile_id='179' method='java.lang.AbstractStringBuilder getCoder ()B' bytes='15' count='256' iicount='256' level='3' stamp='0.309' comment='tiered' hot_count='256'/>
+<task_queued compile_id='180' method='java.lang.String getBytes ([BIB)V' bytes='44' count='256' iicount='256' level='3' stamp='0.309' comment='tiered' hot_count='256'/>
+<writer thread='23815'/>
+<nmethod compile_id='179' compiler='c1' level='3' entry='0x00007f5ae964b3c0' size='880' address='0x00007f5ae964b210' relocation_offset='368' insts_offset='432' stub_offset='656' scopes_data_offset='808' scopes_pcs_offset='824' dependencies_offset='872' metadata_offset='800' method='java.lang.AbstractStringBuilder getCoder ()B' bytes='15' count='259' iicount='259' stamp='0.309'/>
+<writer thread='23816'/>
+<nmethod compile_id='178' compiler='c1' level='3' entry='0x00007f5ae964b760' size='1936' address='0x00007f5ae964b590' relocation_offset='368' insts_offset='464' stub_offset='1488' scopes_data_offset='1696' scopes_pcs_offset='1784' dependencies_offset='1912' nul_chk_table_offset='1920' metadata_offset='1672' method='java.lang.AbstractStringBuilder putStringAt (ILjava/lang/String;)V' bytes='29' count='259' iicount='259' stamp='0.310'/>
+<writer thread='23814'/>
+<nmethod compile_id='180' compiler='c1' level='3' entry='0x00007f5ae964bf80' size='1824' address='0x00007f5ae964bd90' relocation_offset='368' insts_offset='496' stub_offset='1328' scopes_data_offset='1536' scopes_pcs_offset='1648' dependencies_offset='1792' nul_chk_table_offset='1800' metadata_offset='1512' method='java.lang.String getBytes ([BIB)V' bytes='44' count='259' iicount='259' stamp='0.310'/>
+<writer thread='23757'/>
+<task_queued compile_id='181' method='java.lang.StringLatin1 lastIndexOf ([BII)I' bytes='40' count='128' backedge_count='1898' iicount='128' level='3' stamp='0.312' comment='tiered' hot_count='128'/>
+<writer thread='23813'/>
+<nmethod compile_id='181' compiler='c1' level='3' entry='0x00007f5ae964c6e0' size='1792' address='0x00007f5ae964c510' relocation_offset='368' insts_offset='464' stub_offset='1360' scopes_data_offset='1528' scopes_pcs_offset='1624' dependencies_offset='1768' nul_chk_table_offset='1776' metadata_offset='1504' method='java.lang.StringLatin1 lastIndexOf ([BII)I' bytes='40' count='133' backedge_count='1972' iicount='133' stamp='0.313'/>
+<writer thread='23757'/>
+<task_queued compile_id='182' method='java.lang.StringBuilder append (Ljava/lang/String;)Ljava/lang/StringBuilder;' bytes='8' count='271' iicount='271' level='3' stamp='0.316' comment='tiered' hot_count='271'/>
+<task_queued compile_id='183' method='java.lang.AbstractStringBuilder append (Ljava/lang/String;)Ljava/lang/AbstractStringBuilder;' bytes='45' count='271' iicount='271' level='3' stamp='0.316' comment='tiered' hot_count='271'/>
+<writer thread='23815'/>
+<nmethod compile_id='182' compiler='c1' level='3' entry='0x00007f5ae964ce40' size='936' address='0x00007f5ae964cc90' relocation_offset='368' insts_offset='432' stub_offset='656' scopes_data_offset='832' scopes_pcs_offset='864' dependencies_offset='928' metadata_offset='824' method='java.lang.StringBuilder append (Ljava/lang/String;)Ljava/lang/StringBuilder;' bytes='8' count='281' iicount='281' stamp='0.317'/>
+<writer thread='23816'/>
+<nmethod compile_id='183' compiler='c1' level='3' entry='0x00007f5ae964d2a0' size='3032' address='0x00007f5ae964d090' relocation_offset='368' insts_offset='528' stub_offset='2320' scopes_data_offset='2576' scopes_pcs_offset='2776' dependencies_offset='3000' nul_chk_table_offset='3008' metadata_offset='2536' method='java.lang.AbstractStringBuilder append (Ljava/lang/String;)Ljava/lang/AbstractStringBuilder;' bytes='45' count='281' iicount='281' stamp='0.317'/>
+<writer thread='23757'/>
+<task_queued compile_id='184' method='java.lang.reflect.Method getName ()Ljava/lang/String;' bytes='5' count='128' iicount='128' level='1' stamp='0.319' comment='tiered' hot_count='128'/>
+<writer thread='23814'/>
+<nmethod compile_id='184' compiler='c1' level='1' entry='0x00007f5af0a7d4c0' size='752' address='0x00007f5af0a7d310' relocation_offset='368' insts_offset='432' stub_offset='560' scopes_data_offset='704' scopes_pcs_offset='712' dependencies_offset='744' method='java.lang.reflect.Method getName ()Ljava/lang/String;' bytes='5' count='434' iicount='434' stamp='0.319'/>
+<writer thread='23757'/>
+<nmethod compile_id='185' compile_kind='c2n' compiler='' level='0' entry='0x00007f5af0a7d7a0' size='432' address='0x00007f5af0a7d610' relocation_offset='368' consts_offset='432' insts_offset='400' method='java.lang.invoke.MethodHandle linkToStatic (Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/invoke/MemberName;)Ljava/lang/Object;' bytes='0' count='0' iicount='0' stamp='0.321'/>
+<task_queued compile_id='186' method='java.util.Arrays copyOfRange ([BII)[B' bytes='63' count='283' iicount='283' level='3' stamp='0.322' comment='tiered' hot_count='283'/>
+<task_queued compile_id='187' method='java.lang.Enum ordinal ()I' bytes='5' count='128' iicount='128' level='1' stamp='0.323' comment='tiered' hot_count='128'/>
+<writer thread='23813'/>
+<nmethod compile_id='186' compiler='c1' level='3' entry='0x00007f5ae964df20' size='5184' address='0x00007f5ae964dc90' relocation_offset='368' insts_offset='656' stub_offset='3888' scopes_data_offset='4256' scopes_pcs_offset='4712' dependencies_offset='5160' nul_chk_table_offset='5168' oops_offset='4168' metadata_offset='4176' method='java.util.Arrays copyOfRange ([BII)[B' bytes='63' count='284' iicount='284' stamp='0.323'/>
+<writer thread='23757'/>
+<task_queued compile_id='188' method='java.lang.ref.Reference &lt;init&gt; (Ljava/lang/Object;Ljava/lang/ref/ReferenceQueue;)V' bytes='25' count='256' iicount='256' level='3' stamp='0.323' comment='tiered' hot_count='256'/>
+<writer thread='23815'/>
+<nmethod compile_id='187' compiler='c1' level='1' entry='0x00007f5af0a7d9c0' size='752' address='0x00007f5af0a7d810' relocation_offset='368' insts_offset='432' stub_offset='560' scopes_data_offset='704' scopes_pcs_offset='712' dependencies_offset='744' method='java.lang.Enum ordinal ()I' bytes='5' count='133' iicount='133' stamp='0.323'/>
+<writer thread='23757'/>
+<nmethod compile_id='189' compile_kind='c2n' compiler='' level='0' entry='0x00007f5af0a7dca0' size='424' address='0x00007f5af0a7db10' relocation_offset='368' consts_offset='424' insts_offset='400' method='java.lang.invoke.MethodHandle linkToStatic (IILjava/lang/invoke/MemberName;)I' bytes='0' count='0' iicount='0' stamp='0.323'/>
+<task_queued compile_id='190' method='java.lang.AbstractStringBuilder isLatin1 ()Z' bytes='19' count='277' iicount='277' level='3' stamp='0.323' comment='tiered' hot_count='277'/>
+<task_queued compile_id='191' method='java.util.concurrent.ConcurrentHashMap get (Ljava/lang/Object;)Ljava/lang/Object;' bytes='162' count='256' backedge_count='6' iicount='256' level='3' stamp='0.323' comment='tiered' hot_count='256'/>
+<writer thread='23813'/>
+<nmethod compile_id='188' compiler='c1' level='3' entry='0x00007f5ae964f2c0' size='1312' address='0x00007f5ae964f110' relocation_offset='368' insts_offset='432' stub_offset='1040' scopes_data_offset='1208' scopes_pcs_offset='1240' dependencies_offset='1304' metadata_offset='1184' method='java.lang.ref.Reference &lt;init&gt; (Ljava/lang/Object;Ljava/lang/ref/ReferenceQueue;)V' bytes='25' count='271' iicount='271' stamp='0.323'/>
+<writer thread='23815'/>
+<nmethod compile_id='190' compiler='c1' level='3' entry='0x00007f5ae964f840' size='976' address='0x00007f5ae964f690' relocation_offset='368' insts_offset='432' stub_offset='752' scopes_data_offset='904' scopes_pcs_offset='920' dependencies_offset='968' metadata_offset='896' method='java.lang.AbstractStringBuilder isLatin1 ()Z' bytes='19' count='277' iicount='277' stamp='0.324'/>
+<writer thread='23757'/>
+<task_queued compile_id='192' method='java.lang.Class getClassLoader0 ()Ljava/lang/ClassLoader;' bytes='5' count='128' iicount='128' level='1' stamp='0.324' comment='tiered' hot_count='128'/>
+<writer thread='23816'/>
+<nmethod compile_id='192' compiler='c1' level='1' entry='0x00007f5af0a7dec0' size='752' address='0x00007f5af0a7dd10' relocation_offset='368' insts_offset='432' stub_offset='560' scopes_data_offset='704' scopes_pcs_offset='712' dependencies_offset='744' method='java.lang.Class getClassLoader0 ()Ljava/lang/ClassLoader;' bytes='5' count='128' iicount='128' stamp='0.324'/>
+<writer thread='23813'/>
+<nmethod compile_id='191' compiler='c1' level='3' entry='0x00007f5ae964fce0' size='4720' address='0x00007f5ae964fa90' relocation_offset='368' insts_offset='592' stub_offset='3664' scopes_data_offset='3920' scopes_pcs_offset='4288' dependencies_offset='4656' nul_chk_table_offset='4664' oops_offset='3880' metadata_offset='3888' method='java.util.concurrent.ConcurrentHashMap get (Ljava/lang/Object;)Ljava/lang/Object;' bytes='162' count='268' backedge_count='6' iicount='268' stamp='0.324'/>
+<writer thread='23757'/>
+<nmethod compile_id='193' compile_kind='c2n' compiler='' level='0' entry='0x00007f5af0a7e1a0' size='440' address='0x00007f5af0a7e010' relocation_offset='368' consts_offset='440' insts_offset='400' method='java.lang.invoke.MethodHandle invokeBasic (Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;' bytes='0' count='0' iicount='0' stamp='0.324'/>
+<nmethod compile_id='194' compile_kind='c2n' compiler='' level='0' entry='0x00007f5af0a7e3a0' size='432' address='0x00007f5af0a7e210' relocation_offset='368' consts_offset='432' insts_offset='400' method='java.lang.invoke.MethodHandle linkToSpecial (Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/invoke/MemberName;)Ljava/lang/Object;' bytes='0' count='0' iicount='0' stamp='0.324'/>
+<nmethod compile_id='195' compile_kind='c2n' compiler='' level='0' entry='0x00007f5af0a7e5e0' size='944' address='0x00007f5af0a7e410' relocation_offset='368' consts_offset='944' insts_offset='464' method='java.lang.Class isPrimitive ()Z' bytes='0' count='256' iicount='256' stamp='0.325'/>
+<nmethod compile_id='196' compile_kind='c2n' compiler='' level='0' entry='0x00007f5af0a7e9a0' size='424' address='0x00007f5af0a7e810' relocation_offset='368' consts_offset='424' insts_offset='400' method='java.lang.invoke.MethodHandle linkToStatic (Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/invoke/MemberName;)Ljava/lang/Object;' bytes='0' count='0' iicount='0' stamp='0.327'/>
+<task_queued compile_id='197' method='java.lang.invoke.MethodType$ConcurrentWeakInternSet$WeakEntry hashCode ()I' bytes='5' count='128' iicount='128' level='1' stamp='0.327' comment='tiered' hot_count='128'/>
+<writer thread='23814'/>
+<nmethod compile_id='197' compiler='c1' level='1' entry='0x00007f5af0a7ebc0' size='752' address='0x00007f5af0a7ea10' relocation_offset='368' insts_offset='432' stub_offset='560' scopes_data_offset='704' scopes_pcs_offset='712' dependencies_offset='744' method='java.lang.invoke.MethodType$ConcurrentWeakInternSet$WeakEntry hashCode ()I' bytes='5' count='145' iicount='145' stamp='0.327'/>
+<writer thread='23757'/>
+<task_queued compile_id='198' method='java.lang.StringLatin1 newString ([BII)Ljava/lang/String;' bytes='17' count='283' iicount='283' level='3' stamp='0.328' comment='tiered' hot_count='283'/>
+<nmethod compile_id='199' compile_kind='c2n' compiler='' level='0' entry='0x00007f5af0a7eea0' size='424' address='0x00007f5af0a7ed10' relocation_offset='368' consts_offset='424' insts_offset='400' method='java.lang.invoke.MethodHandle linkToSpecial (Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/invoke/MemberName;)Ljava/lang/Object;' bytes='0' count='0' iicount='0' stamp='0.328'/>
+<nmethod compile_id='200' compile_kind='c2n' compiler='' level='0' entry='0x00007f5af0a7f0a0' size='440' address='0x00007f5af0a7ef10' relocation_offset='368' consts_offset='440' insts_offset='400' method='java.lang.invoke.MethodHandle invokeBasic (Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;' bytes='0' count='0' iicount='0' stamp='0.328'/>
+<nmethod compile_id='201' compile_kind='c2n' compiler='' level='0' entry='0x00007f5af0a7f2a0' size='424' address='0x00007f5af0a7f110' relocation_offset='368' consts_offset='424' insts_offset='400' method='java.lang.invoke.MethodHandle linkToSpecial (Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/invoke/MemberName;)Ljava/lang/Object;' bytes='0' count='0' iicount='0' stamp='0.328'/>
+<task_queued compile_id='202' method='java.lang.invoke.MethodType returnType ()Ljava/lang/Class;' bytes='5' count='128' iicount='128' level='1' stamp='0.328' comment='tiered' hot_count='128'/>
+<writer thread='23815'/>
+<nmethod compile_id='198' compiler='c1' level='3' entry='0x00007f5ae9650ee0' size='1464' address='0x00007f5ae9650d10' relocation_offset='368' insts_offset='464' stub_offset='1072' scopes_data_offset='1264' scopes_pcs_offset='1344' dependencies_offset='1456' metadata_offset='1240' method='java.lang.StringLatin1 newString ([BII)Ljava/lang/String;' bytes='17' count='287' iicount='287' stamp='0.328'/>
+<nmethod compile_id='202' compiler='c1' level='1' entry='0x00007f5af0a7f4c0' size='752' address='0x00007f5af0a7f310' relocation_offset='368' insts_offset='432' stub_offset='560' scopes_data_offset='704' scopes_pcs_offset='712' dependencies_offset='744' method='java.lang.invoke.MethodType returnType ()Ljava/lang/Class;' bytes='5' count='128' iicount='128' stamp='0.329'/>
+<writer thread='23757'/>
+<nmethod compile_id='203' compile_kind='c2n' compiler='' level='0' entry='0x00007f5af0a7f7e0' size='944' address='0x00007f5af0a7f610' relocation_offset='368' consts_offset='944' insts_offset='464' method='java.lang.Class isArray ()Z' bytes='0' count='256' iicount='256' stamp='0.329'/>
+<nmethod compile_id='204' compile_kind='c2n' compiler='' level='0' entry='0x00007f5af0a7fba0' size='424' address='0x00007f5af0a7fa10' relocation_offset='368' consts_offset='424' insts_offset='400' method='java.lang.invoke.MethodHandle linkToStatic (Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/invoke/MemberName;)Ljava/lang/Object;' bytes='0' count='0' iicount='0' stamp='0.330'/>
+<task_queued compile_id='205' method='java.lang.invoke.MethodTypeForm canonicalize (Ljava/lang/Class;I)Ljava/lang/Class;' bytes='233' count='256' iicount='256' level='3' stamp='0.330' comment='tiered' hot_count='256'/>
+<task_queued compile_id='206' method='java.lang.ref.Reference &lt;init&gt; (Ljava/lang/Object;)V' bytes='7' count='256' iicount='256' level='3' stamp='0.330' comment='tiered' hot_count='256'/>
+<writer thread='23813'/>
+<nmethod compile_id='206' compiler='c1' level='3' entry='0x00007f5ae96514e0' size='1424' address='0x00007f5ae9651310' relocation_offset='368' insts_offset='464' stub_offset='1104' scopes_data_offset='1280' scopes_pcs_offset='1336' dependencies_offset='1416' metadata_offset='1248' method='java.lang.ref.Reference &lt;init&gt; (Ljava/lang/Object;)V' bytes='7' count='256' iicount='256' stamp='0.330'/>
+<writer thread='23757'/>
+<nmethod compile_id='207' compile_kind='c2n' compiler='' level='0' entry='0x00007f5af0a7fda0' size='440' address='0x00007f5af0a7fc10' relocation_offset='368' consts_offset='440' insts_offset='400' method='java.lang.invoke.MethodHandle invokeBasic (Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;' bytes='0' count='0' iicount='0' stamp='0.331'/>
+<writer thread='23816'/>
+<nmethod compile_id='205' compiler='c1' level='3' entry='0x00007f5ae9651b80' size='4160' address='0x00007f5ae9651910' relocation_offset='368' insts_offset='624' stub_offset='3376' scopes_data_offset='3632' scopes_pcs_offset='3824' dependencies_offset='4096' nul_chk_table_offset='4104' oops_offset='3592' metadata_offset='3600' method='java.lang.invoke.MethodTypeForm canonicalize (Ljava/lang/Class;I)Ljava/lang/Class;' bytes='233' count='259' iicount='259' stamp='0.331'/>
+<writer thread='23757'/>
+<nmethod compile_id='208' compile_kind='c2n' compiler='' level='0' entry='0x00007f5af0a7ffa0' size='440' address='0x00007f5af0a7fe10' relocation_offset='368' consts_offset='440' insts_offset='400' method='java.lang.invoke.MethodHandle invokeBasic (Ljava/lang/Object;)Ljava/lang/Object;' bytes='0' count='0' iicount='0' stamp='0.334'/>
+<task_queued compile_id='209' method='java.lang.ref.ReferenceQueue poll ()Ljava/lang/ref/Reference;' bytes='28' count='256' iicount='256' level='3' stamp='0.334' comment='tiered' hot_count='256'/>
+<task_queued compile_id='210' method='java.lang.invoke.MemberName testFlags (II)Z' bytes='16' count='256' iicount='256' level='3' stamp='0.334' comment='tiered' hot_count='256'/>
+<writer thread='23814'/>
+<nmethod compile_id='209' compiler='c1' level='3' entry='0x00007f5ae9652b60' size='1584' address='0x00007f5ae9652990' relocation_offset='368' insts_offset='464' stub_offset='1200' scopes_data_offset='1376' scopes_pcs_offset='1440' dependencies_offset='1536' handler_table_offset='1544' nul_chk_table_offset='1568' metadata_offset='1368' method='java.lang.ref.ReferenceQueue poll ()Ljava/lang/ref/Reference;' bytes='28' count='263' iicount='263' stamp='0.334'/>
+<writer thread='23757'/>
+<task_queued compile_id='211' method='java.lang.String charAt (I)C' bytes='25' count='5632' iicount='5632' stamp='0.334' comment='tiered' hot_count='5632'/>
+<writer thread='23815'/>
+<nmethod compile_id='210' compiler='c1' level='3' entry='0x00007f5ae96531c0' size='944' address='0x00007f5ae9653010' relocation_offset='368' insts_offset='432' stub_offset='720' scopes_data_offset='872' scopes_pcs_offset='888' dependencies_offset='936' metadata_offset='864' method='java.lang.invoke.MemberName testFlags (II)Z' bytes='16' count='269' iicount='269' stamp='0.334'/>
+<writer thread='23757'/>
+<nmethod compile_id='212' compile_kind='c2n' compiler='' level='0' entry='0x00007f5af0a801a0' size='424' address='0x00007f5af0a80010' relocation_offset='368' consts_offset='424' insts_offset='400' method='java.lang.invoke.MethodHandle linkToStatic (Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/invoke/MemberName;)Ljava/lang/Object;' bytes='0' count='0' iicount='0' stamp='0.335'/>
+<task_queued compile_id='213' method='java.lang.invoke.MethodType checkPtype (Ljava/lang/Class;)V' bytes='19' count='256' iicount='256' level='3' stamp='0.335' comment='tiered' hot_count='256'/>
+<nmethod compile_id='214' compile_kind='c2n' compiler='' level='0' entry='0x00007f5af0a803a0' size='440' address='0x00007f5af0a80210' relocation_offset='368' consts_offset='440' insts_offset='400' method='java.lang.invoke.MethodHandle invokeBasic (Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;' bytes='0' count='0' iicount='0' stamp='0.335'/>
+<writer thread='23814'/>
+<nmethod compile_id='213' compiler='c1' level='3' entry='0x00007f5ae9653600' size='1816' address='0x00007f5ae9653410' relocation_offset='368' insts_offset='496' stub_offset='1328' scopes_data_offset='1544' scopes_pcs_offset='1632' dependencies_offset='1808' oops_offset='1512' metadata_offset='1520' method='java.lang.invoke.MethodType checkPtype (Ljava/lang/Class;)V' bytes='19' count='265' iicount='265' stamp='0.335'/>
+<writer thread='23806'/>
+<nmethod compile_id='211' compiler='c2' level='4' entry='0x00007f5af0a805a0' size='784' address='0x00007f5af0a80410' relocation_offset='368' insts_offset='400' stub_offset='592' scopes_data_offset='632' scopes_pcs_offset='680' dependencies_offset='760' nul_chk_table_offset='768' metadata_offset='616' method='java.lang.String charAt (I)C' bytes='25' count='6370' iicount='6370' stamp='0.335'/>
+<make_not_entrant thread='23806' compile_id='6' compiler='c1' level='3' stamp='0.335'/>
+<writer thread='23757'/>
+<nmethod compile_id='215' compile_kind='c2n' compiler='' level='0' entry='0x00007f5af0a80960' size='1080' address='0x00007f5af0a80790' relocation_offset='368' consts_offset='1080' insts_offset='464' method='java.lang.Object getClass ()Ljava/lang/Class;' bytes='0' count='256' iicount='256' stamp='0.336'/>
+<task_queued compile_id='216' method='java.lang.invoke.MemberName getDeclaringClass ()Ljava/lang/Class;' bytes='5' count='128' iicount='128' level='1' stamp='0.336' comment='tiered' hot_count='128'/>
+<task_queued compile_id='217' method='java.lang.invoke.MethodType hashCode ()I' bytes='53' count='256' backedge_count='830' iicount='256' level='3' stamp='0.336' comment='tiered' hot_count='256'/>
+<task_queued compile_id='218' method='java.lang.invoke.MethodType$ConcurrentWeakInternSet expungeStaleElements ()V' bytes='27' count='256' iicount='256' level='3' stamp='0.336' comment='tiered' hot_count='256'/>
+<task_queued compile_id='219' method='java.lang.StringBuilder append (C)Ljava/lang/StringBuilder;' bytes='8' count='256' iicount='256' level='3' stamp='0.336' comment='tiered' hot_count='256'/>
+<task_queued compile_id='220' method='java.lang.AbstractStringBuilder append (C)Ljava/lang/AbstractStringBuilder;' bytes='77' count='256' iicount='256' level='3' stamp='0.336' comment='tiered' hot_count='256'/>
+<task_queued compile_id='221' method='java.lang.invoke.MemberName isInvocable ()Z' bytes='7' count='256' iicount='256' level='3' stamp='0.336' comment='tiered' hot_count='256'/>
+<task_queued compile_id='222' method='java.lang.invoke.MemberName testAnyFlags (I)Z' bytes='15' count='256' iicount='256' level='3' stamp='0.336' comment='tiered' hot_count='256'/>
+<writer thread='23816'/>
+<nmethod compile_id='219' compiler='c1' level='3' entry='0x00007f5ae9653d40' size='936' address='0x00007f5ae9653b90' relocation_offset='368' insts_offset='432' stub_offset='656' scopes_data_offset='832' scopes_pcs_offset='864' dependencies_offset='928' metadata_offset='824' method='java.lang.StringBuilder append (C)Ljava/lang/StringBuilder;' bytes='8' count='257' iicount='257' stamp='0.337'/>
+<writer thread='23815'/>
+<nmethod compile_id='217' compiler='c1' level='3' entry='0x00007f5ae9654160' size='1752' address='0x00007f5ae9653f90' relocation_offset='368' insts_offset='464' stub_offset='1232' scopes_data_offset='1424' scopes_pcs_offset='1552' dependencies_offset='1712' nul_chk_table_offset='1720' metadata_offset='1416' method='java.lang.invoke.MethodType hashCode ()I' bytes='53' count='265' backedge_count='849' iicount='265' stamp='0.337'/>
+<writer thread='23814'/>
+<nmethod compile_id='221' compiler='c1' level='3' entry='0x00007f5ae9654840' size='1328' address='0x00007f5ae9654690' relocation_offset='368' insts_offset='432' stub_offset='1008' scopes_data_offset='1176' scopes_pcs_offset='1240' dependencies_offset='1320' metadata_offset='1152' method='java.lang.invoke.MemberName isInvocable ()Z' bytes='7' count='265' iicount='265' stamp='0.337'/>
+<writer thread='23813'/>
+<nmethod compile_id='218' compiler='c1' level='3' entry='0x00007f5ae9654e00' size='2392' address='0x00007f5ae9654c10' relocation_offset='368' insts_offset='496' stub_offset='1808' scopes_data_offset='2008' scopes_pcs_offset='2136' dependencies_offset='2328' handler_table_offset='2336' nul_chk_table_offset='2360' metadata_offset='1992' method='java.lang.invoke.MethodType$ConcurrentWeakInternSet expungeStaleElements ()V' bytes='27' count='265' iicount='265' stamp='0.337'/>
+<writer thread='23816'/>
+<nmethod compile_id='222' compiler='c1' level='3' entry='0x00007f5ae9655740' size='1184' address='0x00007f5ae9655590' relocation_offset='368' insts_offset='432' stub_offset='912' scopes_data_offset='1072' scopes_pcs_offset='1112' dependencies_offset='1176' metadata_offset='1056' method='java.lang.invoke.MemberName testAnyFlags (I)Z' bytes='15' count='280' iicount='280' stamp='0.337'/>
+<writer thread='23814'/>
+<nmethod compile_id='216' compiler='c1' level='1' entry='0x00007f5af0a80dc0' size='752' address='0x00007f5af0a80c10' relocation_offset='368' insts_offset='432' stub_offset='560' scopes_data_offset='704' scopes_pcs_offset='712' dependencies_offset='744' method='java.lang.invoke.MemberName getDeclaringClass ()Ljava/lang/Class;' bytes='5' count='152' iicount='152' stamp='0.337'/>
+<writer thread='23815'/>
+<nmethod compile_id='220' compiler='c1' level='3' entry='0x00007f5ae9655cc0' size='3144' address='0x00007f5ae9655a90' relocation_offset='368' insts_offset='560' stub_offset='2384' scopes_data_offset='2632' scopes_pcs_offset='2848' dependencies_offset='3104' nul_chk_table_offset='3112' metadata_offset='2584' method='java.lang.AbstractStringBuilder append (C)Ljava/lang/AbstractStringBuilder;' bytes='77' count='279' iicount='279' stamp='0.337'/>
+<writer thread='23757'/>
+<task_queued compile_id='223' method='jdk.internal.org.objectweb.asm.Item set (ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;)V' bytes='219' count='256' iicount='256' level='3' stamp='0.338' comment='tiered' hot_count='256'/>
+<task_queued compile_id='224' method='jdk.internal.org.objectweb.asm.ClassWriter get (Ljdk/internal/org/objectweb/asm/Item;)Ljdk/internal/org/objectweb/asm/Item;' bytes='49' count='256' backedge_count='3' iicount='256' level='3' stamp='0.338' comment='tiered' hot_count='256'/>
+<writer thread='23813'/>
+<nmethod compile_id='224' compiler='c1' level='3' entry='0x00007f5ae96568e0' size='1720' address='0x00007f5ae9656710' relocation_offset='368' insts_offset='464' stub_offset='1232' scopes_data_offset='1408' scopes_pcs_offset='1496' dependencies_offset='1672' nul_chk_table_offset='1680' metadata_offset='1400' method='jdk.internal.org.objectweb.asm.ClassWriter get (Ljdk/internal/org/objectweb/asm/Item;)Ljdk/internal/org/objectweb/asm/Item;' bytes='49' count='283' backedge_count='5' iicount='283' stamp='0.339'/>
+<writer thread='23816'/>
+<nmethod compile_id='223' compiler='c1' level='3' entry='0x00007f5ae9657020' size='3024' address='0x00007f5ae9656e10' relocation_offset='368' insts_offset='528' stub_offset='2256' scopes_data_offset='2512' scopes_pcs_offset='2720' dependencies_offset='2960' nul_chk_table_offset='2968' metadata_offset='2504' method='jdk.internal.org.objectweb.asm.Item set (ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;)V' bytes='219' count='291' iicount='291' stamp='0.339'/>
+<writer thread='23757'/>
+<nmethod compile_id='225' compile_kind='c2n' compiler='' level='0' entry='0x00007f5af0a810a0' size='424' address='0x00007f5af0a80f10' relocation_offset='368' consts_offset='424' insts_offset='400' method='java.lang.invoke.MethodHandle linkToStatic (ILjava/lang/invoke/MemberName;)Ljava/lang/Object;' bytes='0' count='0' iicount='0' stamp='0.339'/>
+<task_queued compile_id='226' method='java.lang.invoke.MethodType parameterType (I)Ljava/lang/Class;' bytes='7' count='256' iicount='256' level='3' stamp='0.339' comment='tiered' hot_count='256'/>
+<nmethod compile_id='227' compile_kind='c2n' compiler='' level='0' entry='0x00007f5af0a812a0' size='440' address='0x00007f5af0a81110' relocation_offset='368' consts_offset='440' insts_offset='400' method='java.lang.invoke.MethodHandle invokeBasic (I)Ljava/lang/Object;' bytes='0' count='0' iicount='0' stamp='0.339'/>
+<nmethod compile_id='228' compile_kind='c2n' compiler='' level='0' entry='0x00007f5af0a814a0' size='424' address='0x00007f5af0a81310' relocation_offset='368' consts_offset='424' insts_offset='400' method='java.lang.invoke.MethodHandle linkToSpecial (Ljava/lang/Object;ILjava/lang/invoke/MemberName;)Ljava/lang/Object;' bytes='0' count='0' iicount='0' stamp='0.340'/>
+<writer thread='23814'/>
+<nmethod compile_id='226' compiler='c1' level='3' entry='0x00007f5ae9657bc0' size='936' address='0x00007f5ae9657a10' relocation_offset='368' insts_offset='432' stub_offset='656' scopes_data_offset='808' scopes_pcs_offset='832' dependencies_offset='912' nul_chk_table_offset='920' metadata_offset='800' method='java.lang.invoke.MethodType parameterType (I)Ljava/lang/Class;' bytes='7' count='265' iicount='265' stamp='0.340'/>
+<writer thread='23757'/>
+<task_queued compile_id='229' method='java.lang.StringLatin1 replace ([BCC)Ljava/lang/String;' bytes='196' count='105' backedge_count='3072' iicount='105' level='3' stamp='0.341' comment='tiered' hot_count='105'/>
+<task_queued compile_id='230' method='java.nio.Buffer position ()I' bytes='5' count='128' iicount='128' level='1' stamp='0.342' comment='tiered' hot_count='128'/>
+<writer thread='23813'/>
+<nmethod compile_id='230' compiler='c1' level='1' entry='0x00007f5af0a816c0' size='752' address='0x00007f5af0a81510' relocation_offset='368' insts_offset='432' stub_offset='560' scopes_data_offset='704' scopes_pcs_offset='712' dependencies_offset='744' method='java.nio.Buffer position ()I' bytes='5' count='147' iicount='147' stamp='0.342'/>
+<writer thread='23815'/>
+<nmethod compile_id='229' compiler='c1' level='3' entry='0x00007f5ae9658080' size='4864' address='0x00007f5ae9657e10' relocation_offset='368' insts_offset='624' stub_offset='3600' scopes_data_offset='3824' scopes_pcs_offset='4336' dependencies_offset='4832' nul_chk_table_offset='4840' metadata_offset='3784' method='java.lang.StringLatin1 replace ([BCC)Ljava/lang/String;' bytes='196' count='105' backedge_count='3096' iicount='105' stamp='0.342'/>
+<tty_done stamp='0.344'/>
+</tty>
+<compilation_log thread='23816'>
+<start_compile_thread name='C1 CompilerThread11' thread='23816' process='23756' stamp='0.180'/>
+<task compile_id='4' method='java.lang.String coder ()B' bytes='15' count='641' iicount='643' level='3' stamp='0.188'>
+<phase name='setup' stamp='0.188'>
+<phase_done name='setup' stamp='0.188'/>
+</phase>
+<phase name='buildIR' stamp='0.188'>
+<type id='973' name='byte'/>
+<klass id='983' name='java.lang.String' flags='17'/>
+<method id='1093' holder='983' name='coder' return='973' flags='0' bytes='15' iicount='646'/>
+<parse method='1093'  stamp='0.188'>
+<phase name='parse_hir' stamp='0.188'>
+<phase_done name='parse_hir' stamp='0.189'/>
+</phase>
+<parse_done stamp='0.189'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.189'>
+<phase_done name='optimize_blocks' stamp='0.189'/>
+</phase>
+<phase name='gvn' stamp='0.189'>
+<phase_done name='gvn' stamp='0.189'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.189'>
+<phase_done name='rangeCheckElimination' stamp='0.189'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.189'>
+<phase_done name='optimize_null_checks' stamp='0.189'/>
+</phase>
+<phase_done name='buildIR' stamp='0.189'/>
+</phase>
+<phase name='emit_lir' stamp='0.189'>
+<phase name='lirGeneration' stamp='0.189'>
+<phase_done name='lirGeneration' stamp='0.189'/>
+</phase>
+<phase name='linearScan' stamp='0.189'>
+<phase_done name='linearScan' stamp='0.189'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.189'/>
+</phase>
+<phase name='codeemit' stamp='0.189'>
+<phase_done name='codeemit' stamp='0.189'/>
+</phase>
+<phase name='codeinstall' stamp='0.189'>
+<phase_done name='codeinstall' stamp='0.189'/>
+</phase>
+<code_cache total_blobs='255' nmethods='4' adapters='136' free_code_cache='248771584'/>
+<task_done success='1' nmsize='368' count='646' stamp='0.189'/>
+</task>
+<task compile_id='8' method='java.lang.String equals (Ljava/lang/Object;)Z' bytes='65' count='413' iicount='414' level='3' stamp='0.200'>
+<phase name='setup' stamp='0.200'>
+<phase_done name='setup' stamp='0.200'/>
+</phase>
+<phase name='buildIR' stamp='0.200'>
+<type id='969' name='boolean'/>
+<klass id='982' name='java.lang.Object' flags='1'/>
+<klass id='983' name='java.lang.String' flags='17'/>
+<method id='1093' holder='983' name='equals' return='969' arguments='982' flags='1' bytes='65' iicount='428'/>
+<parse method='1093'  stamp='0.200'>
+<phase name='parse_hir' stamp='0.200'>
+<bc code='182' bci='20'/>
+<type id='973' name='byte'/>
+<method id='1095' holder='983' name='coder' return='973' flags='0' bytes='15' compile_id='4' compiler='c1' level='3' iicount='849'/>
+<call method='1095' instr='invokevirtual'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1095'>
+<parse_done stamp='0.200'/>
+</parse>
+<bc code='182' bci='24'/>
+<call method='1095' instr='invokevirtual'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1095'>
+<parse_done stamp='0.200'/>
+</parse>
+<bc code='183' bci='31'/>
+<method id='1098' holder='983' name='isLatin1' return='969' flags='2' bytes='19' compile_id='5' compiler='c1' level='3' iicount='1166'/>
+<call method='1098' instr='invokespecial'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1098'>
+<parse_done stamp='0.200'/>
+</parse>
+<bc code='184' bci='45'/>
+<klass id='1085' name='[B' flags='1041'/>
+<klass id='1100' name='java.lang.StringLatin1' flags='16'/>
+<method id='1101' holder='1100' name='equals' return='969' arguments='1085 1085' flags='9' bytes='36' compile_id='3' compiler='c1' level='3' iicount='321'/>
+<call method='1101' instr='invokestatic'/>
+<inline_fail reason='callee is too large'/>
+<bc code='184' bci='59'/>
+<klass id='1103' name='java.lang.StringUTF16' flags='16'/>
+<method id='1104' holder='1103' name='equals' return='969' arguments='1085 1085' flags='9' bytes='44' iicount='1'/>
+<call method='1104' instr='invokestatic'/>
+<inline_fail reason='callee is too large'/>
+<phase_done name='parse_hir' stamp='0.201'/>
+</phase>
+<parse_done stamp='0.201'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.201'>
+<phase_done name='optimize_blocks' stamp='0.201'/>
+</phase>
+<phase name='gvn' stamp='0.201'>
+<phase_done name='gvn' stamp='0.201'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.201'>
+<phase_done name='rangeCheckElimination' stamp='0.201'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.201'>
+<phase_done name='optimize_null_checks' stamp='0.201'/>
+</phase>
+<phase_done name='buildIR' stamp='0.201'/>
+</phase>
+<phase name='emit_lir' stamp='0.201'>
+<phase name='lirGeneration' stamp='0.201'>
+<phase_done name='lirGeneration' stamp='0.201'/>
+</phase>
+<phase name='linearScan' stamp='0.201'>
+<phase_done name='linearScan' stamp='0.201'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.201'/>
+</phase>
+<phase name='codeemit' stamp='0.201'>
+<phase_done name='codeemit' stamp='0.201'/>
+</phase>
+<phase name='codeinstall' stamp='0.201'>
+<phase_done name='codeinstall' stamp='0.201'/>
+</phase>
+<code_cache total_blobs='301' nmethods='8' adapters='153' free_code_cache='248763648'/>
+<task_done success='1' nmsize='1944' count='429' inlined_bytes='49' stamp='0.201'/>
+</task>
+<task compile_id='13' method='java.util.ImmutableCollections$SetN probe (Ljava/lang/Object;)I' bytes='60' count='266' backedge_count='133' iicount='266' level='3' stamp='0.208'>
+<phase name='setup' stamp='0.208'>
+<phase_done name='setup' stamp='0.208'/>
+</phase>
+<phase name='buildIR' stamp='0.208'>
+<type id='975' name='int'/>
+<klass id='982' name='java.lang.Object' flags='1'/>
+<klass id='1093' name='java.util.ImmutableCollections$SetN' flags='24'/>
+<method id='1094' holder='1093' name='probe' return='975' arguments='982' flags='2' bytes='60' iicount='266'/>
+<parse method='1094'  stamp='0.208'>
+<phase name='parse_hir' stamp='0.208'>
+<bc code='182' bci='1'/>
+<method id='1096' holder='982' name='hashCode' return='975' flags='257' bytes='0' iicount='12'/>
+<call method='1096' instr='invokevirtual'/>
+<inline_fail reason='no static binding'/>
+<bc code='184' bci='13'/>
+<klass id='1100' name='java.lang.Math' flags='17'/>
+<method id='1101' holder='1100' name='floorMod' return='975' arguments='975 975' flags='9' bytes='10' iicount='317'/>
+<call method='1101' instr='invokestatic'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1101'>
+<bc code='184' bci='3'/>
+<method id='1103' holder='1100' name='floorDiv' return='975' arguments='975 975' flags='9' bytes='22' iicount='317'/>
+<call method='1103' instr='invokestatic'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1103'>
+<parse_done stamp='0.208'/>
+</parse>
+<parse_done stamp='0.208'/>
+</parse>
+<bc code='182' bci='35'/>
+<type id='969' name='boolean'/>
+<method id='1105' holder='982' name='equals' return='969' arguments='982' flags='1' bytes='11' iicount='1'/>
+<call method='1105' instr='invokevirtual'/>
+<inline_fail reason='no static binding'/>
+<phase_done name='parse_hir' stamp='0.208'/>
+</phase>
+<parse_done stamp='0.208'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.208'>
+<phase_done name='optimize_blocks' stamp='0.208'/>
+</phase>
+<phase name='gvn' stamp='0.208'>
+<phase_done name='gvn' stamp='0.208'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.208'>
+<phase_done name='rangeCheckElimination' stamp='0.208'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.208'>
+<phase_done name='optimize_null_checks' stamp='0.208'/>
+</phase>
+<phase_done name='buildIR' stamp='0.208'/>
+</phase>
+<phase name='emit_lir' stamp='0.208'>
+<phase name='lirGeneration' stamp='0.208'>
+<phase_done name='lirGeneration' stamp='0.208'/>
+</phase>
+<phase name='linearScan' stamp='0.208'>
+<phase_done name='linearScan' stamp='0.208'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.208'/>
+</phase>
+<phase name='codeemit' stamp='0.208'>
+<phase_done name='codeemit' stamp='0.209'/>
+</phase>
+<phase name='codeinstall' stamp='0.209'>
+<phase_done name='codeinstall' stamp='0.209'/>
+</phase>
+<code_cache total_blobs='311' nmethods='13' adapters='158' free_code_cache='248753024'/>
+<task_done success='1' nmsize='1528' count='426' backedge_count='285' inlined_bytes='32' stamp='0.209'/>
+</task>
+<task compile_id='21' method='java.util.Objects requireNonNull (Ljava/lang/Object;)Ljava/lang/Object;' bytes='14' count='257' iicount='257' level='3' stamp='0.212'>
+<phase name='setup' stamp='0.212'>
+<phase_done name='setup' stamp='0.212'/>
+</phase>
+<phase name='buildIR' stamp='0.212'>
+<klass id='982' name='java.lang.Object' flags='1'/>
+<klass id='1093' name='java.util.Objects' flags='17'/>
+<method id='1094' holder='1093' name='requireNonNull' return='982' arguments='982' flags='9' bytes='14' iicount='257'/>
+<parse method='1094'  stamp='0.212'>
+<phase name='parse_hir' stamp='0.212'>
+<bc code='183' bci='8'/>
+<type id='977' name='void'/>
+<klass id='1089' name='java.lang.NullPointerException' flags='1'/>
+<method id='1096' holder='1089' name='&lt;init&gt;' return='977' flags='1' bytes='5' iicount='1'/>
+<call method='1096' instr='invokespecial'/>
+<inline_fail reason='don&apos;t inline Throwable constructors'/>
+<phase_done name='parse_hir' stamp='0.212'/>
+</phase>
+<parse_done stamp='0.212'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.212'>
+<phase_done name='optimize_blocks' stamp='0.212'/>
+</phase>
+<phase name='gvn' stamp='0.212'>
+<phase_done name='gvn' stamp='0.212'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.212'>
+<phase_done name='rangeCheckElimination' stamp='0.212'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.212'>
+<phase_done name='optimize_null_checks' stamp='0.212'/>
+</phase>
+<phase_done name='buildIR' stamp='0.212'/>
+</phase>
+<phase name='emit_lir' stamp='0.212'>
+<phase name='lirGeneration' stamp='0.212'>
+<phase_done name='lirGeneration' stamp='0.212'/>
+</phase>
+<phase name='linearScan' stamp='0.212'>
+<phase_done name='linearScan' stamp='0.212'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.212'/>
+</phase>
+<phase name='codeemit' stamp='0.212'>
+<phase_done name='codeemit' stamp='0.213'/>
+</phase>
+<phase name='codeinstall' stamp='0.213'>
+<phase_done name='codeinstall' stamp='0.213'/>
+</phase>
+<code_cache total_blobs='319' nmethods='20' adapters='158' free_code_cache='248743040'/>
+<task_done success='1' nmsize='552' count='348' stamp='0.213'/>
+</task>
+<task compile_id='25' method='java.util.ImmutableCollections$AbstractImmutableSet &lt;init&gt; ()V' bytes='5' count='266' iicount='267' level='3' stamp='0.214'>
+<phase name='setup' stamp='0.214'>
+<phase_done name='setup' stamp='0.214'/>
+</phase>
+<phase name='buildIR' stamp='0.214'>
+<type id='977' name='void'/>
+<klass id='1093' name='java.util.ImmutableCollections$AbstractImmutableSet' flags='1032'/>
+<method id='1094' holder='1093' name='&lt;init&gt;' return='977' flags='0' bytes='5' iicount='271'/>
+<parse method='1094'  stamp='0.214'>
+<phase name='parse_hir' stamp='0.214'>
+<bc code='183' bci='1'/>
+<klass id='1096' name='java.util.AbstractSet' flags='1025'/>
+<method id='1097' holder='1096' name='&lt;init&gt;' return='977' flags='4' bytes='5' iicount='282'/>
+<call method='1097' instr='invokespecial'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1097'>
+<bc code='183' bci='1'/>
+<klass id='1099' name='java.util.AbstractCollection' flags='1025'/>
+<method id='1100' holder='1099' name='&lt;init&gt;' return='977' flags='4' bytes='5' compile_id='23' compiler='c1' level='3' iicount='335'/>
+<call method='1100' instr='invokespecial'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1100'>
+<bc code='183' bci='1'/>
+<klass id='982' name='java.lang.Object' flags='1'/>
+<method id='1102' holder='982' name='&lt;init&gt;' return='977' flags='1' bytes='1' compile_id='9' compiler='c1' level='3' iicount='1823'/>
+<call method='1102' instr='invokespecial'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1102'>
+<bc code='177' bci='0'/>
+<dependency type='no_finalizable_subclasses' ctxk='1093'/>
+<parse_done stamp='0.214'/>
+</parse>
+<parse_done stamp='0.214'/>
+</parse>
+<parse_done stamp='0.214'/>
+</parse>
+<phase_done name='parse_hir' stamp='0.214'/>
+</phase>
+<parse_done stamp='0.214'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.214'>
+<phase_done name='optimize_blocks' stamp='0.214'/>
+</phase>
+<phase name='gvn' stamp='0.214'>
+<phase_done name='gvn' stamp='0.214'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.214'>
+<phase_done name='rangeCheckElimination' stamp='0.214'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.214'>
+<phase_done name='optimize_null_checks' stamp='0.214'/>
+</phase>
+<phase_done name='buildIR' stamp='0.214'/>
+</phase>
+<phase name='emit_lir' stamp='0.214'>
+<phase name='lirGeneration' stamp='0.214'>
+<phase_done name='lirGeneration' stamp='0.214'/>
+</phase>
+<phase name='linearScan' stamp='0.214'>
+<phase_done name='linearScan' stamp='0.214'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.214'/>
+</phase>
+<phase name='codeemit' stamp='0.214'>
+<phase_done name='codeemit' stamp='0.214'/>
+</phase>
+<phase name='codeinstall' stamp='0.214'>
+<dependency type='no_finalizable_subclasses' ctxk='1093'/>
+<phase_done name='codeinstall' stamp='0.214'/>
+</phase>
+<code_cache total_blobs='323' nmethods='24' adapters='158' free_code_cache='248737792'/>
+<task_done success='1' nmsize='624' count='315' inlined_bytes='11' stamp='0.214'/>
+</task>
+<task compile_id='28' method='java.lang.module.ModuleDescriptor$1 newExports (Ljava/util/Set;Ljava/lang/String;Ljava/util/Set;)Ljava/lang/module/ModuleDescriptor$Exports;' bytes='13' count='268' iicount='268' level='3' stamp='0.215'>
+<phase name='setup' stamp='0.215'>
+<phase_done name='setup' stamp='0.215'/>
+</phase>
+<phase name='buildIR' stamp='0.215'>
+<klass id='1095' name='java.lang.module.ModuleDescriptor$Exports' flags='25'/>
+<klass id='1094' name='java.util.Set' flags='1537'/>
+<klass id='983' name='java.lang.String' flags='17'/>
+<klass id='1093' name='java.lang.module.ModuleDescriptor$1' flags='0'/>
+<method id='1096' holder='1093' name='newExports' return='1095' arguments='1094 983 1094' flags='1' bytes='13' iicount='268'/>
+<parse method='1096'  stamp='0.215'>
+<phase name='parse_hir' stamp='0.215'>
+<bc code='183' bci='9'/>
+<type id='977' name='void'/>
+<type id='969' name='boolean'/>
+<method id='1098' holder='1095' name='&lt;init&gt;' return='977' arguments='1094 983 1094 969 1093' flags='4096' bytes='10' compile_id='18' compiler='c1' level='3' iicount='519'/>
+<call method='1098' instr='invokespecial'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1098'>
+<bc code='183' bci='6'/>
+<method id='1100' holder='1095' name='&lt;init&gt;' return='977' arguments='1094 983 1094 969' flags='2' bytes='20' compile_id='19' compiler='c1' level='3' iicount='519'/>
+<call method='1100' instr='invokespecial'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1100'>
+<bc code='183' bci='1'/>
+<klass id='982' name='java.lang.Object' flags='1'/>
+<method id='1102' holder='982' name='&lt;init&gt;' return='977' flags='1' bytes='1' compile_id='9' compiler='c1' level='3' iicount='2110'/>
+<call method='1102' instr='invokespecial'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1102'>
+<parse_done stamp='0.215'/>
+</parse>
+<parse_done stamp='0.215'/>
+</parse>
+<parse_done stamp='0.215'/>
+</parse>
+<phase_done name='parse_hir' stamp='0.215'/>
+</phase>
+<parse_done stamp='0.215'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.215'>
+<phase_done name='optimize_blocks' stamp='0.215'/>
+</phase>
+<phase name='gvn' stamp='0.215'>
+<phase_done name='gvn' stamp='0.215'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.215'>
+<phase_done name='rangeCheckElimination' stamp='0.215'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.215'>
+<phase_done name='optimize_null_checks' stamp='0.215'/>
+</phase>
+<phase_done name='buildIR' stamp='0.215'/>
+</phase>
+<phase name='emit_lir' stamp='0.215'>
+<phase name='lirGeneration' stamp='0.215'>
+<phase_done name='lirGeneration' stamp='0.215'/>
+</phase>
+<phase name='linearScan' stamp='0.215'>
+<phase_done name='linearScan' stamp='0.215'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.215'/>
+</phase>
+<phase name='codeemit' stamp='0.215'>
+<phase_done name='codeemit' stamp='0.215'/>
+</phase>
+<phase name='codeinstall' stamp='0.215'>
+<phase_done name='codeinstall' stamp='0.215'/>
+</phase>
+<code_cache total_blobs='324' nmethods='25' adapters='158' free_code_cache='248735872'/>
+<task_done success='1' nmsize='1040' count='305' inlined_bytes='31' stamp='0.215'/>
+</task>
+<task compile_id='30' method='java.util.ImmutableCollections$SetN &lt;init&gt; ([Ljava/lang/Object;)V' bytes='90' count='167' backedge_count='2266' iicount='167' level='3' stamp='0.215'>
+<phase name='setup' stamp='0.215'>
+<phase_done name='setup' stamp='0.215'/>
+</phase>
+<phase name='buildIR' stamp='0.215'>
+<type id='977' name='void'/>
+<klass id='1094' name='[Ljava.lang.Object;' flags='1041'/>
+<klass id='1093' name='java.util.ImmutableCollections$SetN' flags='24'/>
+<method id='1095' holder='1093' name='&lt;init&gt;' return='977' arguments='1094' flags='128' bytes='90' iicount='167'/>
+<parse method='1095'  stamp='0.215'>
+<phase name='parse_hir' stamp='0.215'>
+<bc code='183' bci='1'/>
+<klass id='1097' name='java.util.ImmutableCollections$AbstractImmutableSet' flags='1032'/>
+<method id='1098' holder='1097' name='&lt;init&gt;' return='977' flags='0' bytes='5' compile_id='25' compiler='c1' level='3' iicount='383'/>
+<call method='1098' instr='invokespecial'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1098'>
+<bc code='183' bci='1'/>
+<klass id='1100' name='java.util.AbstractSet' flags='1025'/>
+<method id='1101' holder='1100' name='&lt;init&gt;' return='977' flags='4' bytes='5' compile_id='24' compiler='c1' level='3' iicount='384'/>
+<call method='1101' instr='invokespecial'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1101'>
+<bc code='183' bci='1'/>
+<klass id='1103' name='java.util.AbstractCollection' flags='1025'/>
+<method id='1104' holder='1103' name='&lt;init&gt;' return='977' flags='4' bytes='5' compile_id='23' compiler='c1' level='3' iicount='452'/>
+<call method='1104' instr='invokespecial'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1104'>
+<bc code='183' bci='1'/>
+<klass id='982' name='java.lang.Object' flags='1'/>
+<method id='1106' holder='982' name='&lt;init&gt;' return='977' flags='1' bytes='1' compile_id='9' compiler='c1' level='3' iicount='2202'/>
+<call method='1106' instr='invokespecial'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1106'>
+<parse_done stamp='0.215'/>
+</parse>
+<parse_done stamp='0.215'/>
+</parse>
+<parse_done stamp='0.215'/>
+</parse>
+<parse_done stamp='0.215'/>
+</parse>
+<bc code='183' bci='35'/>
+<type id='975' name='int'/>
+<method id='1108' holder='1093' name='probe' return='975' arguments='982' flags='2' bytes='60' compile_id='13' compiler='c1' level='3' iicount='2358'/>
+<call method='1108' instr='invokespecial'/>
+<inline_fail reason='callee is too large'/>
+<bc code='183' bci='53'/>
+<klass id='1050' name='java.lang.StringBuilder' flags='17'/>
+<method id='1112' holder='1050' name='&lt;init&gt;' return='977' flags='1' bytes='7' iicount='9'/>
+<call method='1112' instr='invokespecial'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1112'>
+<bc code='183' bci='3'/>
+<klass id='1048' name='java.lang.AbstractStringBuilder' flags='1024'/>
+<method id='1114' holder='1048' name='&lt;init&gt;' return='977' arguments='975' flags='0' bytes='39' iicount='9'/>
+<call method='1114' instr='invokespecial'/>
+<inline_fail reason='callee is too large'/>
+<parse_done stamp='0.216'/>
+</parse>
+<bc code='182' bci='58'/>
+<klass id='983' name='java.lang.String' flags='17'/>
+<method id='1117' holder='1050' name='append' return='1050' arguments='983' flags='1' bytes='8' iicount='15'/>
+<call method='1117' instr='invokevirtual'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1117'>
+<bc code='183' bci='2'/>
+<method id='1119' holder='1048' name='append' return='1048' arguments='983' flags='1' bytes='45' iicount='15'/>
+<call method='1119' instr='invokespecial'/>
+<inline_fail reason='callee is too large'/>
+<parse_done stamp='0.216'/>
+</parse>
+<bc code='182' bci='62'/>
+<method id='1121' holder='1050' name='append' return='1050' arguments='982' flags='1' bytes='9' iicount='1'/>
+<call method='1121' instr='invokevirtual'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1121'>
+<bc code='184' bci='2'/>
+<method id='1123' holder='983' name='valueOf' return='983' arguments='982' flags='9' bytes='14' iicount='1'/>
+<call method='1123' instr='invokestatic'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1123'>
+<bc code='182' bci='10'/>
+<method id='1126' holder='982' name='toString' return='983' flags='1' bytes='36' iicount='1'/>
+<call method='1126' instr='invokevirtual'/>
+<inline_fail reason='no static binding'/>
+<parse_done stamp='0.216'/>
+</parse>
+<bc code='182' bci='5'/>
+<call method='1117' instr='invokevirtual'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1117'>
+<bc code='183' bci='2'/>
+<call method='1119' instr='invokespecial'/>
+<inline_fail reason='callee is too large'/>
+<parse_done stamp='0.216'/>
+</parse>
+<parse_done stamp='0.216'/>
+</parse>
+<bc code='182' bci='65'/>
+<method id='1127' holder='1050' name='toString' return='983' flags='1' bytes='35' iicount='9'/>
+<call method='1127' instr='invokevirtual'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1127'>
+<bc code='182' bci='1'/>
+<type id='969' name='boolean'/>
+<method id='1129' holder='1048' name='isLatin1' return='969' flags='16' bytes='19' iicount='21'/>
+<call method='1129' instr='invokevirtual'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1129'>
+<parse_done stamp='0.216'/>
+</parse>
+<bc code='184' bci='16'/>
+<klass id='1085' name='[B' flags='1041'/>
+<klass id='1132' name='java.lang.StringLatin1' flags='16'/>
+<method id='1133' holder='1132' name='newString' return='983' arguments='1085 975 975' flags='9' bytes='17' iicount='27'/>
+<call method='1133' instr='invokestatic'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1133'>
+<bc code='184' bci='9'/>
+<klass id='1135' name='java.util.Arrays' flags='1'/>
+<method id='1136' holder='1135' name='copyOfRange' return='1085' arguments='1085 975 975' flags='9' bytes='63' iicount='27'/>
+<call method='1136' instr='invokestatic'/>
+<inline_fail reason='callee is too large'/>
+<bc code='183' bci='13'/>
+<type id='973' name='byte'/>
+<method id='1138' holder='983' name='&lt;init&gt;' return='977' arguments='1085 973' flags='0' bytes='15' iicount='28'/>
+<call method='1138' instr='invokespecial'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1138'>
+<bc code='183' bci='1'/>
+<call method='1106' instr='invokespecial'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1106'>
+<parse_done stamp='0.216'/>
+</parse>
+<parse_done stamp='0.216'/>
+</parse>
+<parse_done stamp='0.216'/>
+</parse>
+<bc code='184' bci='31'/>
+<klass id='1140' name='java.lang.StringUTF16' flags='16'/>
+<method id='1141' holder='1140' name='newString' return='983' arguments='1085 975 975' flags='9' bytes='50' iicount='1'/>
+<call method='1141' instr='invokestatic'/>
+<inline_fail reason='callee is too large'/>
+<parse_done stamp='0.216'/>
+</parse>
+<bc code='183' bci='68'/>
+<klass id='1111' name='java.lang.IllegalArgumentException' flags='1'/>
+<method id='1143' holder='1111' name='&lt;init&gt;' return='977' arguments='983' flags='1' bytes='6' iicount='1'/>
+<call method='1143' instr='invokespecial'/>
+<inline_fail reason='don&apos;t inline Throwable constructors'/>
+<phase_done name='parse_hir' stamp='0.217'/>
+</phase>
+<parse_done stamp='0.217'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.217'>
+<phase_done name='optimize_blocks' stamp='0.217'/>
+</phase>
+<phase name='gvn' stamp='0.217'>
+<phase_done name='gvn' stamp='0.217'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.217'>
+<phase_done name='rangeCheckElimination' stamp='0.217'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.217'>
+<phase_done name='optimize_null_checks' stamp='0.217'/>
+</phase>
+<phase_done name='buildIR' stamp='0.217'/>
+</phase>
+<phase name='emit_lir' stamp='0.217'>
+<phase name='lirGeneration' stamp='0.217'>
+<phase_done name='lirGeneration' stamp='0.217'/>
+</phase>
+<phase name='linearScan' stamp='0.217'>
+<phase_done name='linearScan' stamp='0.217'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.217'/>
+</phase>
+<phase name='codeemit' stamp='0.217'>
+<phase_done name='codeemit' stamp='0.217'/>
+</phase>
+<phase name='codeinstall' stamp='0.217'>
+<phase_done name='codeinstall' stamp='0.217'/>
+</phase>
+<code_cache total_blobs='338' nmethods='37' adapters='158' free_code_cache='248708736'/>
+<task_done success='1' nmsize='4696' count='219' backedge_count='3037' inlined_bytes='149' stamp='0.217'/>
+</task>
+<task compile_id='42' method='java.nio.Buffer checkIndex (I)I' bytes='22' count='274' iicount='274' level='3' stamp='0.221'>
+<phase name='setup' stamp='0.221'>
+<phase_done name='setup' stamp='0.221'/>
+</phase>
+<phase name='buildIR' stamp='0.221'>
+<type id='975' name='int'/>
+<klass id='1064' name='java.nio.Buffer' flags='1025'/>
+<method id='1093' holder='1064' name='checkIndex' return='975' arguments='975' flags='16' bytes='22' iicount='280'/>
+<parse method='1093'  stamp='0.221'>
+<phase name='parse_hir' stamp='0.221'>
+<bc code='183' bci='16'/>
+<type id='977' name='void'/>
+<klass id='1095' name='java.lang.IndexOutOfBoundsException' unloaded='1'/>
+<method id='1096' holder='1095' name='&lt;init&gt;' return='977' unloaded='1'/>
+<call method='1096' instr='invokespecial'/>
+<inline_fail reason='not inlineable'/>
+<phase_done name='parse_hir' stamp='0.221'/>
+</phase>
+<parse_done stamp='0.221'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.221'>
+<phase_done name='optimize_blocks' stamp='0.221'/>
+</phase>
+<phase name='gvn' stamp='0.221'>
+<phase_done name='gvn' stamp='0.221'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.221'>
+<phase_done name='rangeCheckElimination' stamp='0.221'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.221'>
+<phase_done name='optimize_null_checks' stamp='0.221'/>
+</phase>
+<phase_done name='buildIR' stamp='0.221'/>
+</phase>
+<phase name='emit_lir' stamp='0.221'>
+<phase name='lirGeneration' stamp='0.221'>
+<phase_done name='lirGeneration' stamp='0.221'/>
+</phase>
+<phase name='linearScan' stamp='0.221'>
+<phase_done name='linearScan' stamp='0.221'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.221'/>
+</phase>
+<phase name='codeemit' stamp='0.221'>
+<phase_done name='codeemit' stamp='0.221'/>
+</phase>
+<phase name='codeinstall' stamp='0.221'>
+<phase_done name='codeinstall' stamp='0.221'/>
+</phase>
+<code_cache total_blobs='344' nmethods='43' adapters='158' free_code_cache='248698624'/>
+<task_done success='1' nmsize='584' count='374' stamp='0.221'/>
+</task>
+<task compile_id='49' method='java.lang.StringLatin1 canEncode (I)Z' bytes='13' count='283' iicount='283' level='3' stamp='0.225'>
+<phase name='setup' stamp='0.225'>
+<phase_done name='setup' stamp='0.225'/>
+</phase>
+<phase name='buildIR' stamp='0.225'>
+<type id='969' name='boolean'/>
+<type id='975' name='int'/>
+<klass id='1093' name='java.lang.StringLatin1' flags='16'/>
+<method id='1094' holder='1093' name='canEncode' return='969' arguments='975' flags='9' bytes='13' iicount='283'/>
+<parse method='1094'  stamp='0.225'>
+<phase name='parse_hir' stamp='0.225'>
+<phase_done name='parse_hir' stamp='0.225'/>
+</phase>
+<parse_done stamp='0.225'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.225'>
+<phase_done name='optimize_blocks' stamp='0.225'/>
+</phase>
+<phase name='gvn' stamp='0.225'>
+<phase_done name='gvn' stamp='0.225'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.225'>
+<phase_done name='rangeCheckElimination' stamp='0.225'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.225'>
+<phase_done name='optimize_null_checks' stamp='0.225'/>
+</phase>
+<phase_done name='buildIR' stamp='0.225'/>
+</phase>
+<phase name='emit_lir' stamp='0.225'>
+<phase name='lirGeneration' stamp='0.225'>
+<phase_done name='lirGeneration' stamp='0.225'/>
+</phase>
+<phase name='linearScan' stamp='0.225'>
+<phase_done name='linearScan' stamp='0.225'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.225'/>
+</phase>
+<phase name='codeemit' stamp='0.225'>
+<phase_done name='codeemit' stamp='0.225'/>
+</phase>
+<phase name='codeinstall' stamp='0.225'>
+<phase_done name='codeinstall' stamp='0.225'/>
+</phase>
+<code_cache total_blobs='352' nmethods='49' adapters='160' free_code_cache='248689664'/>
+<task_done success='1' nmsize='400' count='283' stamp='0.225'/>
+</task>
+<task compile_id='54' method='java.util.concurrent.ConcurrentHashMap spread (I)I' bytes='10' count='310' iicount='310' level='3' stamp='0.230'>
+<phase name='setup' stamp='0.230'>
+<phase_done name='setup' stamp='0.230'/>
+</phase>
+<phase name='buildIR' stamp='0.230'>
+<type id='975' name='int'/>
+<klass id='1093' name='java.util.concurrent.ConcurrentHashMap' flags='1'/>
+<method id='1094' holder='1093' name='spread' return='975' arguments='975' flags='24' bytes='10' iicount='315'/>
+<parse method='1094'  stamp='0.231'>
+<phase name='parse_hir' stamp='0.231'>
+<phase_done name='parse_hir' stamp='0.231'/>
+</phase>
+<parse_done stamp='0.231'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.231'>
+<phase_done name='optimize_blocks' stamp='0.231'/>
+</phase>
+<phase name='gvn' stamp='0.231'>
+<phase_done name='gvn' stamp='0.231'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.231'>
+<phase_done name='rangeCheckElimination' stamp='0.231'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.231'>
+<phase_done name='optimize_null_checks' stamp='0.231'/>
+</phase>
+<phase_done name='buildIR' stamp='0.231'/>
+</phase>
+<phase name='emit_lir' stamp='0.231'>
+<phase name='lirGeneration' stamp='0.231'>
+<phase_done name='lirGeneration' stamp='0.231'/>
+</phase>
+<phase name='linearScan' stamp='0.231'>
+<phase_done name='linearScan' stamp='0.231'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.231'/>
+</phase>
+<phase name='codeemit' stamp='0.231'>
+<phase_done name='codeemit' stamp='0.231'/>
+</phase>
+<phase name='codeinstall' stamp='0.231'>
+<phase_done name='codeinstall' stamp='0.231'/>
+</phase>
+<code_cache total_blobs='360' nmethods='55' adapters='162' free_code_cache='248681856'/>
+<task_done success='1' nmsize='336' count='344' stamp='0.231'/>
+</task>
+<task compile_id='59' method='java.util.concurrent.ConcurrentHashMap putVal (Ljava/lang/Object;Ljava/lang/Object;Z)Ljava/lang/Object;' bytes='432' count='259' backedge_count='23' iicount='259' level='3' stamp='0.231'>
+<phase name='setup' stamp='0.231'>
+<phase_done name='setup' stamp='0.231'/>
+</phase>
+<phase name='buildIR' stamp='0.231'>
+<klass id='982' name='java.lang.Object' flags='1'/>
+<type id='969' name='boolean'/>
+<klass id='1093' name='java.util.concurrent.ConcurrentHashMap' flags='1'/>
+<method id='1094' holder='1093' name='putVal' return='982' arguments='982 982 969' flags='16' bytes='432' iicount='259'/>
+<parse method='1094'  stamp='0.231'>
+<phase name='parse_hir' stamp='0.231'>
+<bc code='182' bci='17'/>
+<type id='975' name='int'/>
+<method id='1096' holder='982' name='hashCode' return='975' flags='257' bytes='0' iicount='146'/>
+<call method='1096' instr='invokevirtual'/>
+<inline_fail reason='no static binding'/>
+<bc code='184' bci='20'/>
+<method id='1097' holder='1093' name='spread' return='975' arguments='975' flags='24' bytes='10' compile_id='54' compiler='c1' level='3' iicount='351'/>
+<call method='1097' instr='invokestatic'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1097'>
+<parse_done stamp='0.232'/>
+</parse>
+<bc code='184' bci='69'/>
+<klass id='1099' name='java.util.concurrent.ConcurrentHashMap$Node' flags='8'/>
+<klass id='1100' name='[Ljava.util.concurrent.ConcurrentHashMap$Node;' flags='1040'/>
+<method id='1101' holder='1093' name='tabAt' return='1099' arguments='1100 975' flags='24' bytes='22' compile_id='51' compiler='c1' level='3' iicount='806'/>
+<call method='1101' instr='invokestatic'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1101'>
+<bc code='182' bci='15'/>
+<type id='976' name='long'/>
+<klass id='1051' name='jdk.internal.misc.Unsafe' flags='17'/>
+<method id='1105' holder='1051' name='getObjectAcquire' return='982' arguments='982 976' flags='17' bytes='7' compile_id='52' compiler='c1' level='3' iicount='806'/>
+<call method='1105' instr='invokevirtual'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1105'>
+<bc code='182' bci='3'/>
+<method id='1107' holder='1051' name='getObjectVolatile' return='982' arguments='982 976' flags='257' bytes='0' compile_id='53' compile_kind='c2n' compiler='' level='0' iicount='640'/>
+<call method='1107' instr='invokevirtual'/>
+<inline_success reason='intrinsic'/>
+<parse_done stamp='0.232'/>
+</parse>
+<parse_done stamp='0.232'/>
+</parse>
+<bc code='183' bci='91'/>
+<type id='977' name='void'/>
+<method id='1108' holder='1099' name='&lt;init&gt;' return='977' arguments='975 982 982' flags='0' bytes='20' compile_id='57' compiler='c1' level='3' iicount='277'/>
+<call method='1108' instr='invokespecial'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1108'>
+<bc code='183' bci='1'/>
+<method id='1110' holder='982' name='&lt;init&gt;' return='977' flags='1' bytes='1' compile_id='50' compiler='c1' level='1' iicount='3684'/>
+<call method='1110' instr='invokespecial'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1110'>
+<parse_done stamp='0.232'/>
+</parse>
+<parse_done stamp='0.232'/>
+</parse>
+<bc code='184' bci='94'/>
+<method id='1112' holder='1093' name='casTabAt' return='969' arguments='1100 975 1099 1099' flags='24' bytes='21' compile_id='58' compiler='c1' level='3' iicount='274'/>
+<call method='1112' instr='invokestatic'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1112'>
+<bc code='182' bci='17'/>
+<method id='1114' holder='1051' name='compareAndSetObject' return='969' arguments='982 976 982 982' flags='273' bytes='0' compile_id='56' compile_kind='c2n' compiler='' level='0' iicount='256'/>
+<call method='1114' instr='invokevirtual'/>
+<inline_success reason='intrinsic'/>
+<parse_done stamp='0.232'/>
+</parse>
+<bc code='182' bci='120'/>
+<method id='1115' holder='1093' name='helpTransfer' return='1100' arguments='1100 1099' flags='16' bytes='130' iicount='1'/>
+<call method='1115' instr='invokevirtual'/>
+<dependency type='leaf_type' ctxk='1093'/>
+<inline_fail reason='callee is too large'/>
+<bc code='182' bci='159'/>
+<method id='1117' holder='982' name='equals' return='969' arguments='982' flags='1' bytes='11' iicount='1'/>
+<call method='1117' instr='invokevirtual'/>
+<inline_fail reason='no static binding'/>
+<bc code='184' bci='192'/>
+<call method='1101' instr='invokestatic'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1101'>
+<bc code='182' bci='15'/>
+<call method='1105' instr='invokevirtual'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1105'>
+<bc code='182' bci='3'/>
+<call method='1107' instr='invokevirtual'/>
+<inline_success reason='intrinsic'/>
+<parse_done stamp='0.232'/>
+</parse>
+<parse_done stamp='0.232'/>
+</parse>
+<bc code='182' bci='242'/>
+<call method='1117' instr='invokevirtual'/>
+<inline_fail reason='no static binding'/>
+<bc code='183' bci='293'/>
+<call method='1108' instr='invokespecial'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1108'>
+<bc code='183' bci='1'/>
+<call method='1110' instr='invokespecial'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1110'>
+<parse_done stamp='0.232'/>
+</parse>
+<parse_done stamp='0.232'/>
+</parse>
+<bc code='182' bci='331'/>
+<klass id='1119' name='java.util.concurrent.ConcurrentHashMap$TreeNode' unloaded='1'/>
+<klass id='1118' name='java.util.concurrent.ConcurrentHashMap$TreeBin' unloaded='1'/>
+<method id='1120' holder='1118' name='putTreeVal' return='1119' arguments='975 982 982' unloaded='1'/>
+<call method='1120' instr='invokevirtual'/>
+<inline_fail reason='not inlineable'/>
+<bc code='183' bci='374'/>
+<klass id='983' name='java.lang.String' flags='17'/>
+<klass id='1122' name='java.lang.IllegalStateException' unloaded='1'/>
+<method id='1124' holder='1122' name='&lt;init&gt;' return='977' arguments='983' unloaded='1'/>
+<call method='1124' instr='invokespecial'/>
+<inline_fail reason='not inlineable'/>
+<bc code='183' bci='409'/>
+<method id='1125' holder='1093' name='treeifyBin' return='977' arguments='1100 975' flags='18' bytes='164' iicount='1'/>
+<call method='1125' instr='invokespecial'/>
+<dependency type='leaf_type' ctxk='1093'/>
+<inline_fail reason='callee is too large'/>
+<bc code='183' bci='427'/>
+<method id='1127' holder='1093' name='addCount' return='977' arguments='976 975' flags='18' bytes='289' iicount='259'/>
+<call method='1127' instr='invokespecial'/>
+<dependency type='leaf_type' ctxk='1093'/>
+<inline_fail reason='callee is too large'/>
+<bc code='183' bci='49'/>
+<method id='1129' holder='1093' name='initTable' return='1100' flags='18' bytes='112' iicount='5'/>
+<call method='1129' instr='invokespecial'/>
+<dependency type='leaf_type' ctxk='1093'/>
+<inline_fail reason='callee is too large'/>
+<bc code='183' bci='12'/>
+<klass id='1089' name='java.lang.NullPointerException' flags='1'/>
+<method id='1131' holder='1089' name='&lt;init&gt;' return='977' flags='1' bytes='5' iicount='1'/>
+<call method='1131' instr='invokespecial'/>
+<inline_fail reason='don&apos;t inline Throwable constructors'/>
+<phase_done name='parse_hir' stamp='0.233'/>
+</phase>
+<parse_done stamp='0.233'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.233'>
+<phase_done name='optimize_blocks' stamp='0.233'/>
+</phase>
+<phase name='gvn' stamp='0.233'>
+<phase_done name='gvn' stamp='0.233'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.233'>
+<phase_done name='rangeCheckElimination' stamp='0.233'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.233'>
+<phase_done name='optimize_null_checks' stamp='0.233'/>
+</phase>
+<phase_done name='buildIR' stamp='0.233'/>
+</phase>
+<phase name='emit_lir' stamp='0.233'>
+<phase name='lirGeneration' stamp='0.233'>
+<phase_done name='lirGeneration' stamp='0.233'/>
+</phase>
+<phase name='linearScan' stamp='0.233'>
+<phase_done name='linearScan' stamp='0.234'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.234'/>
+</phase>
+<phase name='codeemit' stamp='0.234'>
+<phase_done name='codeemit' stamp='0.235'/>
+</phase>
+<phase name='codeinstall' stamp='0.235'>
+<dependency type='leaf_type' ctxk='1093'/>
+<phase_done name='codeinstall' stamp='0.235'/>
+</phase>
+<code_cache total_blobs='369' nmethods='64' adapters='162' free_code_cache='248657408'/>
+<task_done success='1' nmsize='8984' count='259' backedge_count='23' inlined_bytes='131' stamp='0.235'/>
+</task>
+<task compile_id='65' method='java.util.HashMap hash (Ljava/lang/Object;)I' bytes='20' count='256' iicount='256' level='3' stamp='0.235'>
+<phase name='setup' stamp='0.235'>
+<phase_done name='setup' stamp='0.235'/>
+</phase>
+<phase name='buildIR' stamp='0.235'>
+<type id='975' name='int'/>
+<klass id='982' name='java.lang.Object' flags='1'/>
+<klass id='1093' name='java.util.HashMap' flags='1'/>
+<method id='1094' holder='1093' name='hash' return='975' arguments='982' flags='24' bytes='20' iicount='256'/>
+<parse method='1094'  stamp='0.235'>
+<phase name='parse_hir' stamp='0.235'>
+<bc code='182' bci='9'/>
+<method id='1096' holder='982' name='hashCode' return='975' flags='257' bytes='0' iicount='146'/>
+<call method='1096' instr='invokevirtual'/>
+<inline_fail reason='no static binding'/>
+<phase_done name='parse_hir' stamp='0.235'/>
+</phase>
+<parse_done stamp='0.235'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.235'>
+<phase_done name='optimize_blocks' stamp='0.235'/>
+</phase>
+<phase name='gvn' stamp='0.235'>
+<phase_done name='gvn' stamp='0.235'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.235'>
+<phase_done name='rangeCheckElimination' stamp='0.235'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.235'>
+<phase_done name='optimize_null_checks' stamp='0.235'/>
+</phase>
+<phase_done name='buildIR' stamp='0.235'/>
+</phase>
+<phase name='emit_lir' stamp='0.235'>
+<phase name='lirGeneration' stamp='0.235'>
+<phase_done name='lirGeneration' stamp='0.235'/>
+</phase>
+<phase name='linearScan' stamp='0.235'>
+<phase_done name='linearScan' stamp='0.235'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.235'/>
+</phase>
+<phase name='codeemit' stamp='0.235'>
+<phase_done name='codeemit' stamp='0.235'/>
+</phase>
+<phase name='codeinstall' stamp='0.235'>
+<phase_done name='codeinstall' stamp='0.235'/>
+</phase>
+<code_cache total_blobs='370' nmethods='65' adapters='162' free_code_cache='248656128'/>
+<task_done success='1' nmsize='584' count='299' stamp='0.235'/>
+</task>
+<task compile_id='69' method='java.util.HashMap getNode (ILjava/lang/Object;)Ljava/util/HashMap$Node;' bytes='148' count='259' backedge_count='14' iicount='259' level='3' stamp='0.236'>
+<phase name='setup' stamp='0.236'>
+<phase_done name='setup' stamp='0.236'/>
+</phase>
+<phase name='buildIR' stamp='0.236'>
+<klass id='1094' name='java.util.HashMap$Node' flags='8'/>
+<type id='975' name='int'/>
+<klass id='982' name='java.lang.Object' flags='1'/>
+<klass id='1093' name='java.util.HashMap' flags='1'/>
+<method id='1095' holder='1093' name='getNode' return='1094' arguments='975 982' flags='16' bytes='148' iicount='264'/>
+<parse method='1095'  stamp='0.236'>
+<phase name='parse_hir' stamp='0.236'>
+<bc code='182' bci='59'/>
+<type id='969' name='boolean'/>
+<method id='1098' holder='982' name='equals' return='969' arguments='982' flags='1' bytes='11' iicount='1'/>
+<call method='1098' instr='invokevirtual'/>
+<inline_fail reason='no static binding'/>
+<bc code='182' bci='94'/>
+<klass id='1099' name='java.util.HashMap$TreeNode' flags='24'/>
+<method id='1100' holder='1099' name='getTreeNode' return='1099' arguments='975 982' flags='16' bytes='22' iicount='1'/>
+<call method='1100' instr='invokevirtual'/>
+<inline_fail reason='not inlineable'/>
+<bc code='182' bci='126'/>
+<call method='1098' instr='invokevirtual'/>
+<inline_fail reason='no static binding'/>
+<phase_done name='parse_hir' stamp='0.236'/>
+</phase>
+<parse_done stamp='0.236'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.236'>
+<phase_done name='optimize_blocks' stamp='0.236'/>
+</phase>
+<phase name='gvn' stamp='0.236'>
+<phase_done name='gvn' stamp='0.236'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.236'>
+<phase_done name='rangeCheckElimination' stamp='0.236'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.236'>
+<phase_done name='optimize_null_checks' stamp='0.236'/>
+</phase>
+<phase_done name='buildIR' stamp='0.236'/>
+</phase>
+<phase name='emit_lir' stamp='0.236'>
+<phase name='lirGeneration' stamp='0.236'>
+<phase_done name='lirGeneration' stamp='0.236'/>
+</phase>
+<phase name='linearScan' stamp='0.236'>
+<phase_done name='linearScan' stamp='0.237'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.237'/>
+</phase>
+<phase name='codeemit' stamp='0.237'>
+<phase_done name='codeemit' stamp='0.237'/>
+</phase>
+<phase name='codeinstall' stamp='0.237'>
+<phase_done name='codeinstall' stamp='0.237'/>
+</phase>
+<code_cache total_blobs='375' nmethods='70' adapters='162' free_code_cache='248646656'/>
+<task_done success='1' nmsize='2472' count='363' backedge_count='14' stamp='0.237'/>
+</task>
+<task compile_id='75' method='java.util.HashMap newNode (ILjava/lang/Object;Ljava/lang/Object;Ljava/util/HashMap$Node;)Ljava/util/HashMap$Node;' bytes='13' count='361' iicount='361' level='3' stamp='0.237'>
+<phase name='setup' stamp='0.237'>
+<phase_done name='setup' stamp='0.237'/>
+</phase>
+<phase name='buildIR' stamp='0.237'>
+<klass id='1094' name='java.util.HashMap$Node' flags='8'/>
+<type id='975' name='int'/>
+<klass id='982' name='java.lang.Object' flags='1'/>
+<klass id='1093' name='java.util.HashMap' flags='1'/>
+<method id='1095' holder='1093' name='newNode' return='1094' arguments='975 982 982 1094' flags='0' bytes='13' iicount='361'/>
+<parse method='1095'  stamp='0.237'>
+<phase name='parse_hir' stamp='0.237'>
+<bc code='183' bci='9'/>
+<type id='977' name='void'/>
+<method id='1097' holder='1094' name='&lt;init&gt;' return='977' arguments='975 982 982 1094' flags='0' bytes='26' iicount='367'/>
+<call method='1097' instr='invokespecial'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1097'>
+<bc code='183' bci='1'/>
+<method id='1099' holder='982' name='&lt;init&gt;' return='977' flags='1' bytes='1' compile_id='50' compiler='c1' level='1' iicount='3743'/>
+<call method='1099' instr='invokespecial'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1099'>
+<parse_done stamp='0.237'/>
+</parse>
+<parse_done stamp='0.237'/>
+</parse>
+<phase_done name='parse_hir' stamp='0.237'/>
+</phase>
+<parse_done stamp='0.237'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.237'>
+<phase_done name='optimize_blocks' stamp='0.237'/>
+</phase>
+<phase name='gvn' stamp='0.237'>
+<phase_done name='gvn' stamp='0.237'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.237'>
+<phase_done name='rangeCheckElimination' stamp='0.237'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.237'>
+<phase_done name='optimize_null_checks' stamp='0.237'/>
+</phase>
+<phase_done name='buildIR' stamp='0.237'/>
+</phase>
+<phase name='emit_lir' stamp='0.237'>
+<phase name='lirGeneration' stamp='0.237'>
+<phase_done name='lirGeneration' stamp='0.237'/>
+</phase>
+<phase name='linearScan' stamp='0.237'>
+<phase_done name='linearScan' stamp='0.237'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.237'/>
+</phase>
+<phase name='codeemit' stamp='0.237'>
+<phase_done name='codeemit' stamp='0.237'/>
+</phase>
+<phase name='codeinstall' stamp='0.237'>
+<phase_done name='codeinstall' stamp='0.237'/>
+</phase>
+<code_cache total_blobs='380' nmethods='75' adapters='162' free_code_cache='248640128'/>
+<task_done success='1' nmsize='944' count='378' inlined_bytes='27' stamp='0.237'/>
+</task>
+<task compile_id='85' method='java.util.Optional &lt;init&gt; (Ljava/lang/Object;)V' bytes='13' count='261' iicount='261' level='3' stamp='0.239'>
+<phase name='setup' stamp='0.239'>
+<phase_done name='setup' stamp='0.239'/>
+</phase>
+<phase name='buildIR' stamp='0.239'>
+<type id='977' name='void'/>
+<klass id='982' name='java.lang.Object' flags='1'/>
+<klass id='1093' name='java.util.Optional' flags='17'/>
+<method id='1094' holder='1093' name='&lt;init&gt;' return='977' arguments='982' flags='2' bytes='13' iicount='264'/>
+<parse method='1094'  stamp='0.239'>
+<phase name='parse_hir' stamp='0.239'>
+<bc code='183' bci='1'/>
+<method id='1096' holder='982' name='&lt;init&gt;' return='977' flags='1' bytes='1' compile_id='50' compiler='c1' level='1' iicount='3882'/>
+<call method='1096' instr='invokespecial'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1096'>
+<parse_done stamp='0.239'/>
+</parse>
+<bc code='184' bci='6'/>
+<klass id='1098' name='java.util.Objects' flags='17'/>
+<method id='1099' holder='1098' name='requireNonNull' return='982' arguments='982' flags='9' bytes='14' compile_id='21' compiler='c1' level='3' iicount='1946'/>
+<call method='1099' instr='invokestatic'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1099'>
+<bc code='183' bci='8'/>
+<klass id='1089' name='java.lang.NullPointerException' flags='1'/>
+<method id='1101' holder='1089' name='&lt;init&gt;' return='977' flags='1' bytes='5' iicount='1'/>
+<call method='1101' instr='invokespecial'/>
+<inline_fail reason='don&apos;t inline Throwable constructors'/>
+<parse_done stamp='0.239'/>
+</parse>
+<phase_done name='parse_hir' stamp='0.239'/>
+</phase>
+<parse_done stamp='0.239'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.239'>
+<phase_done name='optimize_blocks' stamp='0.239'/>
+</phase>
+<phase name='gvn' stamp='0.239'>
+<phase_done name='gvn' stamp='0.239'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.239'>
+<phase_done name='rangeCheckElimination' stamp='0.239'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.239'>
+<phase_done name='optimize_null_checks' stamp='0.239'/>
+</phase>
+<phase_done name='buildIR' stamp='0.239'/>
+</phase>
+<phase name='emit_lir' stamp='0.239'>
+<phase name='lirGeneration' stamp='0.239'>
+<phase_done name='lirGeneration' stamp='0.239'/>
+</phase>
+<phase name='linearScan' stamp='0.239'>
+<phase_done name='linearScan' stamp='0.239'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.239'/>
+</phase>
+<phase name='codeemit' stamp='0.239'>
+<phase_done name='codeemit' stamp='0.239'/>
+</phase>
+<phase name='codeinstall' stamp='0.239'>
+<phase_done name='codeinstall' stamp='0.239'/>
+</phase>
+<code_cache total_blobs='387' nmethods='82' adapters='162' free_code_cache='248626688'/>
+<task_done success='1' nmsize='872' count='277' inlined_bytes='15' stamp='0.239'/>
+</task>
+<task compile_id='89' method='java.lang.module.Resolver findWithBeforeFinder (Ljava/lang/String;)Ljava/lang/module/ModuleReference;' bytes='18' count='271' iicount='271' level='3' stamp='0.239'>
+<phase name='setup' stamp='0.240'>
+<phase_done name='setup' stamp='0.240'/>
+</phase>
+<phase name='buildIR' stamp='0.240'>
+<klass id='1094' name='java.lang.module.ModuleReference' flags='1025'/>
+<klass id='983' name='java.lang.String' flags='17'/>
+<klass id='1093' name='java.lang.module.Resolver' flags='16'/>
+<method id='1095' holder='1093' name='findWithBeforeFinder' return='1094' arguments='983' flags='2' bytes='18' iicount='271'/>
+<parse method='1095'  stamp='0.240'>
+<phase name='parse_hir' stamp='0.240'>
+<bc code='185' bci='5'/>
+<klass id='1098' name='java.util.Optional' flags='17'/>
+<klass id='1097' name='java.lang.module.ModuleFinder' flags='1537'/>
+<method id='1099' holder='1097' name='find' return='1098' arguments='983' flags='1025' bytes='0' iicount='1'/>
+<call method='1099' instr='invokeinterface'/>
+<inline_fail reason='no static binding'/>
+<bc code='182' bci='11'/>
+<klass id='982' name='java.lang.Object' flags='1'/>
+<method id='1100' holder='1098' name='orElse' return='982' arguments='982' flags='1' bytes='16' iicount='274'/>
+<call method='1100' instr='invokevirtual'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1100'>
+<parse_done stamp='0.240'/>
+</parse>
+<phase_done name='parse_hir' stamp='0.240'/>
+</phase>
+<parse_done stamp='0.240'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.240'>
+<phase_done name='optimize_blocks' stamp='0.240'/>
+</phase>
+<phase name='gvn' stamp='0.240'>
+<phase_done name='gvn' stamp='0.240'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.240'>
+<phase_done name='rangeCheckElimination' stamp='0.240'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.240'>
+<phase_done name='optimize_null_checks' stamp='0.240'/>
+</phase>
+<phase_done name='buildIR' stamp='0.240'/>
+</phase>
+<phase name='emit_lir' stamp='0.240'>
+<phase name='lirGeneration' stamp='0.240'>
+<phase_done name='lirGeneration' stamp='0.240'/>
+</phase>
+<phase name='linearScan' stamp='0.240'>
+<phase_done name='linearScan' stamp='0.240'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.240'/>
+</phase>
+<phase name='codeemit' stamp='0.240'>
+<phase_done name='codeemit' stamp='0.240'/>
+</phase>
+<phase name='codeinstall' stamp='0.240'>
+<phase_done name='codeinstall' stamp='0.240'/>
+</phase>
+<code_cache total_blobs='393' nmethods='88' adapters='162' free_code_cache='248617472'/>
+<task_done success='1' nmsize='1096' count='271' inlined_bytes='16' stamp='0.240'/>
+</task>
+<task compile_id='95' method='jdk.internal.module.ModuleReferenceImpl hashCode ()I' bytes='56' count='435' iicount='435' level='3' stamp='0.240'>
+<phase name='setup' stamp='0.240'>
+<phase_done name='setup' stamp='0.240'/>
+</phase>
+<phase name='buildIR' stamp='0.240'>
+<type id='975' name='int'/>
+<klass id='1093' name='jdk.internal.module.ModuleReferenceImpl' flags='1'/>
+<method id='1094' holder='1093' name='hashCode' return='975' flags='1' bytes='56' iicount='439'/>
+<parse method='1094'  stamp='0.240'>
+<phase name='parse_hir' stamp='0.240'>
+<bc code='182' bci='10'/>
+<klass id='1097' name='java.lang.module.ModuleDescriptor' flags='1'/>
+<klass id='1096' name='java.lang.module.ModuleReference' flags='1025'/>
+<method id='1098' holder='1096' name='descriptor' return='1097' flags='17' bytes='5' compile_id='46' compiler='c1' level='1' iicount='243'/>
+<call method='1098' instr='invokevirtual'/>
+<dependency type='leaf_type' ctxk='1093'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1098'>
+<parse_done stamp='0.240'/>
+</parse>
+<bc code='182' bci='13'/>
+<method id='1100' holder='1097' name='hashCode' return='975' flags='1' bytes='170' iicount='238'/>
+<call method='1100' instr='invokevirtual'/>
+<dependency type='leaf_type' ctxk='1097'/>
+<inline_fail reason='callee is too large'/>
+<dependency type='leaf_type' ctxk='1097'/>
+<bc code='184' bci='25'/>
+<klass id='982' name='java.lang.Object' flags='1'/>
+<klass id='1103' name='java.util.Objects' flags='17'/>
+<method id='1104' holder='1103' name='hashCode' return='975' arguments='982' flags='9' bytes='13' iicount='198'/>
+<call method='1104' instr='invokestatic'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1104'>
+<bc code='182' bci='5'/>
+<method id='1106' holder='982' name='hashCode' return='975' flags='257' bytes='0' compile_id='93' compile_kind='c2n' compiler='' level='0' iicount='256'/>
+<call method='1106' instr='invokevirtual'/>
+<inline_fail reason='callee is too large'/>
+<parse_done stamp='0.240'/>
+</parse>
+<bc code='184' bci='38'/>
+<call method='1104' instr='invokestatic'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1104'>
+<bc code='182' bci='5'/>
+<call method='1106' instr='invokevirtual'/>
+<inline_fail reason='native method'/>
+<parse_done stamp='0.240'/>
+</parse>
+<phase_done name='parse_hir' stamp='0.240'/>
+</phase>
+<parse_done stamp='0.240'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.240'>
+<phase_done name='optimize_blocks' stamp='0.240'/>
+</phase>
+<phase name='gvn' stamp='0.240'>
+<phase_done name='gvn' stamp='0.240'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.240'>
+<phase_done name='rangeCheckElimination' stamp='0.240'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.240'>
+<phase_done name='optimize_null_checks' stamp='0.240'/>
+</phase>
+<phase_done name='buildIR' stamp='0.240'/>
+</phase>
+<phase name='emit_lir' stamp='0.240'>
+<phase name='lirGeneration' stamp='0.240'>
+<phase_done name='lirGeneration' stamp='0.240'/>
+</phase>
+<phase name='linearScan' stamp='0.240'>
+<phase_done name='linearScan' stamp='0.240'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.240'/>
+</phase>
+<phase name='codeemit' stamp='0.240'>
+<phase_done name='codeemit' stamp='0.240'/>
+</phase>
+<phase name='codeinstall' stamp='0.240'>
+<dependency type='leaf_type' ctxk='1093'/>
+<dependency type='leaf_type' ctxk='1097'/>
+<phase_done name='codeinstall' stamp='0.241'/>
+</phase>
+<code_cache total_blobs='398' nmethods='93' adapters='162' free_code_cache='248605312'/>
+<task_done success='1' nmsize='1384' count='633' inlined_bytes='31' stamp='0.241'/>
+</task>
+<task compile_id='98' method='java.lang.module.ModuleDescriptor isAutomatic ()Z' bytes='5' count='154' iicount='154' level='1' stamp='0.241'>
+<phase name='setup' stamp='0.241'>
+<phase_done name='setup' stamp='0.241'/>
+</phase>
+<phase name='buildIR' stamp='0.241'>
+<type id='969' name='boolean'/>
+<klass id='1093' name='java.lang.module.ModuleDescriptor' flags='1'/>
+<method id='1094' holder='1093' name='isAutomatic' return='969' flags='1' bytes='5' iicount='154'/>
+<parse method='1094'  stamp='0.241'>
+<phase name='parse_hir' stamp='0.241'>
+<phase_done name='parse_hir' stamp='0.241'/>
+</phase>
+<parse_done stamp='0.241'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.241'>
+<phase_done name='optimize_blocks' stamp='0.241'/>
+</phase>
+<phase name='gvn' stamp='0.241'>
+<phase_done name='gvn' stamp='0.241'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.241'>
+<phase_done name='rangeCheckElimination' stamp='0.241'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.241'>
+<phase_done name='optimize_null_checks' stamp='0.241'/>
+</phase>
+<phase_done name='buildIR' stamp='0.241'/>
+</phase>
+<phase name='emit_lir' stamp='0.241'>
+<phase name='lirGeneration' stamp='0.241'>
+<phase_done name='lirGeneration' stamp='0.241'/>
+</phase>
+<phase name='linearScan' stamp='0.241'>
+<phase_done name='linearScan' stamp='0.241'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.241'/>
+</phase>
+<phase name='codeemit' stamp='0.241'>
+<phase_done name='codeemit' stamp='0.241'/>
+</phase>
+<phase name='codeinstall' stamp='0.241'>
+<phase_done name='codeinstall' stamp='0.241'/>
+</phase>
+<code_cache total_blobs='401' nmethods='96' adapters='162' free_code_cache='248602240'/>
+<task_done success='1' nmsize='272' count='154' stamp='0.241'/>
+</task>
+<task compile_id='90' method='java.util.ImmutableCollections$Set0 size ()I' bytes='2' count='130' iicount='130' level='1' stamp='0.241'>
+<phase name='setup' stamp='0.241'>
+<phase_done name='setup' stamp='0.241'/>
+</phase>
+<phase name='buildIR' stamp='0.241'>
+<type id='975' name='int'/>
+<klass id='1093' name='java.util.ImmutableCollections$Set0' flags='24'/>
+<method id='1094' holder='1093' name='size' return='975' flags='1' bytes='2' iicount='130'/>
+<parse method='1094'  stamp='0.241'>
+<phase name='parse_hir' stamp='0.241'>
+<phase_done name='parse_hir' stamp='0.241'/>
+</phase>
+<parse_done stamp='0.241'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.241'>
+<phase_done name='optimize_blocks' stamp='0.241'/>
+</phase>
+<phase name='gvn' stamp='0.241'>
+<phase_done name='gvn' stamp='0.241'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.241'>
+<phase_done name='rangeCheckElimination' stamp='0.241'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.241'>
+<phase_done name='optimize_null_checks' stamp='0.241'/>
+</phase>
+<phase_done name='buildIR' stamp='0.241'/>
+</phase>
+<phase name='emit_lir' stamp='0.241'>
+<phase name='lirGeneration' stamp='0.241'>
+<phase_done name='lirGeneration' stamp='0.241'/>
+</phase>
+<phase name='linearScan' stamp='0.241'>
+<phase_done name='linearScan' stamp='0.241'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.241'/>
+</phase>
+<phase name='codeemit' stamp='0.241'>
+<phase_done name='codeemit' stamp='0.241'/>
+</phase>
+<phase name='codeinstall' stamp='0.241'>
+<phase_done name='codeinstall' stamp='0.241'/>
+</phase>
+<code_cache total_blobs='402' nmethods='97' adapters='162' free_code_cache='248601472'/>
+<task_done success='1' nmsize='272' count='130' stamp='0.241'/>
+</task>
+<task compile_id='103' method='java.util.HashMap$HashIterator &lt;init&gt; (Ljava/util/HashMap;)V' bytes='79' count='292' backedge_count='643' iicount='292' level='3' stamp='0.241'>
+<phase name='setup' stamp='0.241'>
+<phase_done name='setup' stamp='0.241'/>
+</phase>
+<phase name='buildIR' stamp='0.241'>
+<type id='977' name='void'/>
+<klass id='1094' name='java.util.HashMap' flags='1'/>
+<klass id='1093' name='java.util.HashMap$HashIterator' flags='1024'/>
+<method id='1095' holder='1093' name='&lt;init&gt;' return='977' arguments='1094' flags='0' bytes='79' iicount='331'/>
+<parse method='1095'  stamp='0.241'>
+<phase name='parse_hir' stamp='0.241'>
+<bc code='183' bci='6'/>
+<klass id='982' name='java.lang.Object' flags='1'/>
+<method id='1097' holder='982' name='&lt;init&gt;' return='977' flags='1' bytes='1' compile_id='50' compiler='c1' level='1' iicount='4711'/>
+<call method='1097' instr='invokespecial'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1097'>
+<bc code='177' bci='0'/>
+<dependency type='no_finalizable_subclasses' ctxk='1093'/>
+<parse_done stamp='0.241'/>
+</parse>
+<phase_done name='parse_hir' stamp='0.241'/>
+</phase>
+<parse_done stamp='0.241'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.241'>
+<phase_done name='optimize_blocks' stamp='0.241'/>
+</phase>
+<phase name='gvn' stamp='0.241'>
+<phase_done name='gvn' stamp='0.241'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.241'>
+<phase_done name='rangeCheckElimination' stamp='0.241'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.241'>
+<phase_done name='optimize_null_checks' stamp='0.241'/>
+</phase>
+<phase_done name='buildIR' stamp='0.241'/>
+</phase>
+<phase name='emit_lir' stamp='0.241'>
+<phase name='lirGeneration' stamp='0.241'>
+<phase_done name='lirGeneration' stamp='0.242'/>
+</phase>
+<phase name='linearScan' stamp='0.242'>
+<phase_done name='linearScan' stamp='0.242'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.242'/>
+</phase>
+<phase name='codeemit' stamp='0.242'>
+<phase_done name='codeemit' stamp='0.242'/>
+</phase>
+<phase name='codeinstall' stamp='0.242'>
+<dependency type='no_finalizable_subclasses' ctxk='1093'/>
+<phase_done name='codeinstall' stamp='0.242'/>
+</phase>
+<code_cache total_blobs='410' nmethods='105' adapters='162' free_code_cache='248588288'/>
+<task_done success='1' nmsize='1136' count='635' backedge_count='1086' inlined_bytes='1' stamp='0.242'/>
+</task>
+<task compile_id='110' method='java.util.KeyValueHolder getValue ()Ljava/lang/Object;' bytes='5' count='176' iicount='176' level='1' stamp='0.243'>
+<phase name='setup' stamp='0.243'>
+<phase_done name='setup' stamp='0.243'/>
+</phase>
+<phase name='buildIR' stamp='0.243'>
+<klass id='982' name='java.lang.Object' flags='1'/>
+<klass id='1093' name='java.util.KeyValueHolder' flags='16'/>
+<method id='1094' holder='1093' name='getValue' return='982' flags='1' bytes='5' iicount='176'/>
+<parse method='1094'  stamp='0.243'>
+<phase name='parse_hir' stamp='0.243'>
+<phase_done name='parse_hir' stamp='0.243'/>
+</phase>
+<parse_done stamp='0.243'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.243'>
+<phase_done name='optimize_blocks' stamp='0.243'/>
+</phase>
+<phase name='gvn' stamp='0.243'>
+<phase_done name='gvn' stamp='0.243'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.243'>
+<phase_done name='rangeCheckElimination' stamp='0.243'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.243'>
+<phase_done name='optimize_null_checks' stamp='0.243'/>
+</phase>
+<phase_done name='buildIR' stamp='0.243'/>
+</phase>
+<phase name='emit_lir' stamp='0.243'>
+<phase name='lirGeneration' stamp='0.243'>
+<phase_done name='lirGeneration' stamp='0.243'/>
+</phase>
+<phase name='linearScan' stamp='0.243'>
+<phase_done name='linearScan' stamp='0.243'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.243'/>
+</phase>
+<phase name='codeemit' stamp='0.243'>
+<phase_done name='codeemit' stamp='0.243'/>
+</phase>
+<phase name='codeinstall' stamp='0.243'>
+<phase_done name='codeinstall' stamp='0.243'/>
+</phase>
+<code_cache total_blobs='416' nmethods='109' adapters='162' free_code_cache='248572416'/>
+<task_done success='1' nmsize='272' count='176' stamp='0.243'/>
+</task>
+<task compile_id='113' method='java.lang.String indexOf (II)I' bytes='29' count='259' iicount='259' level='3' stamp='0.243'>
+<phase name='setup' stamp='0.243'>
+<phase_done name='setup' stamp='0.243'/>
+</phase>
+<phase name='buildIR' stamp='0.243'>
+<type id='975' name='int'/>
+<klass id='983' name='java.lang.String' flags='17'/>
+<method id='1093' holder='983' name='indexOf' return='975' arguments='975 975' flags='1' bytes='29' iicount='259'/>
+<parse method='1093'  stamp='0.243'>
+<phase name='parse_hir' stamp='0.243'>
+<bc code='183' bci='1'/>
+<type id='969' name='boolean'/>
+<method id='1095' holder='983' name='isLatin1' return='969' flags='2' bytes='19' compile_id='5' compiler='c1' level='3' iicount='6476'/>
+<call method='1095' instr='invokespecial'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1095'>
+<parse_done stamp='0.244'/>
+</parse>
+<bc code='184' bci='13'/>
+<klass id='1085' name='[B' flags='1041'/>
+<klass id='1098' name='java.lang.StringLatin1' flags='16'/>
+<method id='1099' holder='1098' name='indexOf' return='975' arguments='1085 975 975' flags='9' bytes='61' iicount='271'/>
+<call method='1099' instr='invokestatic'/>
+<inline_fail reason='callee is too large'/>
+<bc code='184' bci='25'/>
+<klass id='1101' name='java.lang.StringUTF16' flags='16'/>
+<method id='1102' holder='1101' name='indexOf' return='975' arguments='1085 975 975' flags='9' bytes='43' iicount='1'/>
+<call method='1102' instr='invokestatic'/>
+<inline_fail reason='callee is too large'/>
+<phase_done name='parse_hir' stamp='0.244'/>
+</phase>
+<parse_done stamp='0.244'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.244'>
+<phase_done name='optimize_blocks' stamp='0.244'/>
+</phase>
+<phase name='gvn' stamp='0.244'>
+<phase_done name='gvn' stamp='0.244'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.244'>
+<phase_done name='rangeCheckElimination' stamp='0.244'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.244'>
+<phase_done name='optimize_null_checks' stamp='0.244'/>
+</phase>
+<phase_done name='buildIR' stamp='0.244'/>
+</phase>
+<phase name='emit_lir' stamp='0.244'>
+<phase name='lirGeneration' stamp='0.244'>
+<phase_done name='lirGeneration' stamp='0.244'/>
+</phase>
+<phase name='linearScan' stamp='0.244'>
+<phase_done name='linearScan' stamp='0.244'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.244'/>
+</phase>
+<phase name='codeemit' stamp='0.244'>
+<phase_done name='codeemit' stamp='0.244'/>
+</phase>
+<phase name='codeinstall' stamp='0.244'>
+<phase_done name='codeinstall' stamp='0.244'/>
+</phase>
+<code_cache total_blobs='420' nmethods='113' adapters='162' free_code_cache='248578688'/>
+<task_done success='1' nmsize='728' count='295' inlined_bytes='19' stamp='0.244'/>
+</task>
+<task compile_id='124' method='java.lang.CharacterDataLatin1 getProperties (I)I' bytes='11' count='260' iicount='260' level='3' stamp='0.245'>
+<phase name='setup' stamp='0.245'>
+<phase_done name='setup' stamp='0.245'/>
+</phase>
+<phase name='buildIR' stamp='0.245'>
+<type id='975' name='int'/>
+<klass id='1093' name='java.lang.CharacterDataLatin1' flags='0'/>
+<method id='1094' holder='1093' name='getProperties' return='975' arguments='975' flags='0' bytes='11' iicount='260'/>
+<parse method='1094'  stamp='0.245'>
+<phase name='parse_hir' stamp='0.245'>
+<phase_done name='parse_hir' stamp='0.245'/>
+</phase>
+<parse_done stamp='0.245'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.245'>
+<phase_done name='optimize_blocks' stamp='0.245'/>
+</phase>
+<phase name='gvn' stamp='0.245'>
+<phase_done name='gvn' stamp='0.245'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.245'>
+<phase_done name='rangeCheckElimination' stamp='0.245'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.245'>
+<phase_done name='optimize_null_checks' stamp='0.245'/>
+</phase>
+<phase_done name='buildIR' stamp='0.245'/>
+</phase>
+<phase name='emit_lir' stamp='0.245'>
+<phase name='lirGeneration' stamp='0.245'>
+<phase_done name='lirGeneration' stamp='0.245'/>
+</phase>
+<phase name='linearScan' stamp='0.245'>
+<phase_done name='linearScan' stamp='0.245'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.245'/>
+</phase>
+<phase name='codeemit' stamp='0.245'>
+<phase_done name='codeemit' stamp='0.245'/>
+</phase>
+<phase name='codeinstall' stamp='0.245'>
+<phase_done name='codeinstall' stamp='0.245'/>
+</phase>
+<code_cache total_blobs='432' nmethods='123' adapters='162' free_code_cache='248567296'/>
+<task_done success='1' nmsize='400' count='260' stamp='0.245'/>
+</task>
+<task compile_id='125' method='java.lang.module.ResolvedModule name ()Ljava/lang/String;' bytes='11' count='308' iicount='308' level='3' stamp='0.245'>
+<phase name='setup' stamp='0.245'>
+<phase_done name='setup' stamp='0.245'/>
+</phase>
+<phase name='buildIR' stamp='0.245'>
+<klass id='983' name='java.lang.String' flags='17'/>
+<klass id='1093' name='java.lang.module.ResolvedModule' flags='17'/>
+<method id='1094' holder='1093' name='name' return='983' flags='1' bytes='11' iicount='309'/>
+<parse method='1094'  stamp='0.245'>
+<phase name='parse_hir' stamp='0.245'>
+<bc code='182' bci='1'/>
+<klass id='1096' name='java.lang.module.ModuleReference' flags='1025'/>
+<method id='1097' holder='1093' name='reference' return='1096' flags='1' bytes='5' compile_id='111' compiler='c1' level='1' iicount='156'/>
+<call method='1097' instr='invokevirtual'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1097'>
+<parse_done stamp='0.245'/>
+</parse>
+<bc code='182' bci='4'/>
+<klass id='1099' name='java.lang.module.ModuleDescriptor' flags='1'/>
+<method id='1100' holder='1096' name='descriptor' return='1099' flags='17' bytes='5' compile_id='46' compiler='c1' level='1' iicount='243'/>
+<call method='1100' instr='invokevirtual'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1100'>
+<parse_done stamp='0.245'/>
+</parse>
+<bc code='182' bci='7'/>
+<method id='1102' holder='1099' name='name' return='983' flags='1' bytes='5' compile_id='41' compiler='c1' level='1' iicount='168'/>
+<call method='1102' instr='invokevirtual'/>
+<dependency type='leaf_type' ctxk='1099'/>
+<inline_success reason='receiver is statically known'/>
+<dependency type='leaf_type' ctxk='1099'/>
+<parse method='1102'>
+<parse_done stamp='0.245'/>
+</parse>
+<phase_done name='parse_hir' stamp='0.245'/>
+</phase>
+<parse_done stamp='0.245'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.245'>
+<phase_done name='optimize_blocks' stamp='0.245'/>
+</phase>
+<phase name='gvn' stamp='0.245'>
+<phase_done name='gvn' stamp='0.245'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.245'>
+<phase_done name='rangeCheckElimination' stamp='0.245'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.245'>
+<phase_done name='optimize_null_checks' stamp='0.245'/>
+</phase>
+<phase_done name='buildIR' stamp='0.245'/>
+</phase>
+<phase name='emit_lir' stamp='0.245'>
+<phase name='lirGeneration' stamp='0.245'>
+<phase_done name='lirGeneration' stamp='0.245'/>
+</phase>
+<phase name='linearScan' stamp='0.245'>
+<phase_done name='linearScan' stamp='0.245'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.245'/>
+</phase>
+<phase name='codeemit' stamp='0.245'>
+<phase_done name='codeemit' stamp='0.245'/>
+</phase>
+<phase name='codeinstall' stamp='0.245'>
+<dependency type='leaf_type' ctxk='1099'/>
+<phase_done name='codeinstall' stamp='0.245'/>
+</phase>
+<code_cache total_blobs='434' nmethods='125' adapters='162' free_code_cache='248563328'/>
+<task_done success='1' nmsize='720' count='316' inlined_bytes='15' stamp='0.245'/>
+</task>
+<task compile_id='130' method='java.util.HashMap &lt;init&gt; ()V' bytes='11' count='266' iicount='266' level='3' stamp='0.248'>
+<phase name='setup' stamp='0.248'>
+<phase_done name='setup' stamp='0.248'/>
+</phase>
+<phase name='buildIR' stamp='0.248'>
+<type id='977' name='void'/>
+<klass id='1093' name='java.util.HashMap' flags='1'/>
+<method id='1094' holder='1093' name='&lt;init&gt;' return='977' flags='1' bytes='11' iicount='266'/>
+<parse method='1094'  stamp='0.248'>
+<phase name='parse_hir' stamp='0.248'>
+<bc code='183' bci='1'/>
+<klass id='1096' name='java.util.AbstractMap' flags='1025'/>
+<method id='1097' holder='1096' name='&lt;init&gt;' return='977' flags='4' bytes='5' iicount='315'/>
+<call method='1097' instr='invokespecial'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1097'>
+<bc code='183' bci='1'/>
+<klass id='982' name='java.lang.Object' flags='1'/>
+<method id='1099' holder='982' name='&lt;init&gt;' return='977' flags='1' bytes='1' compile_id='50' compiler='c1' level='1' iicount='6550'/>
+<call method='1099' instr='invokespecial'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1099'>
+<bc code='177' bci='0'/>
+<dependency type='no_finalizable_subclasses' ctxk='1093'/>
+<parse_done stamp='0.248'/>
+</parse>
+<parse_done stamp='0.248'/>
+</parse>
+<phase_done name='parse_hir' stamp='0.248'/>
+</phase>
+<parse_done stamp='0.248'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.248'>
+<phase_done name='optimize_blocks' stamp='0.248'/>
+</phase>
+<phase name='gvn' stamp='0.248'>
+<phase_done name='gvn' stamp='0.248'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.248'>
+<phase_done name='rangeCheckElimination' stamp='0.248'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.248'>
+<phase_done name='optimize_null_checks' stamp='0.248'/>
+</phase>
+<phase_done name='buildIR' stamp='0.248'/>
+</phase>
+<phase name='emit_lir' stamp='0.248'>
+<phase name='lirGeneration' stamp='0.248'>
+<phase_done name='lirGeneration' stamp='0.248'/>
+</phase>
+<phase name='linearScan' stamp='0.248'>
+<phase_done name='linearScan' stamp='0.248'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.248'/>
+</phase>
+<phase name='codeemit' stamp='0.248'>
+<phase_done name='codeemit' stamp='0.248'/>
+</phase>
+<phase name='codeinstall' stamp='0.248'>
+<dependency type='no_finalizable_subclasses' ctxk='1093'/>
+<phase_done name='codeinstall' stamp='0.248'/>
+</phase>
+<code_cache total_blobs='442' nmethods='131' adapters='162' free_code_cache='248556544'/>
+<task_done success='1' nmsize='528' count='306' inlined_bytes='6' stamp='0.248'/>
+</task>
+<task compile_id='134' method='java.util.HashMap resize ()[Ljava/util/HashMap$Node;' bytes='356' count='287' backedge_count='1174' iicount='287' level='3' stamp='0.249'>
+<phase name='setup' stamp='0.249'>
+<phase_done name='setup' stamp='0.249'/>
+</phase>
+<phase name='buildIR' stamp='0.249'>
+<klass id='1095' name='[Ljava.util.HashMap$Node;' flags='1040'/>
+<klass id='1093' name='java.util.HashMap' flags='1'/>
+<method id='1096' holder='1093' name='resize' return='1095' flags='16' bytes='356' iicount='288'/>
+<parse method='1096'  stamp='0.249'>
+<phase name='parse_hir' stamp='0.249'>
+<bc code='182' bci='217'/>
+<type id='977' name='void'/>
+<type id='975' name='int'/>
+<klass id='1098' name='java.util.HashMap$TreeNode' flags='24'/>
+<method id='1099' holder='1098' name='split' return='977' arguments='1093 1095 975 975' flags='16' bytes='218' iicount='1'/>
+<call method='1099' instr='invokevirtual'/>
+<inline_fail reason='not inlineable'/>
+<phase_done name='parse_hir' stamp='0.249'/>
+</phase>
+<parse_done stamp='0.249'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.249'>
+<phase_done name='optimize_blocks' stamp='0.249'/>
+</phase>
+<phase name='gvn' stamp='0.249'>
+<phase_done name='gvn' stamp='0.249'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.249'>
+<phase_done name='rangeCheckElimination' stamp='0.249'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.249'>
+<phase_done name='optimize_null_checks' stamp='0.249'/>
+</phase>
+<phase_done name='buildIR' stamp='0.249'/>
+</phase>
+<phase name='emit_lir' stamp='0.249'>
+<phase name='lirGeneration' stamp='0.249'>
+<phase_done name='lirGeneration' stamp='0.249'/>
+</phase>
+<phase name='linearScan' stamp='0.249'>
+<phase_done name='linearScan' stamp='0.249'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.249'/>
+</phase>
+<phase name='codeemit' stamp='0.249'>
+<phase_done name='codeemit' stamp='0.250'/>
+</phase>
+<phase name='codeinstall' stamp='0.250'>
+<phase_done name='codeinstall' stamp='0.250'/>
+</phase>
+<code_cache total_blobs='448' nmethods='137' adapters='162' free_code_cache='248543872'/>
+<task_done success='1' nmsize='5352' count='387' backedge_count='1414' stamp='0.250'/>
+</task>
+<task compile_id='139' method='java.util.ArrayList access$000 (Ljava/util/ArrayList;)I' bytes='5' count='167' iicount='167' level='1' stamp='0.250'>
+<phase name='setup' stamp='0.250'>
+<phase_done name='setup' stamp='0.250'/>
+</phase>
+<phase name='buildIR' stamp='0.250'>
+<type id='975' name='int'/>
+<klass id='1093' name='java.util.ArrayList' flags='1'/>
+<method id='1094' holder='1093' name='access$000' return='975' arguments='1093' flags='4104' bytes='5' iicount='167'/>
+<parse method='1094'  stamp='0.250'>
+<phase name='parse_hir' stamp='0.250'>
+<phase_done name='parse_hir' stamp='0.250'/>
+</phase>
+<parse_done stamp='0.250'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.250'>
+<phase_done name='optimize_blocks' stamp='0.250'/>
+</phase>
+<phase name='gvn' stamp='0.250'>
+<phase_done name='gvn' stamp='0.250'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.250'>
+<phase_done name='rangeCheckElimination' stamp='0.250'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.250'>
+<phase_done name='optimize_null_checks' stamp='0.250'/>
+</phase>
+<phase_done name='buildIR' stamp='0.250'/>
+</phase>
+<phase name='emit_lir' stamp='0.250'>
+<phase name='lirGeneration' stamp='0.250'>
+<phase_done name='lirGeneration' stamp='0.250'/>
+</phase>
+<phase name='linearScan' stamp='0.250'>
+<phase_done name='linearScan' stamp='0.250'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.250'/>
+</phase>
+<phase name='codeemit' stamp='0.250'>
+<phase_done name='codeemit' stamp='0.250'/>
+</phase>
+<phase name='codeinstall' stamp='0.250'>
+<phase_done name='codeinstall' stamp='0.250'/>
+</phase>
+<code_cache total_blobs='449' nmethods='138' adapters='162' free_code_cache='248542976'/>
+<task_done success='1' nmsize='240' count='167' stamp='0.250'/>
+</task>
+<task compile_id='142' method='java.util.ImmutableCollections$SetN iterator ()Ljava/util/Iterator;' bytes='9' count='256' iicount='256' level='3' stamp='0.250'>
+<phase name='setup' stamp='0.250'>
+<phase_done name='setup' stamp='0.250'/>
+</phase>
+<phase name='buildIR' stamp='0.250'>
+<klass id='1094' name='java.util.Iterator' flags='1537'/>
+<klass id='1093' name='java.util.ImmutableCollections$SetN' flags='24'/>
+<method id='1095' holder='1093' name='iterator' return='1094' flags='1' bytes='9' iicount='256'/>
+<parse method='1095'  stamp='0.250'>
+<phase name='parse_hir' stamp='0.250'>
+<bc code='183' bci='5'/>
+<type id='977' name='void'/>
+<klass id='1097' name='java.util.ImmutableCollections$SetN$1' flags='0'/>
+<method id='1098' holder='1097' name='&lt;init&gt;' return='977' arguments='1093' flags='0' bytes='15' iicount='258'/>
+<call method='1098' instr='invokespecial'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1098'>
+<bc code='183' bci='6'/>
+<klass id='982' name='java.lang.Object' flags='1'/>
+<method id='1100' holder='982' name='&lt;init&gt;' return='977' flags='1' bytes='1' compile_id='50' compiler='c1' level='1' iicount='7592'/>
+<call method='1100' instr='invokespecial'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1100'>
+<parse_done stamp='0.250'/>
+</parse>
+<parse_done stamp='0.250'/>
+</parse>
+<phase_done name='parse_hir' stamp='0.250'/>
+</phase>
+<parse_done stamp='0.250'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.250'>
+<phase_done name='optimize_blocks' stamp='0.250'/>
+</phase>
+<phase name='gvn' stamp='0.250'>
+<phase_done name='gvn' stamp='0.250'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.250'>
+<phase_done name='rangeCheckElimination' stamp='0.250'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.250'>
+<phase_done name='optimize_null_checks' stamp='0.250'/>
+</phase>
+<phase_done name='buildIR' stamp='0.250'/>
+</phase>
+<phase name='emit_lir' stamp='0.250'>
+<phase name='lirGeneration' stamp='0.250'>
+<phase_done name='lirGeneration' stamp='0.250'/>
+</phase>
+<phase name='linearScan' stamp='0.250'>
+<phase_done name='linearScan' stamp='0.250'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.250'/>
+</phase>
+<phase name='codeemit' stamp='0.250'>
+<phase_done name='codeemit' stamp='0.250'/>
+</phase>
+<phase name='codeinstall' stamp='0.250'>
+<phase_done name='codeinstall' stamp='0.250'/>
+</phase>
+<code_cache total_blobs='455' nmethods='144' adapters='162' free_code_cache='248536448'/>
+<task_done success='1' nmsize='720' count='263' inlined_bytes='16' stamp='0.250'/>
+</task>
+<task compile_id='148' method='java.util.Collections$UnmodifiableCollection$1 hasNext ()Z' bytes='10' count='265' iicount='265' level='3' stamp='0.251'>
+<phase name='setup' stamp='0.251'>
+<phase_done name='setup' stamp='0.251'/>
+</phase>
+<phase name='buildIR' stamp='0.251'>
+<type id='969' name='boolean'/>
+<klass id='1093' name='java.util.Collections$UnmodifiableCollection$1' flags='0'/>
+<method id='1094' holder='1093' name='hasNext' return='969' flags='1' bytes='10' iicount='265'/>
+<parse method='1094'  stamp='0.251'>
+<phase name='parse_hir' stamp='0.251'>
+<bc code='185' bci='4'/>
+<klass id='1096' name='java.util.Iterator' flags='1537'/>
+<method id='1097' holder='1096' name='hasNext' return='969' flags='1025' bytes='0' iicount='1'/>
+<call method='1097' instr='invokeinterface'/>
+<inline_fail reason='no static binding'/>
+<phase_done name='parse_hir' stamp='0.251'/>
+</phase>
+<parse_done stamp='0.251'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.251'>
+<phase_done name='optimize_blocks' stamp='0.251'/>
+</phase>
+<phase name='gvn' stamp='0.251'>
+<phase_done name='gvn' stamp='0.251'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.251'>
+<phase_done name='rangeCheckElimination' stamp='0.251'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.251'>
+<phase_done name='optimize_null_checks' stamp='0.251'/>
+</phase>
+<phase_done name='buildIR' stamp='0.251'/>
+</phase>
+<phase name='emit_lir' stamp='0.251'>
+<phase name='lirGeneration' stamp='0.251'>
+<phase_done name='lirGeneration' stamp='0.251'/>
+</phase>
+<phase name='linearScan' stamp='0.251'>
+<phase_done name='linearScan' stamp='0.251'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.251'/>
+</phase>
+<phase name='codeemit' stamp='0.251'>
+<phase_done name='codeemit' stamp='0.251'/>
+</phase>
+<phase name='codeinstall' stamp='0.251'>
+<phase_done name='codeinstall' stamp='0.251'/>
+</phase>
+<code_cache total_blobs='458' nmethods='147' adapters='162' free_code_cache='248533504'/>
+<task_done success='1' nmsize='552' count='280' stamp='0.251'/>
+</task>
+<task compile_id='151' method='java.util.Collections$1 &lt;init&gt; (Ljava/lang/Object;)V' bytes='15' count='267' iicount='267' level='3' stamp='0.251'>
+<phase name='setup' stamp='0.251'>
+<phase_done name='setup' stamp='0.251'/>
+</phase>
+<phase name='buildIR' stamp='0.251'>
+<type id='977' name='void'/>
+<klass id='982' name='java.lang.Object' flags='1'/>
+<klass id='1093' name='java.util.Collections$1' flags='0'/>
+<method id='1094' holder='1093' name='&lt;init&gt;' return='977' arguments='982' flags='0' bytes='15' iicount='267'/>
+<parse method='1094'  stamp='0.251'>
+<phase name='parse_hir' stamp='0.251'>
+<bc code='183' bci='6'/>
+<method id='1096' holder='982' name='&lt;init&gt;' return='977' flags='1' bytes='1' compile_id='50' compiler='c1' level='1' iicount='8227'/>
+<call method='1096' instr='invokespecial'/>
+<dependency type='leaf_type' ctxk='1093'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1096'>
+<bc code='177' bci='0'/>
+<dependency type='leaf_type' ctxk='1093'/>
+<parse_done stamp='0.251'/>
+</parse>
+<phase_done name='parse_hir' stamp='0.251'/>
+</phase>
+<parse_done stamp='0.251'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.251'>
+<phase_done name='optimize_blocks' stamp='0.251'/>
+</phase>
+<phase name='gvn' stamp='0.251'>
+<phase_done name='gvn' stamp='0.251'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.251'>
+<phase_done name='rangeCheckElimination' stamp='0.251'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.251'>
+<phase_done name='optimize_null_checks' stamp='0.251'/>
+</phase>
+<phase_done name='buildIR' stamp='0.251'/>
+</phase>
+<phase name='emit_lir' stamp='0.251'>
+<phase name='lirGeneration' stamp='0.251'>
+<phase_done name='lirGeneration' stamp='0.251'/>
+</phase>
+<phase name='linearScan' stamp='0.251'>
+<phase_done name='linearScan' stamp='0.251'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.251'/>
+</phase>
+<phase name='codeemit' stamp='0.251'>
+<phase_done name='codeemit' stamp='0.251'/>
+</phase>
+<phase name='codeinstall' stamp='0.251'>
+<dependency type='leaf_type' ctxk='1093'/>
+<phase_done name='codeinstall' stamp='0.251'/>
+</phase>
+<code_cache total_blobs='462' nmethods='151' adapters='162' free_code_cache='248525440'/>
+<task_done success='1' nmsize='528' count='274' inlined_bytes='1' stamp='0.251'/>
+</task>
+<task compile_id='158' method='jdk.internal.module.ModuleReferenceImpl moduleResolution ()Ljdk/internal/module/ModuleResolution;' bytes='5' count='148' iicount='148' level='1' stamp='0.253'>
+<phase name='setup' stamp='0.253'>
+<phase_done name='setup' stamp='0.253'/>
+</phase>
+<phase name='buildIR' stamp='0.253'>
+<klass id='1094' name='jdk.internal.module.ModuleResolution' flags='17'/>
+<klass id='1093' name='jdk.internal.module.ModuleReferenceImpl' flags='1'/>
+<method id='1095' holder='1093' name='moduleResolution' return='1094' flags='1' bytes='5' iicount='148'/>
+<parse method='1095'  stamp='0.253'>
+<phase name='parse_hir' stamp='0.253'>
+<phase_done name='parse_hir' stamp='0.253'/>
+</phase>
+<parse_done stamp='0.253'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.253'>
+<phase_done name='optimize_blocks' stamp='0.253'/>
+</phase>
+<phase name='gvn' stamp='0.253'>
+<phase_done name='gvn' stamp='0.253'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.253'>
+<phase_done name='rangeCheckElimination' stamp='0.253'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.253'>
+<phase_done name='optimize_null_checks' stamp='0.253'/>
+</phase>
+<phase_done name='buildIR' stamp='0.253'/>
+</phase>
+<phase name='emit_lir' stamp='0.253'>
+<phase name='lirGeneration' stamp='0.253'>
+<phase_done name='lirGeneration' stamp='0.253'/>
+</phase>
+<phase name='linearScan' stamp='0.253'>
+<phase_done name='linearScan' stamp='0.253'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.253'/>
+</phase>
+<phase name='codeemit' stamp='0.253'>
+<phase_done name='codeemit' stamp='0.253'/>
+</phase>
+<phase name='codeinstall' stamp='0.253'>
+<phase_done name='codeinstall' stamp='0.253'/>
+</phase>
+<code_cache total_blobs='469' nmethods='158' adapters='162' free_code_cache='248518272'/>
+<task_done success='1' nmsize='272' count='148' stamp='0.253'/>
+</task>
+<task compile_id='165' method='java.util.HashMap putIfAbsent (Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;' bytes='13' count='269' iicount='269' level='3' stamp='0.254'>
+<phase name='setup' stamp='0.254'>
+<phase_done name='setup' stamp='0.254'/>
+</phase>
+<phase name='buildIR' stamp='0.254'>
+<klass id='982' name='java.lang.Object' flags='1'/>
+<klass id='1093' name='java.util.HashMap' flags='1'/>
+<method id='1094' holder='1093' name='putIfAbsent' return='982' arguments='982 982' flags='1' bytes='13' iicount='284'/>
+<parse method='1094'  stamp='0.254'>
+<phase name='parse_hir' stamp='0.254'>
+<bc code='184' bci='2'/>
+<type id='975' name='int'/>
+<method id='1096' holder='1093' name='hash' return='975' arguments='982' flags='24' bytes='20' compile_id='65' compiler='c1' level='3' iicount='6654'/>
+<call method='1096' instr='invokestatic'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1096'>
+<bc code='182' bci='9'/>
+<method id='1099' holder='982' name='hashCode' return='975' flags='257' bytes='0' compile_id='93' compile_kind='c2n' compiler='' level='0' iicount='256'/>
+<call method='1099' instr='invokevirtual'/>
+<inline_fail reason='no static binding'/>
+<parse_done stamp='0.254'/>
+</parse>
+<bc code='182' bci='9'/>
+<type id='969' name='boolean'/>
+<method id='1100' holder='1093' name='putVal' return='982' arguments='975 982 982 969 969' flags='16' bytes='300' compile_id='72' compiler='c1' level='3' iicount='3071'/>
+<call method='1100' instr='invokevirtual'/>
+<inline_fail reason='callee is too large'/>
+<phase_done name='parse_hir' stamp='0.255'/>
+</phase>
+<parse_done stamp='0.255'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.255'>
+<phase_done name='optimize_blocks' stamp='0.255'/>
+</phase>
+<phase name='gvn' stamp='0.255'>
+<phase_done name='gvn' stamp='0.255'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.255'>
+<phase_done name='rangeCheckElimination' stamp='0.255'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.255'>
+<phase_done name='optimize_null_checks' stamp='0.255'/>
+</phase>
+<phase_done name='buildIR' stamp='0.255'/>
+</phase>
+<phase name='emit_lir' stamp='0.255'>
+<phase name='lirGeneration' stamp='0.255'>
+<phase_done name='lirGeneration' stamp='0.255'/>
+</phase>
+<phase name='linearScan' stamp='0.255'>
+<phase_done name='linearScan' stamp='0.255'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.255'/>
+</phase>
+<phase name='codeemit' stamp='0.255'>
+<phase_done name='codeemit' stamp='0.255'/>
+</phase>
+<phase name='codeinstall' stamp='0.255'>
+<phase_done name='codeinstall' stamp='0.255'/>
+</phase>
+<code_cache total_blobs='480' nmethods='166' adapters='162' free_code_cache='248504320'/>
+<task_done success='1' nmsize='952' count='492' inlined_bytes='20' stamp='0.255'/>
+</task>
+<task compile_id='167' method='java.lang.Module getDescriptor ()Ljava/lang/module/ModuleDescriptor;' bytes='5' count='135' iicount='135' level='1' stamp='0.255'>
+<phase name='setup' stamp='0.255'>
+<phase_done name='setup' stamp='0.255'/>
+</phase>
+<phase name='buildIR' stamp='0.255'>
+<klass id='1093' name='java.lang.module.ModuleDescriptor' flags='1'/>
+<klass id='1019' name='java.lang.Module' flags='17'/>
+<method id='1094' holder='1019' name='getDescriptor' return='1093' flags='1' bytes='5' iicount='136'/>
+<parse method='1094'  stamp='0.255'>
+<phase name='parse_hir' stamp='0.255'>
+<phase_done name='parse_hir' stamp='0.255'/>
+</phase>
+<parse_done stamp='0.255'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.255'>
+<phase_done name='optimize_blocks' stamp='0.255'/>
+</phase>
+<phase name='gvn' stamp='0.255'>
+<phase_done name='gvn' stamp='0.255'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.255'>
+<phase_done name='rangeCheckElimination' stamp='0.255'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.255'>
+<phase_done name='optimize_null_checks' stamp='0.255'/>
+</phase>
+<phase_done name='buildIR' stamp='0.255'/>
+</phase>
+<phase name='emit_lir' stamp='0.255'>
+<phase name='lirGeneration' stamp='0.255'>
+<phase_done name='lirGeneration' stamp='0.255'/>
+</phase>
+<phase name='linearScan' stamp='0.255'>
+<phase_done name='linearScan' stamp='0.255'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.255'/>
+</phase>
+<phase name='codeemit' stamp='0.255'>
+<phase_done name='codeemit' stamp='0.255'/>
+</phase>
+<phase name='codeinstall' stamp='0.255'>
+<phase_done name='codeinstall' stamp='0.255'/>
+</phase>
+<code_cache total_blobs='481' nmethods='168' adapters='162' free_code_cache='248503552'/>
+<task_done success='1' nmsize='272' count='146' stamp='0.255'/>
+</task>
+<task compile_id='172' method='java.util.jar.Attributes$Name isValid (C)Z' bytes='32' count='331' iicount='331' level='3' stamp='0.281'>
+<phase name='setup' stamp='0.281'>
+<phase_done name='setup' stamp='0.281'/>
+</phase>
+<phase name='buildIR' stamp='0.281'>
+<type id='969' name='boolean'/>
+<type id='970' name='char'/>
+<klass id='1093' name='java.util.jar.Attributes$Name' flags='9'/>
+<method id='1094' holder='1093' name='isValid' return='969' arguments='970' flags='10' bytes='32' iicount='331'/>
+<parse method='1094'  stamp='0.281'>
+<phase name='parse_hir' stamp='0.281'>
+<bc code='184' bci='1'/>
+<method id='1096' holder='1093' name='isAlpha' return='969' arguments='970' flags='10' bytes='30' iicount='349'/>
+<call method='1096' instr='invokestatic'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1096'>
+<parse_done stamp='0.281'/>
+</parse>
+<bc code='184' bci='8'/>
+<method id='1098' holder='1093' name='isDigit' return='969' arguments='970' flags='10' bytes='18' iicount='23'/>
+<call method='1098' instr='invokestatic'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1098'>
+<parse_done stamp='0.281'/>
+</parse>
+<phase_done name='parse_hir' stamp='0.281'/>
+</phase>
+<parse_done stamp='0.281'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.281'>
+<phase_done name='optimize_blocks' stamp='0.281'/>
+</phase>
+<phase name='gvn' stamp='0.281'>
+<phase_done name='gvn' stamp='0.281'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.281'>
+<phase_done name='rangeCheckElimination' stamp='0.281'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.281'>
+<phase_done name='optimize_null_checks' stamp='0.281'/>
+</phase>
+<phase_done name='buildIR' stamp='0.281'/>
+</phase>
+<phase name='emit_lir' stamp='0.281'>
+<phase name='lirGeneration' stamp='0.281'>
+<phase_done name='lirGeneration' stamp='0.281'/>
+</phase>
+<phase name='linearScan' stamp='0.281'>
+<phase_done name='linearScan' stamp='0.281'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.281'/>
+</phase>
+<phase name='codeemit' stamp='0.281'>
+<phase_done name='codeemit' stamp='0.281'/>
+</phase>
+<phase name='codeinstall' stamp='0.281'>
+<phase_done name='codeinstall' stamp='0.281'/>
+</phase>
+<code_cache total_blobs='518' nmethods='173' adapters='194' free_code_cache='248478720'/>
+<task_done success='1' nmsize='1168' count='368' inlined_bytes='48' stamp='0.281'/>
+</task>
+<task compile_id='178' method='java.lang.AbstractStringBuilder putStringAt (ILjava/lang/String;)V' bytes='29' count='256' iicount='256' level='3' stamp='0.309'>
+<phase name='setup' stamp='0.309'>
+<phase_done name='setup' stamp='0.309'/>
+</phase>
+<phase name='buildIR' stamp='0.309'>
+<type id='977' name='void'/>
+<type id='975' name='int'/>
+<klass id='983' name='java.lang.String' flags='17'/>
+<klass id='1048' name='java.lang.AbstractStringBuilder' flags='1024'/>
+<method id='1093' holder='1048' name='putStringAt' return='977' arguments='975 983' flags='18' bytes='29' iicount='256'/>
+<parse method='1093'  stamp='0.309'>
+<phase name='parse_hir' stamp='0.309'>
+<bc code='182' bci='1'/>
+<type id='973' name='byte'/>
+<method id='1095' holder='1048' name='getCoder' return='973' flags='16' bytes='15' iicount='256'/>
+<call method='1095' instr='invokevirtual'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1095'>
+<parse_done stamp='0.309'/>
+</parse>
+<bc code='182' bci='5'/>
+<method id='1098' holder='983' name='coder' return='973' flags='0' bytes='15' compile_id='4' compiler='c1' level='3' iicount='8510'/>
+<call method='1098' instr='invokevirtual'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1098'>
+<parse_done stamp='0.309'/>
+</parse>
+<bc code='183' bci='12'/>
+<method id='1100' holder='1048' name='inflate' return='977' flags='2' bytes='42' iicount='1'/>
+<call method='1100' instr='invokespecial'/>
+<inline_fail reason='callee is too large'/>
+<bc code='182' bci='25'/>
+<klass id='1085' name='[B' flags='1041'/>
+<method id='1102' holder='983' name='getBytes' return='977' arguments='1085 975 973' flags='0' bytes='44' iicount='259'/>
+<call method='1102' instr='invokevirtual'/>
+<inline_fail reason='callee is too large'/>
+<phase_done name='parse_hir' stamp='0.309'/>
+</phase>
+<parse_done stamp='0.309'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.309'>
+<phase_done name='optimize_blocks' stamp='0.309'/>
+</phase>
+<phase name='gvn' stamp='0.309'>
+<phase_done name='gvn' stamp='0.309'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.309'>
+<phase_done name='rangeCheckElimination' stamp='0.309'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.309'>
+<phase_done name='optimize_null_checks' stamp='0.309'/>
+</phase>
+<phase_done name='buildIR' stamp='0.309'/>
+</phase>
+<phase name='emit_lir' stamp='0.309'>
+<phase name='lirGeneration' stamp='0.309'>
+<phase_done name='lirGeneration' stamp='0.309'/>
+</phase>
+<phase name='linearScan' stamp='0.309'>
+<phase_done name='linearScan' stamp='0.310'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.310'/>
+</phase>
+<phase name='codeemit' stamp='0.310'>
+<phase_done name='codeemit' stamp='0.310'/>
+</phase>
+<phase name='codeinstall' stamp='0.310'>
+<phase_done name='codeinstall' stamp='0.310'/>
+</phase>
+<code_cache total_blobs='528' nmethods='179' adapters='198' free_code_cache='248469248'/>
+<task_done success='1' nmsize='1208' count='259' inlined_bytes='30' stamp='0.310'/>
+</task>
+<task compile_id='183' method='java.lang.AbstractStringBuilder append (Ljava/lang/String;)Ljava/lang/AbstractStringBuilder;' bytes='45' count='281' iicount='281' level='3' stamp='0.317'>
+<phase name='setup' stamp='0.317'>
+<phase_done name='setup' stamp='0.317'/>
+</phase>
+<phase name='buildIR' stamp='0.317'>
+<klass id='1048' name='java.lang.AbstractStringBuilder' flags='1024'/>
+<klass id='983' name='java.lang.String' flags='17'/>
+<method id='1093' holder='1048' name='append' return='1048' arguments='983' flags='1' bytes='45' iicount='281'/>
+<parse method='1093'  stamp='0.317'>
+<phase name='parse_hir' stamp='0.317'>
+<bc code='183' bci='5'/>
+<method id='1095' holder='1048' name='appendNull' return='1048' flags='2' bytes='83' iicount='1'/>
+<call method='1095' instr='invokespecial'/>
+<inline_fail reason='callee is too large'/>
+<bc code='182' bci='10'/>
+<type id='975' name='int'/>
+<method id='1097' holder='983' name='length' return='975' flags='1' bytes='11' compile_id='45' compiler='c1' level='3' iicount='1685'/>
+<call method='1097' instr='invokevirtual'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1097'>
+<bc code='182' bci='6'/>
+<type id='973' name='byte'/>
+<method id='1099' holder='983' name='coder' return='973' flags='0' bytes='15' compile_id='4' compiler='c1' level='3' iicount='8888'/>
+<call method='1099' instr='invokevirtual'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1099'>
+<parse_done stamp='0.317'/>
+</parse>
+<parse_done stamp='0.317'/>
+</parse>
+<bc code='183' bci='21'/>
+<type id='977' name='void'/>
+<method id='1102' holder='1048' name='ensureCapacityInternal' return='977' arguments='975' flags='2' bytes='39' compile_id='129' compiler='c1' level='3' iicount='413'/>
+<call method='1102' instr='invokespecial'/>
+<inline_fail reason='callee is too large'/>
+<bc code='183' bci='30'/>
+<method id='1104' holder='1048' name='putStringAt' return='977' arguments='975 983' flags='18' bytes='29' compile_id='178' compiler='c1' level='3' iicount='281'/>
+<call method='1104' instr='invokespecial'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1104'>
+<bc code='182' bci='1'/>
+<method id='1106' holder='1048' name='getCoder' return='973' flags='16' bytes='15' compile_id='179' compiler='c1' level='3' iicount='281'/>
+<call method='1106' instr='invokevirtual'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1106'>
+<parse_done stamp='0.317'/>
+</parse>
+<bc code='182' bci='5'/>
+<call method='1099' instr='invokevirtual'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1099'>
+<parse_done stamp='0.317'/>
+</parse>
+<bc code='183' bci='12'/>
+<method id='1108' holder='1048' name='inflate' return='977' flags='2' bytes='42' iicount='1'/>
+<call method='1108' instr='invokespecial'/>
+<inline_fail reason='callee is too large'/>
+<bc code='182' bci='25'/>
+<klass id='1085' name='[B' flags='1041'/>
+<method id='1110' holder='983' name='getBytes' return='977' arguments='1085 975 973' flags='0' bytes='44' compile_id='180' compiler='c1' level='3' iicount='281'/>
+<call method='1110' instr='invokevirtual'/>
+<inline_fail reason='callee is too large'/>
+<parse_done stamp='0.317'/>
+</parse>
+<phase_done name='parse_hir' stamp='0.317'/>
+</phase>
+<parse_done stamp='0.317'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.317'>
+<phase_done name='optimize_blocks' stamp='0.317'/>
+</phase>
+<phase name='gvn' stamp='0.317'>
+<phase_done name='gvn' stamp='0.317'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.317'>
+<phase_done name='rangeCheckElimination' stamp='0.317'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.317'>
+<phase_done name='optimize_null_checks' stamp='0.317'/>
+</phase>
+<phase_done name='buildIR' stamp='0.317'/>
+</phase>
+<phase name='emit_lir' stamp='0.317'>
+<phase name='lirGeneration' stamp='0.317'>
+<phase_done name='lirGeneration' stamp='0.317'/>
+</phase>
+<phase name='linearScan' stamp='0.317'>
+<phase_done name='linearScan' stamp='0.317'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.317'/>
+</phase>
+<phase name='codeemit' stamp='0.317'>
+<phase_done name='codeemit' stamp='0.317'/>
+</phase>
+<phase name='codeinstall' stamp='0.317'>
+<phase_done name='codeinstall' stamp='0.317'/>
+</phase>
+<code_cache total_blobs='532' nmethods='183' adapters='198' free_code_cache='248461312'/>
+<task_done success='1' nmsize='2008' count='281' inlined_bytes='85' stamp='0.317'/>
+</task>
+<task compile_id='192' method='java.lang.Class getClassLoader0 ()Ljava/lang/ClassLoader;' bytes='5' count='128' iicount='128' level='1' stamp='0.324'>
+<phase name='setup' stamp='0.324'>
+<phase_done name='setup' stamp='0.324'/>
+</phase>
+<phase name='buildIR' stamp='0.324'>
+<klass id='986' name='java.lang.ClassLoader' flags='1025'/>
+<klass id='984' name='java.lang.Class' flags='17'/>
+<method id='1093' holder='984' name='getClassLoader0' return='986' flags='0' bytes='5' iicount='128'/>
+<parse method='1093'  stamp='0.324'>
+<phase name='parse_hir' stamp='0.324'>
+<phase_done name='parse_hir' stamp='0.324'/>
+</phase>
+<parse_done stamp='0.324'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.324'>
+<phase_done name='optimize_blocks' stamp='0.324'/>
+</phase>
+<phase name='gvn' stamp='0.324'>
+<phase_done name='gvn' stamp='0.324'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.324'>
+<phase_done name='rangeCheckElimination' stamp='0.324'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.324'>
+<phase_done name='optimize_null_checks' stamp='0.324'/>
+</phase>
+<phase_done name='buildIR' stamp='0.324'/>
+</phase>
+<phase name='emit_lir' stamp='0.324'>
+<phase name='lirGeneration' stamp='0.324'>
+<phase_done name='lirGeneration' stamp='0.324'/>
+</phase>
+<phase name='linearScan' stamp='0.324'>
+<phase_done name='linearScan' stamp='0.324'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.324'/>
+</phase>
+<phase name='codeemit' stamp='0.324'>
+<phase_done name='codeemit' stamp='0.324'/>
+</phase>
+<phase name='codeinstall' stamp='0.324'>
+<phase_done name='codeinstall' stamp='0.324'/>
+</phase>
+<code_cache total_blobs='562' nmethods='191' adapters='220' free_code_cache='248435328'/>
+<task_done success='1' nmsize='272' count='128' stamp='0.324'/>
+</task>
+<task compile_id='205' method='java.lang.invoke.MethodTypeForm canonicalize (Ljava/lang/Class;I)Ljava/lang/Class;' bytes='233' count='259' iicount='259' level='3' stamp='0.330'>
+<phase name='setup' stamp='0.330'>
+<phase_done name='setup' stamp='0.330'/>
+</phase>
+<phase name='buildIR' stamp='0.330'>
+<klass id='984' name='java.lang.Class' flags='17'/>
+<type id='975' name='int'/>
+<klass id='1093' name='java.lang.invoke.MethodTypeForm' flags='16'/>
+<method id='1094' holder='1093' name='canonicalize' return='984' arguments='984 975' flags='8' bytes='233' iicount='259'/>
+<parse method='1094'  stamp='0.330'>
+<phase name='parse_hir' stamp='0.330'>
+<bc code='182' bci='10'/>
+<type id='969' name='boolean'/>
+<method id='1097' holder='984' name='isPrimitive' return='969' flags='257' bytes='0' compile_id='195' compile_kind='c2n' compiler='' level='0' iicount='256'/>
+<call method='1097' instr='invokevirtual'/>
+<inline_success reason='intrinsic'/>
+<bc code='184' bci='53'/>
+<klass id='1099' name='sun.invoke.util.Wrapper' flags='16401'/>
+<method id='1100' holder='1099' name='asPrimitiveType' return='984' arguments='984' flags='9' bytes='20' iicount='1'/>
+<call method='1100' instr='invokestatic'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1100'>
+<bc code='184' bci='1'/>
+<method id='1102' holder='1099' name='findWrapperType' return='1099' arguments='984' flags='8' bytes='25' iicount='1'/>
+<call method='1102' instr='invokestatic'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1102'>
+<bc code='184' bci='4'/>
+<method id='1107' holder='1099' name='hashWrap' return='975' arguments='984' flags='10' bytes='62' iicount='10'/>
+<call method='1107' instr='invokestatic'/>
+<inline_fail reason='callee is too large'/>
+<parse_done stamp='0.330'/>
+</parse>
+<bc code='182' bci='10'/>
+<method id='1109' holder='1099' name='primitiveType' return='984' flags='1' bytes='5' iicount='4'/>
+<call method='1109' instr='invokevirtual'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1109'>
+<parse_done stamp='0.330'/>
+</parse>
+<bc code='184' bci='14'/>
+<method id='1111' holder='1099' name='forceType' return='984' arguments='984 984' flags='8' bytes='165' iicount='1'/>
+<call method='1111' instr='invokestatic'/>
+<inline_fail reason='callee is too large'/>
+<parse_done stamp='0.330'/>
+</parse>
+<bc code='184' bci='149'/>
+<method id='1118' holder='1099' name='asWrapperType' return='984' arguments='984' flags='9' bytes='18' iicount='1'/>
+<call method='1118' instr='invokestatic'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1118'>
+<bc code='182' bci='1'/>
+<call method='1097' instr='invokevirtual'/>
+<inline_success reason='intrinsic'/>
+<bc code='184' bci='8'/>
+<method id='1120' holder='1099' name='forPrimitiveType' return='1099' arguments='984' flags='9' bytes='49' iicount='54'/>
+<call method='1120' instr='invokestatic'/>
+<inline_fail reason='callee is too large'/>
+<bc code='182' bci='12'/>
+<method id='1122' holder='1099' name='wrapperType' return='984' arguments='984' flags='1' bytes='52' iicount='1'/>
+<call method='1122' instr='invokevirtual'/>
+<inline_fail reason='callee is too large'/>
+<parse_done stamp='0.330'/>
+</parse>
+<phase_done name='parse_hir' stamp='0.330'/>
+</phase>
+<parse_done stamp='0.330'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.330'>
+<phase_done name='optimize_blocks' stamp='0.330'/>
+</phase>
+<phase name='gvn' stamp='0.330'>
+<phase_done name='gvn' stamp='0.330'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.330'>
+<phase_done name='rangeCheckElimination' stamp='0.330'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.331'>
+<phase_done name='optimize_null_checks' stamp='0.331'/>
+</phase>
+<phase_done name='buildIR' stamp='0.331'/>
+</phase>
+<phase name='emit_lir' stamp='0.331'>
+<phase name='lirGeneration' stamp='0.331'>
+<phase_done name='lirGeneration' stamp='0.331'/>
+</phase>
+<phase name='linearScan' stamp='0.331'>
+<phase_done name='linearScan' stamp='0.331'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.331'/>
+</phase>
+<phase name='codeemit' stamp='0.331'>
+<phase_done name='codeemit' stamp='0.331'/>
+</phase>
+<phase name='codeinstall' stamp='0.331'>
+<phase_done name='codeinstall' stamp='0.331'/>
+</phase>
+<code_cache total_blobs='583' nmethods='207' adapters='225' free_code_cache='248412928'/>
+<task_done success='1' nmsize='2968' count='259' inlined_bytes='68' stamp='0.331'/>
+</task>
+<task compile_id='219' method='java.lang.StringBuilder append (C)Ljava/lang/StringBuilder;' bytes='8' count='256' iicount='256' level='3' stamp='0.336'>
+<phase name='setup' stamp='0.336'>
+<phase_done name='setup' stamp='0.336'/>
+</phase>
+<phase name='buildIR' stamp='0.336'>
+<klass id='1050' name='java.lang.StringBuilder' flags='17'/>
+<type id='970' name='char'/>
+<method id='1093' holder='1050' name='append' return='1050' arguments='970' flags='1' bytes='8' iicount='257'/>
+<parse method='1093'  stamp='0.336'>
+<phase name='parse_hir' stamp='0.336'>
+<bc code='183' bci='2'/>
+<klass id='1048' name='java.lang.AbstractStringBuilder' flags='1024'/>
+<method id='1095' holder='1048' name='append' return='1048' arguments='970' flags='1' bytes='77' iicount='257'/>
+<call method='1095' instr='invokespecial'/>
+<inline_fail reason='callee is too large'/>
+<phase_done name='parse_hir' stamp='0.336'/>
+</phase>
+<parse_done stamp='0.336'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.336'>
+<phase_done name='optimize_blocks' stamp='0.336'/>
+</phase>
+<phase name='gvn' stamp='0.336'>
+<phase_done name='gvn' stamp='0.336'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.336'>
+<phase_done name='rangeCheckElimination' stamp='0.336'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.336'>
+<phase_done name='optimize_null_checks' stamp='0.336'/>
+</phase>
+<phase_done name='buildIR' stamp='0.336'/>
+</phase>
+<phase name='emit_lir' stamp='0.336'>
+<phase name='lirGeneration' stamp='0.336'>
+<phase_done name='lirGeneration' stamp='0.336'/>
+</phase>
+<phase name='linearScan' stamp='0.336'>
+<phase_done name='linearScan' stamp='0.337'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.337'/>
+</phase>
+<phase name='codeemit' stamp='0.337'>
+<phase_done name='codeemit' stamp='0.337'/>
+</phase>
+<phase name='codeinstall' stamp='0.337'>
+<phase_done name='codeinstall' stamp='0.337'/>
+</phase>
+<code_cache total_blobs='601' nmethods='216' adapters='232' free_code_cache='248399616'/>
+<task_done success='1' nmsize='392' count='257' stamp='0.337'/>
+</task>
+<task compile_id='222' method='java.lang.invoke.MemberName testAnyFlags (I)Z' bytes='15' count='263' iicount='263' level='3' stamp='0.337'>
+<phase name='setup' stamp='0.337'>
+<phase_done name='setup' stamp='0.337'/>
+</phase>
+<phase name='buildIR' stamp='0.337'>
+<type id='969' name='boolean'/>
+<type id='975' name='int'/>
+<klass id='1038' name='java.lang.invoke.MemberName' flags='16'/>
+<method id='1093' holder='1038' name='testAnyFlags' return='969' arguments='975' flags='2' bytes='15' iicount='265'/>
+<parse method='1093'  stamp='0.337'>
+<phase name='parse_hir' stamp='0.337'>
+<bc code='183' bci='3'/>
+<method id='1095' holder='1038' name='testFlags' return='969' arguments='975 975' flags='2' bytes='16' compile_id='210' compiler='c1' level='3' iicount='403'/>
+<call method='1095' instr='invokespecial'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1095'>
+<parse_done stamp='0.337'/>
+</parse>
+<phase_done name='parse_hir' stamp='0.337'/>
+</phase>
+<parse_done stamp='0.337'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.337'>
+<phase_done name='optimize_blocks' stamp='0.337'/>
+</phase>
+<phase name='gvn' stamp='0.337'>
+<phase_done name='gvn' stamp='0.337'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.337'>
+<phase_done name='rangeCheckElimination' stamp='0.337'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.337'>
+<phase_done name='optimize_null_checks' stamp='0.337'/>
+</phase>
+<phase_done name='buildIR' stamp='0.337'/>
+</phase>
+<phase name='emit_lir' stamp='0.337'>
+<phase name='lirGeneration' stamp='0.337'>
+<phase_done name='lirGeneration' stamp='0.337'/>
+</phase>
+<phase name='linearScan' stamp='0.337'>
+<phase_done name='linearScan' stamp='0.337'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.337'/>
+</phase>
+<phase name='codeemit' stamp='0.337'>
+<phase_done name='codeemit' stamp='0.337'/>
+</phase>
+<phase name='codeinstall' stamp='0.337'>
+<phase_done name='codeinstall' stamp='0.337'/>
+</phase>
+<code_cache total_blobs='605' nmethods='220' adapters='232' free_code_cache='248392704'/>
+<task_done success='1' nmsize='624' count='281' inlined_bytes='16' stamp='0.337'/>
+</task>
+<task compile_id='223' method='jdk.internal.org.objectweb.asm.Item set (ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;)V' bytes='219' count='276' iicount='276' level='3' stamp='0.339'>
+<phase name='setup' stamp='0.339'>
+<phase_done name='setup' stamp='0.339'/>
+</phase>
+<phase name='buildIR' stamp='0.339'>
+<type id='977' name='void'/>
+<type id='975' name='int'/>
+<klass id='983' name='java.lang.String' flags='17'/>
+<klass id='1093' name='jdk.internal.org.objectweb.asm.Item' flags='16'/>
+<method id='1094' holder='1093' name='set' return='977' arguments='975 983 983 983' flags='0' bytes='219' iicount='276'/>
+<parse method='1094'  stamp='0.339'>
+<phase name='parse_hir' stamp='0.339'>
+<bc code='182' bci='180'/>
+<method id='1096' holder='983' name='hashCode' return='975' flags='1' bytes='49' compile_id='81' compiler='c2' level='4' iicount='6415'/>
+<call method='1096' instr='invokevirtual'/>
+<inline_fail reason='callee is too large'/>
+<bc code='182' bci='184'/>
+<call method='1096' instr='invokevirtual'/>
+<inline_fail reason='callee is too large'/>
+<bc code='182' bci='166'/>
+<call method='1096' instr='invokevirtual'/>
+<inline_fail reason='callee is too large'/>
+<bc code='182' bci='199'/>
+<call method='1096' instr='invokevirtual'/>
+<inline_fail reason='callee is too large'/>
+<bc code='182' bci='203'/>
+<call method='1096' instr='invokevirtual'/>
+<inline_fail reason='callee is too large'/>
+<bc code='182' bci='209'/>
+<call method='1096' instr='invokevirtual'/>
+<inline_fail reason='callee is too large'/>
+<phase_done name='parse_hir' stamp='0.339'/>
+</phase>
+<parse_done stamp='0.339'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.339'>
+<phase_done name='optimize_blocks' stamp='0.339'/>
+</phase>
+<phase name='gvn' stamp='0.339'>
+<phase_done name='gvn' stamp='0.339'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.339'>
+<phase_done name='rangeCheckElimination' stamp='0.339'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.339'>
+<phase_done name='optimize_null_checks' stamp='0.339'/>
+</phase>
+<phase_done name='buildIR' stamp='0.339'/>
+</phase>
+<phase name='emit_lir' stamp='0.339'>
+<phase name='lirGeneration' stamp='0.339'>
+<phase_done name='lirGeneration' stamp='0.339'/>
+</phase>
+<phase name='linearScan' stamp='0.339'>
+<phase_done name='linearScan' stamp='0.339'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.339'/>
+</phase>
+<phase name='codeemit' stamp='0.339'>
+<phase_done name='codeemit' stamp='0.339'/>
+</phase>
+<phase name='codeinstall' stamp='0.339'>
+<phase_done name='codeinstall' stamp='0.339'/>
+</phase>
+<code_cache total_blobs='611' nmethods='224' adapters='234' free_code_cache='248382592'/>
+<task_done success='1' nmsize='1976' count='291' stamp='0.339'/>
+</task>
+</compilation_log>
+<compilation_log thread='23815'>
+<start_compile_thread name='C1 CompilerThread10' thread='23815' process='23756' stamp='0.180'/>
+<task compile_id='3' method='java.lang.StringLatin1 equals ([B[B)Z' bytes='36' count='256' backedge_count='325' iicount='256' level='3' stamp='0.185'>
+<phase name='setup' stamp='0.185'>
+<phase_done name='setup' stamp='0.185'/>
+</phase>
+<phase name='buildIR' stamp='0.186'>
+<type id='969' name='boolean'/>
+<klass id='1085' name='[B' flags='1041'/>
+<klass id='1093' name='java.lang.StringLatin1' flags='16'/>
+<method id='1094' holder='1093' name='equals' return='969' arguments='1085 1085' flags='9' bytes='36' iicount='256'/>
+<parse method='1094'  stamp='0.186'>
+<phase name='parse_hir' stamp='0.186'>
+<phase_done name='parse_hir' stamp='0.186'/>
+</phase>
+<parse_done stamp='0.186'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.186'>
+<phase_done name='optimize_blocks' stamp='0.186'/>
+</phase>
+<phase name='gvn' stamp='0.186'>
+<phase_done name='gvn' stamp='0.186'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.186'>
+<phase_done name='rangeCheckElimination' stamp='0.186'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.186'>
+<phase_done name='optimize_null_checks' stamp='0.186'/>
+</phase>
+<phase_done name='buildIR' stamp='0.186'/>
+</phase>
+<phase name='emit_lir' stamp='0.186'>
+<phase name='lirGeneration' stamp='0.186'>
+<phase_done name='lirGeneration' stamp='0.186'/>
+</phase>
+<phase name='linearScan' stamp='0.186'>
+<phase_done name='linearScan' stamp='0.186'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.186'/>
+</phase>
+<phase name='codeemit' stamp='0.186'>
+<phase_done name='codeemit' stamp='0.186'/>
+</phase>
+<phase name='codeinstall' stamp='0.186'>
+<phase_done name='codeinstall' stamp='0.186'/>
+</phase>
+<code_cache total_blobs='239' nmethods='3' adapters='135' free_code_cache='248785536'/>
+<task_done success='1' nmsize='688' count='256' backedge_count='325' stamp='0.186'/>
+</task>
+<task compile_id='7' method='java.lang.StringLatin1 charAt ([BI)C' bytes='28' count='566' iicount='566' level='3' stamp='0.195'>
+<phase name='setup' stamp='0.195'>
+<phase_done name='setup' stamp='0.195'/>
+</phase>
+<phase name='buildIR' stamp='0.195'>
+<type id='970' name='char'/>
+<klass id='1085' name='[B' flags='1041'/>
+<type id='975' name='int'/>
+<klass id='1093' name='java.lang.StringLatin1' flags='16'/>
+<method id='1094' holder='1093' name='charAt' return='970' arguments='1085 975' flags='9' bytes='28' iicount='588'/>
+<parse method='1094'  stamp='0.195'>
+<phase name='parse_hir' stamp='0.195'>
+<bc code='183' bci='15'/>
+<type id='977' name='void'/>
+<klass id='1096' name='java.lang.StringIndexOutOfBoundsException' unloaded='1'/>
+<method id='1097' holder='1096' name='&lt;init&gt;' return='977' arguments='975' unloaded='1'/>
+<call method='1097' instr='invokespecial'/>
+<inline_fail reason='not inlineable'/>
+<phase_done name='parse_hir' stamp='0.195'/>
+</phase>
+<parse_done stamp='0.195'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.195'>
+<phase_done name='optimize_blocks' stamp='0.195'/>
+</phase>
+<phase name='gvn' stamp='0.195'>
+<phase_done name='gvn' stamp='0.195'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.195'>
+<phase_done name='rangeCheckElimination' stamp='0.195'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.195'>
+<phase_done name='optimize_null_checks' stamp='0.195'/>
+</phase>
+<phase_done name='buildIR' stamp='0.195'/>
+</phase>
+<phase name='emit_lir' stamp='0.195'>
+<phase name='lirGeneration' stamp='0.195'>
+<phase_done name='lirGeneration' stamp='0.195'/>
+</phase>
+<phase name='linearScan' stamp='0.195'>
+<phase_done name='linearScan' stamp='0.195'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.195'/>
+</phase>
+<phase name='codeemit' stamp='0.195'>
+<phase_done name='codeemit' stamp='0.196'/>
+</phase>
+<phase name='codeinstall' stamp='0.196'>
+<phase_done name='codeinstall' stamp='0.196'/>
+</phase>
+<code_cache total_blobs='298' nmethods='6' adapters='151' free_code_cache='248769408'/>
+<task_done success='1' nmsize='584' count='622' stamp='0.196'/>
+</task>
+<task compile_id='10' method='java.lang.String hashCode ()I' bytes='49' count='323' iicount='323' level='3' stamp='0.207'>
+<phase name='setup' stamp='0.207'>
+<phase_done name='setup' stamp='0.207'/>
+</phase>
+<phase name='buildIR' stamp='0.207'>
+<type id='975' name='int'/>
+<klass id='983' name='java.lang.String' flags='17'/>
+<method id='1093' holder='983' name='hashCode' return='975' flags='1' bytes='49' iicount='349'/>
+<parse method='1093'  stamp='0.207'>
+<phase name='parse_hir' stamp='0.207'>
+<bc code='183' bci='19'/>
+<type id='969' name='boolean'/>
+<method id='1095' holder='983' name='isLatin1' return='969' flags='2' bytes='19' compile_id='5' compiler='c1' level='3' iicount='1323'/>
+<call method='1095' instr='invokespecial'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1095'>
+<parse_done stamp='0.207'/>
+</parse>
+<bc code='184' bci='29'/>
+<klass id='1085' name='[B' flags='1041'/>
+<klass id='1098' name='java.lang.StringLatin1' flags='16'/>
+<method id='1099' holder='1098' name='hashCode' return='975' arguments='1085' flags='9' bytes='42' compile_id='2' compiler='c1' level='3' iicount='257'/>
+<call method='1099' instr='invokestatic'/>
+<inline_fail reason='callee is too large'/>
+<bc code='184' bci='39'/>
+<klass id='1101' name='java.lang.StringUTF16' flags='16'/>
+<method id='1102' holder='1101' name='hashCode' return='975' arguments='1085' flags='9' bytes='33' iicount='1'/>
+<call method='1102' instr='invokestatic'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1102'>
+<bc code='184' bci='20'/>
+<type id='970' name='char'/>
+<method id='1104' holder='1101' name='getChar' return='970' arguments='1085 975' flags='8' bytes='60' compile_id='1' compiler='c1' level='3' iicount='512'/>
+<call method='1104' instr='invokestatic'/>
+<inline_success reason='intrinsic'/>
+<parse_done stamp='0.207'/>
+</parse>
+<phase_done name='parse_hir' stamp='0.208'/>
+</phase>
+<parse_done stamp='0.208'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.208'>
+<phase_done name='optimize_blocks' stamp='0.208'/>
+</phase>
+<phase name='gvn' stamp='0.208'>
+<phase_done name='gvn' stamp='0.208'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.208'>
+<phase_done name='rangeCheckElimination' stamp='0.208'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.208'>
+<phase_done name='optimize_null_checks' stamp='0.208'/>
+</phase>
+<phase_done name='buildIR' stamp='0.208'/>
+</phase>
+<phase name='emit_lir' stamp='0.208'>
+<phase name='lirGeneration' stamp='0.208'>
+<phase_done name='lirGeneration' stamp='0.208'/>
+</phase>
+<phase name='linearScan' stamp='0.208'>
+<phase_done name='linearScan' stamp='0.208'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.208'/>
+</phase>
+<phase name='codeemit' stamp='0.208'>
+<phase_done name='codeemit' stamp='0.208'/>
+</phase>
+<phase name='codeinstall' stamp='0.208'>
+<phase_done name='codeinstall' stamp='0.208'/>
+</phase>
+<code_cache total_blobs='308' nmethods='10' adapters='158' free_code_cache='248758016'/>
+<task_done success='1' nmsize='1128' count='635' inlined_bytes='52' stamp='0.208'/>
+</task>
+<task compile_id='14' method='java.util.ImmutableCollections$Set0 hashCode ()I' bytes='2' count='140' iicount='140' level='1' stamp='0.210'>
+<phase name='setup' stamp='0.210'>
+<phase_done name='setup' stamp='0.210'/>
+</phase>
+<phase name='buildIR' stamp='0.210'>
+<type id='975' name='int'/>
+<klass id='1093' name='java.util.ImmutableCollections$Set0' flags='24'/>
+<method id='1094' holder='1093' name='hashCode' return='975' flags='1' bytes='2' iicount='145'/>
+<parse method='1094'  stamp='0.210'>
+<phase name='parse_hir' stamp='0.210'>
+<phase_done name='parse_hir' stamp='0.210'/>
+</phase>
+<parse_done stamp='0.210'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.210'>
+<phase_done name='optimize_blocks' stamp='0.210'/>
+</phase>
+<phase name='gvn' stamp='0.210'>
+<phase_done name='gvn' stamp='0.210'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.210'>
+<phase_done name='rangeCheckElimination' stamp='0.210'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.210'>
+<phase_done name='optimize_null_checks' stamp='0.210'/>
+</phase>
+<phase_done name='buildIR' stamp='0.210'/>
+</phase>
+<phase name='emit_lir' stamp='0.210'>
+<phase name='lirGeneration' stamp='0.210'>
+<phase_done name='lirGeneration' stamp='0.210'/>
+</phase>
+<phase name='linearScan' stamp='0.210'>
+<phase_done name='linearScan' stamp='0.210'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.210'/>
+</phase>
+<phase name='codeemit' stamp='0.210'>
+<phase_done name='codeemit' stamp='0.211'/>
+</phase>
+<phase name='codeinstall' stamp='0.211'>
+<phase_done name='codeinstall' stamp='0.211'/>
+</phase>
+<code_cache total_blobs='313' nmethods='14' adapters='158' free_code_cache='248750208'/>
+<task_done success='1' nmsize='272' count='177' stamp='0.211'/>
+</task>
+<task compile_id='15' method='java.util.Objects equals (Ljava/lang/Object;Ljava/lang/Object;)Z' bytes='23' count='281' iicount='281' level='3' stamp='0.211'>
+<phase name='setup' stamp='0.211'>
+<phase_done name='setup' stamp='0.211'/>
+</phase>
+<phase name='buildIR' stamp='0.211'>
+<type id='969' name='boolean'/>
+<klass id='982' name='java.lang.Object' flags='1'/>
+<klass id='1093' name='java.util.Objects' flags='17'/>
+<method id='1094' holder='1093' name='equals' return='969' arguments='982 982' flags='9' bytes='23' iicount='281'/>
+<parse method='1094'  stamp='0.211'>
+<phase name='parse_hir' stamp='0.211'>
+<bc code='182' bci='11'/>
+<method id='1096' holder='982' name='equals' return='969' arguments='982' flags='1' bytes='11' iicount='1'/>
+<call method='1096' instr='invokevirtual'/>
+<inline_fail reason='no static binding'/>
+<phase_done name='parse_hir' stamp='0.211'/>
+</phase>
+<parse_done stamp='0.211'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.211'>
+<phase_done name='optimize_blocks' stamp='0.211'/>
+</phase>
+<phase name='gvn' stamp='0.211'>
+<phase_done name='gvn' stamp='0.211'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.211'>
+<phase_done name='rangeCheckElimination' stamp='0.211'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.211'>
+<phase_done name='optimize_null_checks' stamp='0.211'/>
+</phase>
+<phase_done name='buildIR' stamp='0.211'/>
+</phase>
+<phase name='emit_lir' stamp='0.211'>
+<phase name='lirGeneration' stamp='0.211'>
+<phase_done name='lirGeneration' stamp='0.211'/>
+</phase>
+<phase name='linearScan' stamp='0.211'>
+<phase_done name='linearScan' stamp='0.211'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.211'/>
+</phase>
+<phase name='codeemit' stamp='0.211'>
+<phase_done name='codeemit' stamp='0.211'/>
+</phase>
+<phase name='codeinstall' stamp='0.211'>
+<phase_done name='codeinstall' stamp='0.211'/>
+</phase>
+<code_cache total_blobs='314' nmethods='15' adapters='158' free_code_cache='248748800'/>
+<task_done success='1' nmsize='712' count='289' stamp='0.211'/>
+</task>
+<task compile_id='16' method='java.util.Collections emptySet ()Ljava/util/Set;' bytes='4' count='268' iicount='268' level='3' stamp='0.211'>
+<phase name='setup' stamp='0.211'>
+<phase_done name='setup' stamp='0.211'/>
+</phase>
+<phase name='buildIR' stamp='0.211'>
+<klass id='1094' name='java.util.Set' flags='1537'/>
+<klass id='1093' name='java.util.Collections' flags='1'/>
+<method id='1095' holder='1093' name='emptySet' return='1094' flags='25' bytes='4' iicount='268'/>
+<parse method='1095'  stamp='0.211'>
+<phase name='parse_hir' stamp='0.211'>
+<phase_done name='parse_hir' stamp='0.211'/>
+</phase>
+<parse_done stamp='0.211'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.211'>
+<phase_done name='optimize_blocks' stamp='0.211'/>
+</phase>
+<phase name='gvn' stamp='0.211'>
+<phase_done name='gvn' stamp='0.211'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.211'>
+<phase_done name='rangeCheckElimination' stamp='0.211'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.211'>
+<phase_done name='optimize_null_checks' stamp='0.211'/>
+</phase>
+<phase_done name='buildIR' stamp='0.211'/>
+</phase>
+<phase name='emit_lir' stamp='0.211'>
+<phase name='lirGeneration' stamp='0.211'>
+<phase_done name='lirGeneration' stamp='0.211'/>
+</phase>
+<phase name='linearScan' stamp='0.211'>
+<phase_done name='linearScan' stamp='0.211'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.211'/>
+</phase>
+<phase name='codeemit' stamp='0.211'>
+<phase_done name='codeemit' stamp='0.211'/>
+</phase>
+<phase name='codeinstall' stamp='0.211'>
+<phase_done name='codeinstall' stamp='0.211'/>
+</phase>
+<code_cache total_blobs='315' nmethods='16' adapters='158' free_code_cache='248747904'/>
+<task_done success='1' nmsize='304' count='268' stamp='0.211'/>
+</task>
+<task compile_id='17' method='java.util.Collections$EmptySet hashCode ()I' bytes='2' count='151' iicount='151' level='1' stamp='0.211'>
+<phase name='setup' stamp='0.211'>
+<phase_done name='setup' stamp='0.211'/>
+</phase>
+<phase name='buildIR' stamp='0.211'>
+<type id='975' name='int'/>
+<klass id='1093' name='java.util.Collections$EmptySet' flags='10'/>
+<method id='1094' holder='1093' name='hashCode' return='975' flags='1' bytes='2' iicount='151'/>
+<parse method='1094'  stamp='0.211'>
+<phase name='parse_hir' stamp='0.211'>
+<phase_done name='parse_hir' stamp='0.211'/>
+</phase>
+<parse_done stamp='0.211'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.211'>
+<phase_done name='optimize_blocks' stamp='0.211'/>
+</phase>
+<phase name='gvn' stamp='0.211'>
+<phase_done name='gvn' stamp='0.211'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.211'>
+<phase_done name='rangeCheckElimination' stamp='0.211'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.211'>
+<phase_done name='optimize_null_checks' stamp='0.211'/>
+</phase>
+<phase_done name='buildIR' stamp='0.211'/>
+</phase>
+<phase name='emit_lir' stamp='0.211'>
+<phase name='lirGeneration' stamp='0.211'>
+<phase_done name='lirGeneration' stamp='0.211'/>
+</phase>
+<phase name='linearScan' stamp='0.211'>
+<phase_done name='linearScan' stamp='0.211'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.211'/>
+</phase>
+<phase name='codeemit' stamp='0.211'>
+<phase_done name='codeemit' stamp='0.211'/>
+</phase>
+<phase name='codeinstall' stamp='0.211'>
+<phase_done name='codeinstall' stamp='0.212'/>
+</phase>
+<code_cache total_blobs='316' nmethods='17' adapters='158' free_code_cache='248747136'/>
+<task_done success='1' nmsize='272' count='151' stamp='0.212'/>
+</task>
+<task compile_id='22' method='java.lang.module.ModuleDescriptor$Exports hashCode ()I' bytes='38' count='279' iicount='279' level='3' stamp='0.212'>
+<phase name='setup' stamp='0.212'>
+<phase_done name='setup' stamp='0.212'/>
+</phase>
+<phase name='buildIR' stamp='0.212'>
+<type id='975' name='int'/>
+<klass id='1093' name='java.lang.module.ModuleDescriptor$Exports' flags='25'/>
+<method id='1094' holder='1093' name='hashCode' return='975' flags='1' bytes='38' iicount='282'/>
+<parse method='1094'  stamp='0.212'>
+<phase name='parse_hir' stamp='0.212'>
+<bc code='185' bci='4'/>
+<klass id='1096' name='java.util.Set' flags='1537'/>
+<method id='1097' holder='1096' name='hashCode' return='975' flags='1025' bytes='0' iicount='1'/>
+<call method='1097' instr='invokeinterface'/>
+<inline_fail reason='no static binding'/>
+<bc code='182' bci='18'/>
+<klass id='983' name='java.lang.String' flags='17'/>
+<method id='1098' holder='983' name='hashCode' return='975' flags='1' bytes='49' compile_id='10' compiler='c1' level='3' iicount='1670'/>
+<call method='1098' instr='invokevirtual'/>
+<inline_fail reason='callee is too large'/>
+<bc code='185' bci='31'/>
+<call method='1097' instr='invokeinterface'/>
+<inline_fail reason='no static binding'/>
+<phase_done name='parse_hir' stamp='0.212'/>
+</phase>
+<parse_done stamp='0.212'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.212'>
+<phase_done name='optimize_blocks' stamp='0.212'/>
+</phase>
+<phase name='gvn' stamp='0.212'>
+<phase_done name='gvn' stamp='0.213'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.213'>
+<phase_done name='rangeCheckElimination' stamp='0.213'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.213'>
+<phase_done name='optimize_null_checks' stamp='0.213'/>
+</phase>
+<phase_done name='buildIR' stamp='0.213'/>
+</phase>
+<phase name='emit_lir' stamp='0.213'>
+<phase name='lirGeneration' stamp='0.213'>
+<phase_done name='lirGeneration' stamp='0.213'/>
+</phase>
+<phase name='linearScan' stamp='0.213'>
+<phase_done name='linearScan' stamp='0.213'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.213'/>
+</phase>
+<phase name='codeemit' stamp='0.213'>
+<phase_done name='codeemit' stamp='0.213'/>
+</phase>
+<phase name='codeinstall' stamp='0.213'>
+<phase_done name='codeinstall' stamp='0.213'/>
+</phase>
+<code_cache total_blobs='320' nmethods='21' adapters='158' free_code_cache='248741248'/>
+<task_done success='1' nmsize='1000' count='316' stamp='0.213'/>
+</task>
+<task compile_id='26' method='java.util.Set of ([Ljava/lang/Object;)Ljava/util/Set;' bytes='66' count='265' iicount='265' level='3' stamp='0.215'>
+<phase name='setup' stamp='0.215'>
+<phase_done name='setup' stamp='0.215'/>
+</phase>
+<phase name='buildIR' stamp='0.215'>
+<klass id='1093' name='java.util.Set' flags='1537'/>
+<klass id='1094' name='[Ljava.lang.Object;' flags='1041'/>
+<method id='1095' holder='1093' name='of' return='1093' arguments='1094' flags='137' bytes='66' iicount='265'/>
+<parse method='1095'  stamp='0.215'>
+<phase name='parse_hir' stamp='0.215'>
+<bc code='184' bci='28'/>
+<klass id='1097' name='java.util.ImmutableCollections$Set0' flags='24'/>
+<method id='1098' holder='1097' name='instance' return='1097' flags='8' bytes='4' iicount='103'/>
+<call method='1098' instr='invokestatic'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1098'>
+<parse_done stamp='0.215'/>
+</parse>
+<bc code='183' bci='39'/>
+<type id='977' name='void'/>
+<klass id='982' name='java.lang.Object' flags='1'/>
+<klass id='1102' name='java.util.ImmutableCollections$Set1' flags='24'/>
+<method id='1103' holder='1102' name='&lt;init&gt;' return='977' arguments='982' flags='0' bytes='13' iicount='132'/>
+<call method='1103' instr='invokespecial'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1103'>
+<bc code='183' bci='1'/>
+<klass id='1105' name='java.util.ImmutableCollections$AbstractImmutableSet' flags='1032'/>
+<method id='1106' holder='1105' name='&lt;init&gt;' return='977' flags='0' bytes='5' compile_id='25' compiler='c1' level='3' iicount='370'/>
+<call method='1106' instr='invokespecial'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1106'>
+<bc code='183' bci='1'/>
+<klass id='1108' name='java.util.AbstractSet' flags='1025'/>
+<method id='1109' holder='1108' name='&lt;init&gt;' return='977' flags='4' bytes='5' compile_id='24' compiler='c1' level='3' iicount='372'/>
+<call method='1109' instr='invokespecial'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1109'>
+<bc code='183' bci='1'/>
+<klass id='1111' name='java.util.AbstractCollection' flags='1025'/>
+<method id='1112' holder='1111' name='&lt;init&gt;' return='977' flags='4' bytes='5' compile_id='23' compiler='c1' level='3' iicount='437'/>
+<call method='1112' instr='invokespecial'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1112'>
+<bc code='183' bci='1'/>
+<method id='1114' holder='982' name='&lt;init&gt;' return='977' flags='1' bytes='1' compile_id='9' compiler='c1' level='3' iicount='2148'/>
+<call method='1114' instr='invokespecial'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1114'>
+<parse_done stamp='0.215'/>
+</parse>
+<parse_done stamp='0.215'/>
+</parse>
+<parse_done stamp='0.215'/>
+</parse>
+<parse_done stamp='0.215'/>
+</parse>
+<bc code='184' bci='6'/>
+<klass id='1116' name='java.util.Objects' flags='17'/>
+<method id='1117' holder='1116' name='requireNonNull' return='982' arguments='982' flags='9' bytes='14' compile_id='21' compiler='c1' level='3' iicount='583'/>
+<call method='1117' instr='invokestatic'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1117'>
+<bc code='183' bci='8'/>
+<klass id='1089' name='java.lang.NullPointerException' flags='1'/>
+<method id='1119' holder='1089' name='&lt;init&gt;' return='977' flags='1' bytes='5' iicount='1'/>
+<call method='1119' instr='invokespecial'/>
+<inline_fail reason='don&apos;t inline Throwable constructors'/>
+<parse_done stamp='0.215'/>
+</parse>
+<parse_done stamp='0.215'/>
+</parse>
+<bc code='183' bci='53'/>
+<klass id='1121' name='java.util.ImmutableCollections$Set2' flags='24'/>
+<method id='1122' holder='1121' name='&lt;init&gt;' return='977' arguments='982 982' flags='0' bytes='72' iicount='76'/>
+<call method='1122' instr='invokespecial'/>
+<inline_fail reason='callee is too large'/>
+<bc code='183' bci='62'/>
+<klass id='1124' name='java.util.ImmutableCollections$SetN' flags='24'/>
+<method id='1125' holder='1124' name='&lt;init&gt;' return='977' arguments='1094' flags='128' bytes='90' iicount='166'/>
+<call method='1125' instr='invokespecial'/>
+<inline_fail reason='callee is too large'/>
+<phase_done name='parse_hir' stamp='0.215'/>
+</phase>
+<parse_done stamp='0.215'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.215'>
+<phase_done name='optimize_blocks' stamp='0.215'/>
+</phase>
+<phase name='gvn' stamp='0.215'>
+<phase_done name='gvn' stamp='0.215'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.215'>
+<phase_done name='rangeCheckElimination' stamp='0.215'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.215'>
+<phase_done name='optimize_null_checks' stamp='0.215'/>
+</phase>
+<phase_done name='buildIR' stamp='0.215'/>
+</phase>
+<phase name='emit_lir' stamp='0.215'>
+<phase name='lirGeneration' stamp='0.215'>
+<phase_done name='lirGeneration' stamp='0.215'/>
+</phase>
+<phase name='linearScan' stamp='0.215'>
+<phase_done name='linearScan' stamp='0.216'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.216'/>
+</phase>
+<phase name='codeemit' stamp='0.216'>
+<phase_done name='codeemit' stamp='0.216'/>
+</phase>
+<phase name='codeinstall' stamp='0.216'>
+<phase_done name='codeinstall' stamp='0.216'/>
+</phase>
+<code_cache total_blobs='327' nmethods='28' adapters='158' free_code_cache='248729984'/>
+<task_done success='1' nmsize='1896' count='309' inlined_bytes='47' stamp='0.216'/>
+</task>
+<task compile_id='33' method='java.lang.module.ModuleDescriptor$1 newExports (Ljava/util/Set;Ljava/lang/String;)Ljava/lang/module/ModuleDescriptor$Exports;' bytes='15' count='272' iicount='272' level='3' stamp='0.216'>
+<phase name='setup' stamp='0.216'>
+<phase_done name='setup' stamp='0.216'/>
+</phase>
+<phase name='buildIR' stamp='0.216'>
+<klass id='1095' name='java.lang.module.ModuleDescriptor$Exports' flags='25'/>
+<klass id='1094' name='java.util.Set' flags='1537'/>
+<klass id='983' name='java.lang.String' flags='17'/>
+<klass id='1093' name='java.lang.module.ModuleDescriptor$1' flags='0'/>
+<method id='1096' holder='1093' name='newExports' return='1095' arguments='1094 983' flags='1' bytes='15' iicount='272'/>
+<parse method='1096'  stamp='0.216'>
+<phase name='parse_hir' stamp='0.216'>
+<bc code='184' bci='6'/>
+<klass id='1098' name='java.util.Collections' flags='1'/>
+<method id='1099' holder='1098' name='emptySet' return='1094' flags='25' bytes='4' compile_id='16' compiler='c1' level='3' iicount='716'/>
+<call method='1099' instr='invokestatic'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1099'>
+<parse_done stamp='0.216'/>
+</parse>
+<bc code='183' bci='11'/>
+<type id='977' name='void'/>
+<type id='969' name='boolean'/>
+<method id='1104' holder='1095' name='&lt;init&gt;' return='977' arguments='1094 983 1094 969 1093' flags='4096' bytes='10' compile_id='18' compiler='c1' level='3' iicount='636'/>
+<call method='1104' instr='invokespecial'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1104'>
+<bc code='183' bci='6'/>
+<method id='1106' holder='1095' name='&lt;init&gt;' return='977' arguments='1094 983 1094 969' flags='2' bytes='20' compile_id='19' compiler='c1' level='3' iicount='636'/>
+<call method='1106' instr='invokespecial'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1106'>
+<bc code='183' bci='1'/>
+<klass id='982' name='java.lang.Object' flags='1'/>
+<method id='1108' holder='982' name='&lt;init&gt;' return='977' flags='1' bytes='1' compile_id='9' compiler='c1' level='3' iicount='2312'/>
+<call method='1108' instr='invokespecial'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1108'>
+<parse_done stamp='0.216'/>
+</parse>
+<parse_done stamp='0.216'/>
+</parse>
+<parse_done stamp='0.216'/>
+</parse>
+<phase_done name='parse_hir' stamp='0.216'/>
+</phase>
+<parse_done stamp='0.216'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.216'>
+<phase_done name='optimize_blocks' stamp='0.216'/>
+</phase>
+<phase name='gvn' stamp='0.216'>
+<phase_done name='gvn' stamp='0.216'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.216'>
+<phase_done name='rangeCheckElimination' stamp='0.216'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.216'>
+<phase_done name='optimize_null_checks' stamp='0.216'/>
+</phase>
+<phase_done name='buildIR' stamp='0.216'/>
+</phase>
+<phase name='emit_lir' stamp='0.216'>
+<phase name='lirGeneration' stamp='0.216'>
+<phase_done name='lirGeneration' stamp='0.216'/>
+</phase>
+<phase name='linearScan' stamp='0.216'>
+<phase_done name='linearScan' stamp='0.216'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.216'/>
+</phase>
+<phase name='codeemit' stamp='0.216'>
+<phase_done name='codeemit' stamp='0.216'/>
+</phase>
+<phase name='codeinstall' stamp='0.216'>
+<phase_done name='codeinstall' stamp='0.216'/>
+</phase>
+<code_cache total_blobs='332' nmethods='31' adapters='158' free_code_cache='248724864'/>
+<task_done success='1' nmsize='1136' count='306' inlined_bytes='35' stamp='0.216'/>
+</task>
+<task compile_id='36' method='jdk.internal.module.Builder newRequires (Ljava/util/Set;Ljava/lang/String;Ljava/lang/String;)Ljava/lang/module/ModuleDescriptor$Requires;' bytes='51' count='258' iicount='258' level='3' stamp='0.217'>
+<phase name='setup' stamp='0.217'>
+<phase_done name='setup' stamp='0.217'/>
+</phase>
+<phase name='buildIR' stamp='0.217'>
+<klass id='1095' name='java.lang.module.ModuleDescriptor$Requires' flags='25'/>
+<klass id='1094' name='java.util.Set' flags='1537'/>
+<klass id='983' name='java.lang.String' flags='17'/>
+<klass id='1093' name='jdk.internal.module.Builder' flags='16'/>
+<method id='1096' holder='1093' name='newRequires' return='1095' arguments='1094 983 983' flags='9' bytes='51' iicount='262'/>
+<parse method='1096'  stamp='0.217'>
+<phase name='parse_hir' stamp='0.217'>
+<bc code='182' bci='19'/>
+<klass id='1099' name='java.lang.module.ModuleDescriptor$Version' flags='25'/>
+<method id='1101' holder='1099' name='toString' return='983' flags='1' bytes='5' iicount='83'/>
+<call method='1101' instr='invokevirtual'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1101'>
+<parse_done stamp='0.217'/>
+</parse>
+<bc code='182' bci='22'/>
+<type id='969' name='boolean'/>
+<klass id='982' name='java.lang.Object' flags='1'/>
+<method id='1103' holder='983' name='equals' return='969' arguments='982' flags='1' bytes='65' compile_id='8' compiler='c1' level='3' iicount='1918'/>
+<call method='1103' instr='invokevirtual'/>
+<inline_fail reason='callee is too large'/>
+<bc code='184' bci='35'/>
+<method id='1105' holder='1099' name='parse' return='1099' arguments='983' flags='9' bytes='9' iicount='1'/>
+<call method='1105' instr='invokestatic'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1105'>
+<bc code='183' bci='5'/>
+<type id='977' name='void'/>
+<method id='1107' holder='1099' name='&lt;init&gt;' return='977' arguments='983' flags='2' bytes='488' iicount='1'/>
+<call method='1107' instr='invokespecial'/>
+<inline_fail reason='callee is too large'/>
+<parse_done stamp='0.217'/>
+</parse>
+<bc code='185' bci='45'/>
+<klass id='1109' name='jdk.internal.misc.JavaLangModuleAccess' flags='1537'/>
+<method id='1111' holder='1109' name='newRequires' return='1095' arguments='1094 983 1099' flags='1025' bytes='0' iicount='1'/>
+<call method='1111' instr='invokeinterface'/>
+<inline_success reason='receiver is statically known'/>
+<klass id='1098' name='java.lang.module.ModuleDescriptor$1' flags='0'/>
+<dependency type='leaf_type' ctxk='1098'/>
+<method id='1112' holder='1098' name='newRequires' return='1095' arguments='1094 983 1099' flags='1' bytes='13' iicount='322'/>
+<parse method='1112'>
+<bc code='183' bci='9'/>
+<method id='1114' holder='1095' name='&lt;init&gt;' return='977' arguments='1094 983 1099 969 1098' flags='4096' bytes='10' iicount='338'/>
+<call method='1114' instr='invokespecial'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1114'>
+<bc code='183' bci='6'/>
+<method id='1116' holder='1095' name='&lt;init&gt;' return='977' arguments='1094 983 1099 969' flags='2' bytes='25' iicount='347'/>
+<call method='1116' instr='invokespecial'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1116'>
+<bc code='183' bci='1'/>
+<method id='1118' holder='982' name='&lt;init&gt;' return='977' flags='1' bytes='1' compile_id='9' compiler='c1' level='3' iicount='2664'/>
+<call method='1118' instr='invokespecial'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1118'>
+<parse_done stamp='0.217'/>
+</parse>
+<parse_done stamp='0.217'/>
+</parse>
+<parse_done stamp='0.217'/>
+</parse>
+<parse_done stamp='0.217'/>
+</parse>
+<phase_done name='parse_hir' stamp='0.217'/>
+</phase>
+<parse_done stamp='0.217'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.217'>
+<phase_done name='optimize_blocks' stamp='0.217'/>
+</phase>
+<phase name='gvn' stamp='0.217'>
+<phase_done name='gvn' stamp='0.217'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.217'>
+<phase_done name='rangeCheckElimination' stamp='0.217'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.217'>
+<phase_done name='optimize_null_checks' stamp='0.217'/>
+</phase>
+<phase_done name='buildIR' stamp='0.217'/>
+</phase>
+<phase name='emit_lir' stamp='0.217'>
+<phase name='lirGeneration' stamp='0.217'>
+<phase_done name='lirGeneration' stamp='0.217'/>
+</phase>
+<phase name='linearScan' stamp='0.217'>
+<phase_done name='linearScan' stamp='0.218'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.218'/>
+</phase>
+<phase name='codeemit' stamp='0.218'>
+<phase_done name='codeemit' stamp='0.218'/>
+</phase>
+<phase name='codeinstall' stamp='0.218'>
+<dependency type='leaf_type' ctxk='1098'/>
+<phase_done name='codeinstall' stamp='0.218'/>
+</phase>
+<code_cache total_blobs='340' nmethods='39' adapters='158' free_code_cache='248704128'/>
+<task_done success='1' nmsize='2008' count='349' inlined_bytes='63' stamp='0.218'/>
+</task>
+<task compile_id='41' method='java.lang.module.ModuleDescriptor name ()Ljava/lang/String;' bytes='5' count='141' iicount='141' level='1' stamp='0.221'>
+<phase name='setup' stamp='0.221'>
+<phase_done name='setup' stamp='0.221'/>
+</phase>
+<phase name='buildIR' stamp='0.221'>
+<klass id='983' name='java.lang.String' flags='17'/>
+<klass id='1093' name='java.lang.module.ModuleDescriptor' flags='1'/>
+<method id='1094' holder='1093' name='name' return='983' flags='1' bytes='5' iicount='144'/>
+<parse method='1094'  stamp='0.221'>
+<phase name='parse_hir' stamp='0.221'>
+<phase_done name='parse_hir' stamp='0.221'/>
+</phase>
+<parse_done stamp='0.221'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.221'>
+<phase_done name='optimize_blocks' stamp='0.221'/>
+</phase>
+<phase name='gvn' stamp='0.221'>
+<phase_done name='gvn' stamp='0.221'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.221'>
+<phase_done name='rangeCheckElimination' stamp='0.221'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.221'>
+<phase_done name='optimize_null_checks' stamp='0.221'/>
+</phase>
+<phase_done name='buildIR' stamp='0.221'/>
+</phase>
+<phase name='emit_lir' stamp='0.221'>
+<phase name='lirGeneration' stamp='0.221'>
+<phase_done name='lirGeneration' stamp='0.221'/>
+</phase>
+<phase name='linearScan' stamp='0.221'>
+<phase_done name='linearScan' stamp='0.221'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.221'/>
+</phase>
+<phase name='codeemit' stamp='0.221'>
+<phase_done name='codeemit' stamp='0.221'/>
+</phase>
+<phase name='codeinstall' stamp='0.221'>
+<phase_done name='codeinstall' stamp='0.221'/>
+</phase>
+<code_cache total_blobs='342' nmethods='41' adapters='158' free_code_cache='248700800'/>
+<task_done success='1' nmsize='272' count='168' stamp='0.221'/>
+</task>
+<task compile_id='46' method='java.lang.module.ModuleReference descriptor ()Ljava/lang/module/ModuleDescriptor;' bytes='5' count='153' iicount='153' level='1' stamp='0.222'>
+<phase name='setup' stamp='0.222'>
+<phase_done name='setup' stamp='0.222'/>
+</phase>
+<phase name='buildIR' stamp='0.222'>
+<klass id='1094' name='java.lang.module.ModuleDescriptor' flags='1'/>
+<klass id='1093' name='java.lang.module.ModuleReference' flags='1025'/>
+<method id='1095' holder='1093' name='descriptor' return='1094' flags='17' bytes='5' iicount='183'/>
+<parse method='1095'  stamp='0.222'>
+<phase name='parse_hir' stamp='0.222'>
+<phase_done name='parse_hir' stamp='0.222'/>
+</phase>
+<parse_done stamp='0.222'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.222'>
+<phase_done name='optimize_blocks' stamp='0.222'/>
+</phase>
+<phase name='gvn' stamp='0.222'>
+<phase_done name='gvn' stamp='0.222'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.222'>
+<phase_done name='rangeCheckElimination' stamp='0.222'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.222'>
+<phase_done name='optimize_null_checks' stamp='0.222'/>
+</phase>
+<phase_done name='buildIR' stamp='0.222'/>
+</phase>
+<phase name='emit_lir' stamp='0.222'>
+<phase name='lirGeneration' stamp='0.222'>
+<phase_done name='lirGeneration' stamp='0.222'/>
+</phase>
+<phase name='linearScan' stamp='0.222'>
+<phase_done name='linearScan' stamp='0.222'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.222'/>
+</phase>
+<phase name='codeemit' stamp='0.222'>
+<phase_done name='codeemit' stamp='0.222'/>
+</phase>
+<phase name='codeinstall' stamp='0.222'>
+<phase_done name='codeinstall' stamp='0.222'/>
+</phase>
+<code_cache total_blobs='347' nmethods='46' adapters='158' free_code_cache='248695552'/>
+<task_done success='1' nmsize='272' count='243' stamp='0.222'/>
+</task>
+<task compile_id='48' method='java.net.URI toLower (C)I' bytes='19' count='261' iicount='261' level='3' stamp='0.222'>
+<phase name='setup' stamp='0.222'>
+<phase_done name='setup' stamp='0.222'/>
+</phase>
+<phase name='buildIR' stamp='0.222'>
+<type id='975' name='int'/>
+<type id='970' name='char'/>
+<klass id='1093' name='java.net.URI' flags='17'/>
+<method id='1094' holder='1093' name='toLower' return='975' arguments='970' flags='10' bytes='19' iicount='276'/>
+<parse method='1094'  stamp='0.222'>
+<phase name='parse_hir' stamp='0.222'>
+<phase_done name='parse_hir' stamp='0.222'/>
+</phase>
+<parse_done stamp='0.222'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.222'>
+<phase_done name='optimize_blocks' stamp='0.222'/>
+</phase>
+<phase name='gvn' stamp='0.222'>
+<phase_done name='gvn' stamp='0.222'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.222'>
+<phase_done name='rangeCheckElimination' stamp='0.222'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.222'>
+<phase_done name='optimize_null_checks' stamp='0.222'/>
+</phase>
+<phase_done name='buildIR' stamp='0.222'/>
+</phase>
+<phase name='emit_lir' stamp='0.222'>
+<phase name='lirGeneration' stamp='0.222'>
+<phase_done name='lirGeneration' stamp='0.222'/>
+</phase>
+<phase name='linearScan' stamp='0.222'>
+<phase_done name='linearScan' stamp='0.222'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.222'/>
+</phase>
+<phase name='codeemit' stamp='0.222'>
+<phase_done name='codeemit' stamp='0.222'/>
+</phase>
+<phase name='codeinstall' stamp='0.222'>
+<phase_done name='codeinstall' stamp='0.222'/>
+</phase>
+<code_cache total_blobs='348' nmethods='47' adapters='158' free_code_cache='248694528'/>
+<task_done success='1' nmsize='432' count='297' stamp='0.222'/>
+</task>
+<task compile_id='51' method='java.util.concurrent.ConcurrentHashMap tabAt ([Ljava/util/concurrent/ConcurrentHashMap$Node;I)Ljava/util/concurrent/ConcurrentHashMap$Node;' bytes='22' count='640' iicount='640' level='3' stamp='0.230'>
+<phase name='setup' stamp='0.230'>
+<phase_done name='setup' stamp='0.230'/>
+</phase>
+<phase name='buildIR' stamp='0.230'>
+<klass id='1094' name='java.util.concurrent.ConcurrentHashMap$Node' flags='8'/>
+<klass id='1095' name='[Ljava.util.concurrent.ConcurrentHashMap$Node;' flags='1040'/>
+<type id='975' name='int'/>
+<klass id='1093' name='java.util.concurrent.ConcurrentHashMap' flags='1'/>
+<method id='1096' holder='1093' name='tabAt' return='1094' arguments='1095 975' flags='24' bytes='22' iicount='640'/>
+<parse method='1096'  stamp='0.230'>
+<phase name='parse_hir' stamp='0.230'>
+<bc code='182' bci='15'/>
+<klass id='982' name='java.lang.Object' flags='1'/>
+<type id='976' name='long'/>
+<klass id='1051' name='jdk.internal.misc.Unsafe' flags='17'/>
+<method id='1100' holder='1051' name='getObjectAcquire' return='982' arguments='982 976' flags='17' bytes='7' iicount='640'/>
+<call method='1100' instr='invokevirtual'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1100'>
+<bc code='182' bci='3'/>
+<method id='1102' holder='1051' name='getObjectVolatile' return='982' arguments='982 976' flags='257' bytes='0' compile_id='53' compile_kind='c2n' compiler='' level='0' iicount='640'/>
+<call method='1102' instr='invokevirtual'/>
+<inline_success reason='intrinsic'/>
+<parse_done stamp='0.230'/>
+</parse>
+<phase_done name='parse_hir' stamp='0.230'/>
+</phase>
+<parse_done stamp='0.230'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.230'>
+<phase_done name='optimize_blocks' stamp='0.230'/>
+</phase>
+<phase name='gvn' stamp='0.230'>
+<phase_done name='gvn' stamp='0.230'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.230'>
+<phase_done name='rangeCheckElimination' stamp='0.230'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.230'>
+<phase_done name='optimize_null_checks' stamp='0.230'/>
+</phase>
+<phase_done name='buildIR' stamp='0.230'/>
+</phase>
+<phase name='emit_lir' stamp='0.230'>
+<phase name='lirGeneration' stamp='0.230'>
+<phase_done name='lirGeneration' stamp='0.230'/>
+</phase>
+<phase name='linearScan' stamp='0.230'>
+<phase_done name='linearScan' stamp='0.230'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.230'/>
+</phase>
+<phase name='codeemit' stamp='0.230'>
+<phase_done name='codeemit' stamp='0.230'/>
+</phase>
+<phase name='codeinstall' stamp='0.230'>
+<phase_done name='codeinstall' stamp='0.230'/>
+</phase>
+<code_cache total_blobs='358' nmethods='53' adapters='162' free_code_cache='248683904'/>
+<task_done success='1' nmsize='784' count='651' inlined_bytes='7' stamp='0.230'/>
+</task>
+<task compile_id='58' method='java.util.concurrent.ConcurrentHashMap casTabAt ([Ljava/util/concurrent/ConcurrentHashMap$Node;ILjava/util/concurrent/ConcurrentHashMap$Node;Ljava/util/concurrent/ConcurrentHashMap$Node;)Z' bytes='21' count='262' iicount='263' level='3' stamp='0.231'>
+<phase name='setup' stamp='0.231'>
+<phase_done name='setup' stamp='0.231'/>
+</phase>
+<phase name='buildIR' stamp='0.231'>
+<type id='969' name='boolean'/>
+<klass id='1095' name='[Ljava.util.concurrent.ConcurrentHashMap$Node;' flags='1040'/>
+<type id='975' name='int'/>
+<klass id='1094' name='java.util.concurrent.ConcurrentHashMap$Node' flags='8'/>
+<klass id='1093' name='java.util.concurrent.ConcurrentHashMap' flags='1'/>
+<method id='1096' holder='1093' name='casTabAt' return='969' arguments='1095 975 1094 1094' flags='24' bytes='21' iicount='270'/>
+<parse method='1096'  stamp='0.231'>
+<phase name='parse_hir' stamp='0.231'>
+<bc code='182' bci='17'/>
+<klass id='982' name='java.lang.Object' flags='1'/>
+<type id='976' name='long'/>
+<klass id='1051' name='jdk.internal.misc.Unsafe' flags='17'/>
+<method id='1100' holder='1051' name='compareAndSetObject' return='969' arguments='982 976 982 982' flags='273' bytes='0' compile_id='56' compile_kind='c2n' compiler='' level='0' iicount='256'/>
+<call method='1100' instr='invokevirtual'/>
+<inline_success reason='intrinsic'/>
+<phase_done name='parse_hir' stamp='0.231'/>
+</phase>
+<parse_done stamp='0.231'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.231'>
+<phase_done name='optimize_blocks' stamp='0.231'/>
+</phase>
+<phase name='gvn' stamp='0.231'>
+<phase_done name='gvn' stamp='0.231'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.231'>
+<phase_done name='rangeCheckElimination' stamp='0.231'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.231'>
+<phase_done name='optimize_null_checks' stamp='0.231'/>
+</phase>
+<phase_done name='buildIR' stamp='0.231'/>
+</phase>
+<phase name='emit_lir' stamp='0.231'>
+<phase name='lirGeneration' stamp='0.231'>
+<phase_done name='lirGeneration' stamp='0.231'/>
+</phase>
+<phase name='linearScan' stamp='0.231'>
+<phase_done name='linearScan' stamp='0.231'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.231'/>
+</phase>
+<phase name='codeemit' stamp='0.231'>
+<phase_done name='codeemit' stamp='0.231'/>
+</phase>
+<phase name='codeinstall' stamp='0.231'>
+<phase_done name='codeinstall' stamp='0.231'/>
+</phase>
+<code_cache total_blobs='364' nmethods='59' adapters='162' free_code_cache='248677120'/>
+<task_done success='1' nmsize='464' count='274' stamp='0.231'/>
+</task>
+<task compile_id='62' method='java.util.ImmutableCollections$SetN$1 next ()Ljava/lang/Object;' bytes='35' count='290' iicount='294' level='3' stamp='0.231'>
+<phase name='setup' stamp='0.231'>
+<phase_done name='setup' stamp='0.231'/>
+</phase>
+<phase name='buildIR' stamp='0.231'>
+<klass id='982' name='java.lang.Object' flags='1'/>
+<klass id='1093' name='java.util.ImmutableCollections$SetN$1' flags='0'/>
+<method id='1094' holder='1093' name='next' return='982' flags='1' bytes='35' iicount='320'/>
+<parse method='1094'  stamp='0.231'>
+<phase name='parse_hir' stamp='0.231'>
+<bc code='182' bci='1'/>
+<type id='969' name='boolean'/>
+<method id='1096' holder='1093' name='hasNext' return='969' flags='1' bytes='47' compile_id='55' compiler='c1' level='3' iicount='642'/>
+<call method='1096' instr='invokevirtual'/>
+<dependency type='leaf_type' ctxk='1093'/>
+<inline_fail reason='callee is too large'/>
+<dependency type='leaf_type' ctxk='1093'/>
+<bc code='183' bci='11'/>
+<type id='977' name='void'/>
+<klass id='1098' name='java.util.NoSuchElementException' unloaded='1'/>
+<method id='1099' holder='1098' name='&lt;init&gt;' return='977' unloaded='1'/>
+<call method='1099' instr='invokespecial'/>
+<inline_fail reason='not inlineable'/>
+<phase_done name='parse_hir' stamp='0.231'/>
+</phase>
+<parse_done stamp='0.231'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.231'>
+<phase_done name='optimize_blocks' stamp='0.231'/>
+</phase>
+<phase name='gvn' stamp='0.231'>
+<phase_done name='gvn' stamp='0.231'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.231'>
+<phase_done name='rangeCheckElimination' stamp='0.231'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.231'>
+<phase_done name='optimize_null_checks' stamp='0.231'/>
+</phase>
+<phase_done name='buildIR' stamp='0.231'/>
+</phase>
+<phase name='emit_lir' stamp='0.231'>
+<phase name='lirGeneration' stamp='0.231'>
+<phase_done name='lirGeneration' stamp='0.231'/>
+</phase>
+<phase name='linearScan' stamp='0.231'>
+<phase_done name='linearScan' stamp='0.231'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.231'/>
+</phase>
+<phase name='codeemit' stamp='0.231'>
+<phase_done name='codeemit' stamp='0.232'/>
+</phase>
+<phase name='codeinstall' stamp='0.232'>
+<dependency type='leaf_type' ctxk='1093'/>
+<phase_done name='codeinstall' stamp='0.232'/>
+</phase>
+<code_cache total_blobs='365' nmethods='60' adapters='162' free_code_cache='248675712'/>
+<task_done success='1' nmsize='664' count='320' stamp='0.232'/>
+</task>
+<task compile_id='64' method='java.lang.module.ModuleDescriptor exports ()Ljava/util/Set;' bytes='5' count='135' iicount='135' level='1' stamp='0.232'>
+<phase name='setup' stamp='0.232'>
+<phase_done name='setup' stamp='0.232'/>
+</phase>
+<phase name='buildIR' stamp='0.232'>
+<klass id='1094' name='java.util.Set' flags='1537'/>
+<klass id='1093' name='java.lang.module.ModuleDescriptor' flags='1'/>
+<method id='1095' holder='1093' name='exports' return='1094' flags='1' bytes='5' iicount='143'/>
+<parse method='1095'  stamp='0.232'>
+<phase name='parse_hir' stamp='0.232'>
+<phase_done name='parse_hir' stamp='0.232'/>
+</phase>
+<parse_done stamp='0.232'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.233'>
+<phase_done name='optimize_blocks' stamp='0.233'/>
+</phase>
+<phase name='gvn' stamp='0.233'>
+<phase_done name='gvn' stamp='0.233'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.233'>
+<phase_done name='rangeCheckElimination' stamp='0.233'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.233'>
+<phase_done name='optimize_null_checks' stamp='0.233'/>
+</phase>
+<phase_done name='buildIR' stamp='0.233'/>
+</phase>
+<phase name='emit_lir' stamp='0.233'>
+<phase name='lirGeneration' stamp='0.233'>
+<phase_done name='lirGeneration' stamp='0.233'/>
+</phase>
+<phase name='linearScan' stamp='0.233'>
+<phase_done name='linearScan' stamp='0.233'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.233'/>
+</phase>
+<phase name='codeemit' stamp='0.233'>
+<phase_done name='codeemit' stamp='0.233'/>
+</phase>
+<phase name='codeinstall' stamp='0.233'>
+<phase_done name='codeinstall' stamp='0.233'/>
+</phase>
+<code_cache total_blobs='367' nmethods='62' adapters='162' free_code_cache='248674176'/>
+<task_done success='1' nmsize='272' count='169' stamp='0.233'/>
+</task>
+<task compile_id='67' method='java.lang.module.ModuleDescriptor$Requires modifiers ()Ljava/util/Set;' bytes='5' count='141' iicount='141' level='1' stamp='0.236'>
+<phase name='setup' stamp='0.236'>
+<phase_done name='setup' stamp='0.236'/>
+</phase>
+<phase name='buildIR' stamp='0.236'>
+<klass id='1094' name='java.util.Set' flags='1537'/>
+<klass id='1093' name='java.lang.module.ModuleDescriptor$Requires' flags='25'/>
+<method id='1095' holder='1093' name='modifiers' return='1094' flags='1' bytes='5' iicount='141'/>
+<parse method='1095'  stamp='0.236'>
+<phase name='parse_hir' stamp='0.236'>
+<phase_done name='parse_hir' stamp='0.236'/>
+</phase>
+<parse_done stamp='0.236'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.236'>
+<phase_done name='optimize_blocks' stamp='0.236'/>
+</phase>
+<phase name='gvn' stamp='0.236'>
+<phase_done name='gvn' stamp='0.236'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.236'>
+<phase_done name='rangeCheckElimination' stamp='0.236'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.236'>
+<phase_done name='optimize_null_checks' stamp='0.236'/>
+</phase>
+<phase_done name='buildIR' stamp='0.236'/>
+</phase>
+<phase name='emit_lir' stamp='0.236'>
+<phase name='lirGeneration' stamp='0.236'>
+<phase_done name='lirGeneration' stamp='0.236'/>
+</phase>
+<phase name='linearScan' stamp='0.236'>
+<phase_done name='linearScan' stamp='0.236'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.236'/>
+</phase>
+<phase name='codeemit' stamp='0.236'>
+<phase_done name='codeemit' stamp='0.236'/>
+</phase>
+<phase name='codeinstall' stamp='0.236'>
+<phase_done name='codeinstall' stamp='0.236'/>
+</phase>
+<code_cache total_blobs='372' nmethods='67' adapters='162' free_code_cache='248654592'/>
+<task_done success='1' nmsize='272' count='176' stamp='0.236'/>
+</task>
+<task compile_id='70' method='java.util.HashMap containsKey (Ljava/lang/Object;)Z' bytes='18' count='281' iicount='281' level='3' stamp='0.236'>
+<phase name='setup' stamp='0.236'>
+<phase_done name='setup' stamp='0.236'/>
+</phase>
+<phase name='buildIR' stamp='0.236'>
+<type id='969' name='boolean'/>
+<klass id='982' name='java.lang.Object' flags='1'/>
+<klass id='1093' name='java.util.HashMap' flags='1'/>
+<method id='1094' holder='1093' name='containsKey' return='969' arguments='982' flags='1' bytes='18' iicount='281'/>
+<parse method='1094'  stamp='0.236'>
+<phase name='parse_hir' stamp='0.236'>
+<bc code='184' bci='2'/>
+<type id='975' name='int'/>
+<method id='1096' holder='1093' name='hash' return='975' arguments='982' flags='24' bytes='20' compile_id='65' compiler='c1' level='3' iicount='557'/>
+<call method='1096' instr='invokestatic'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1096'>
+<bc code='182' bci='9'/>
+<method id='1099' holder='982' name='hashCode' return='975' flags='257' bytes='0' iicount='146'/>
+<call method='1099' instr='invokevirtual'/>
+<inline_fail reason='no static binding'/>
+<parse_done stamp='0.236'/>
+</parse>
+<bc code='182' bci='6'/>
+<klass id='1100' name='java.util.HashMap$Node' flags='8'/>
+<method id='1101' holder='1093' name='getNode' return='1100' arguments='975 982' flags='16' bytes='148' iicount='301'/>
+<call method='1101' instr='invokevirtual'/>
+<inline_fail reason='callee is too large'/>
+<phase_done name='parse_hir' stamp='0.236'/>
+</phase>
+<parse_done stamp='0.236'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.236'>
+<phase_done name='optimize_blocks' stamp='0.236'/>
+</phase>
+<phase name='gvn' stamp='0.236'>
+<phase_done name='gvn' stamp='0.236'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.236'>
+<phase_done name='rangeCheckElimination' stamp='0.236'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.236'>
+<phase_done name='optimize_null_checks' stamp='0.236'/>
+</phase>
+<phase_done name='buildIR' stamp='0.236'/>
+</phase>
+<phase name='emit_lir' stamp='0.236'>
+<phase name='lirGeneration' stamp='0.236'>
+<phase_done name='lirGeneration' stamp='0.237'/>
+</phase>
+<phase name='linearScan' stamp='0.237'>
+<phase_done name='linearScan' stamp='0.237'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.237'/>
+</phase>
+<phase name='codeemit' stamp='0.237'>
+<phase_done name='codeemit' stamp='0.237'/>
+</phase>
+<phase name='codeinstall' stamp='0.237'>
+<phase_done name='codeinstall' stamp='0.237'/>
+</phase>
+<code_cache total_blobs='374' nmethods='69' adapters='162' free_code_cache='248650240'/>
+<task_done success='1' nmsize='1016' count='281' inlined_bytes='20' stamp='0.237'/>
+</task>
+<task compile_id='73' method='java.util.HashMap$Node &lt;init&gt; (ILjava/lang/Object;Ljava/lang/Object;Ljava/util/HashMap$Node;)V' bytes='26' count='364' iicount='364' level='3' stamp='0.237'>
+<phase name='setup' stamp='0.237'>
+<phase_done name='setup' stamp='0.237'/>
+</phase>
+<phase name='buildIR' stamp='0.237'>
+<type id='977' name='void'/>
+<type id='975' name='int'/>
+<klass id='982' name='java.lang.Object' flags='1'/>
+<klass id='1093' name='java.util.HashMap$Node' flags='8'/>
+<method id='1094' holder='1093' name='&lt;init&gt;' return='977' arguments='975 982 982 1093' flags='0' bytes='26' iicount='364'/>
+<parse method='1094'  stamp='0.237'>
+<phase name='parse_hir' stamp='0.237'>
+<bc code='183' bci='1'/>
+<method id='1096' holder='982' name='&lt;init&gt;' return='977' flags='1' bytes='1' compile_id='50' compiler='c1' level='1' iicount='3738'/>
+<call method='1096' instr='invokespecial'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1096'>
+<bc code='177' bci='0'/>
+<dependency type='no_finalizable_subclasses' ctxk='1093'/>
+<parse_done stamp='0.237'/>
+</parse>
+<phase_done name='parse_hir' stamp='0.237'/>
+</phase>
+<parse_done stamp='0.237'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.237'>
+<phase_done name='optimize_blocks' stamp='0.237'/>
+</phase>
+<phase name='gvn' stamp='0.237'>
+<phase_done name='gvn' stamp='0.237'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.237'>
+<phase_done name='rangeCheckElimination' stamp='0.237'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.237'>
+<phase_done name='optimize_null_checks' stamp='0.237'/>
+</phase>
+<phase_done name='buildIR' stamp='0.237'/>
+</phase>
+<phase name='emit_lir' stamp='0.237'>
+<phase name='lirGeneration' stamp='0.237'>
+<phase_done name='lirGeneration' stamp='0.237'/>
+</phase>
+<phase name='linearScan' stamp='0.237'>
+<phase_done name='linearScan' stamp='0.237'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.237'/>
+</phase>
+<phase name='codeemit' stamp='0.237'>
+<phase_done name='codeemit' stamp='0.237'/>
+</phase>
+<phase name='codeinstall' stamp='0.237'>
+<dependency type='no_finalizable_subclasses' ctxk='1093'/>
+<phase_done name='codeinstall' stamp='0.237'/>
+</phase>
+<code_cache total_blobs='378' nmethods='73' adapters='162' free_code_cache='248642560'/>
+<task_done success='1' nmsize='752' count='381' inlined_bytes='1' stamp='0.237'/>
+</task>
+<task compile_id='78' method='java.util.Collections$1 hasNext ()Z' bytes='5' count='128' iicount='128' level='1' stamp='0.237'>
+<phase name='setup' stamp='0.237'>
+<phase_done name='setup' stamp='0.237'/>
+</phase>
+<phase name='buildIR' stamp='0.237'>
+<type id='969' name='boolean'/>
+<klass id='1093' name='java.util.Collections$1' flags='0'/>
+<method id='1094' holder='1093' name='hasNext' return='969' flags='1' bytes='5' iicount='128'/>
+<parse method='1094'  stamp='0.237'>
+<phase name='parse_hir' stamp='0.237'>
+<phase_done name='parse_hir' stamp='0.237'/>
+</phase>
+<parse_done stamp='0.237'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.237'>
+<phase_done name='optimize_blocks' stamp='0.238'/>
+</phase>
+<phase name='gvn' stamp='0.238'>
+<phase_done name='gvn' stamp='0.238'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.238'>
+<phase_done name='rangeCheckElimination' stamp='0.238'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.238'>
+<phase_done name='optimize_null_checks' stamp='0.238'/>
+</phase>
+<phase_done name='buildIR' stamp='0.238'/>
+</phase>
+<phase name='emit_lir' stamp='0.238'>
+<phase name='lirGeneration' stamp='0.238'>
+<phase_done name='lirGeneration' stamp='0.238'/>
+</phase>
+<phase name='linearScan' stamp='0.238'>
+<phase_done name='linearScan' stamp='0.238'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.238'/>
+</phase>
+<phase name='codeemit' stamp='0.238'>
+<phase_done name='codeemit' stamp='0.238'/>
+</phase>
+<phase name='codeinstall' stamp='0.238'>
+<phase_done name='codeinstall' stamp='0.238'/>
+</phase>
+<code_cache total_blobs='382' nmethods='77' adapters='162' free_code_cache='248638592'/>
+<task_done success='1' nmsize='272' count='128' stamp='0.238'/>
+</task>
+<task compile_id='80' method='java.lang.module.Resolver isTracing ()Z' bytes='13' count='259' iicount='259' level='3' stamp='0.238'>
+<phase name='setup' stamp='0.238'>
+<phase_done name='setup' stamp='0.238'/>
+</phase>
+<phase name='buildIR' stamp='0.238'>
+<type id='969' name='boolean'/>
+<klass id='1093' name='java.lang.module.Resolver' flags='16'/>
+<method id='1094' holder='1093' name='isTracing' return='969' flags='2' bytes='13' iicount='263'/>
+<parse method='1094'  stamp='0.238'>
+<phase name='parse_hir' stamp='0.238'>
+<phase_done name='parse_hir' stamp='0.239'/>
+</phase>
+<parse_done stamp='0.239'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.239'>
+<phase_done name='optimize_blocks' stamp='0.239'/>
+</phase>
+<phase name='gvn' stamp='0.239'>
+<phase_done name='gvn' stamp='0.239'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.239'>
+<phase_done name='rangeCheckElimination' stamp='0.239'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.239'>
+<phase_done name='optimize_null_checks' stamp='0.239'/>
+</phase>
+<phase_done name='buildIR' stamp='0.239'/>
+</phase>
+<phase name='emit_lir' stamp='0.239'>
+<phase name='lirGeneration' stamp='0.239'>
+<phase_done name='lirGeneration' stamp='0.239'/>
+</phase>
+<phase name='linearScan' stamp='0.239'>
+<phase_done name='linearScan' stamp='0.239'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.239'/>
+</phase>
+<phase name='codeemit' stamp='0.239'>
+<phase_done name='codeemit' stamp='0.239'/>
+</phase>
+<phase name='codeinstall' stamp='0.239'>
+<phase_done name='codeinstall' stamp='0.239'/>
+</phase>
+<code_cache total_blobs='385' nmethods='80' adapters='162' free_code_cache='248629376'/>
+<task_done success='1' nmsize='432' count='314' stamp='0.239'/>
+</task>
+<task compile_id='86' method='java.util.ImmutableCollections$MapN get (Ljava/lang/Object;)Ljava/lang/Object;' bytes='21' count='275' iicount='275' level='3' stamp='0.239'>
+<phase name='setup' stamp='0.239'>
+<phase_done name='setup' stamp='0.239'/>
+</phase>
+<phase name='buildIR' stamp='0.239'>
+<klass id='982' name='java.lang.Object' flags='1'/>
+<klass id='1093' name='java.util.ImmutableCollections$MapN' flags='24'/>
+<method id='1094' holder='1093' name='get' return='982' arguments='982' flags='1' bytes='21' iicount='275'/>
+<parse method='1094'  stamp='0.239'>
+<phase name='parse_hir' stamp='0.239'>
+<bc code='183' bci='2'/>
+<type id='975' name='int'/>
+<method id='1096' holder='1093' name='probe' return='975' arguments='982' flags='2' bytes='64' compile_id='66' compiler='c1' level='3' iicount='424'/>
+<call method='1096' instr='invokespecial'/>
+<inline_fail reason='callee is too large'/>
+<phase_done name='parse_hir' stamp='0.239'/>
+</phase>
+<parse_done stamp='0.239'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.239'>
+<phase_done name='optimize_blocks' stamp='0.239'/>
+</phase>
+<phase name='gvn' stamp='0.239'>
+<phase_done name='gvn' stamp='0.239'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.239'>
+<phase_done name='rangeCheckElimination' stamp='0.239'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.239'>
+<phase_done name='optimize_null_checks' stamp='0.239'/>
+</phase>
+<phase_done name='buildIR' stamp='0.239'/>
+</phase>
+<phase name='emit_lir' stamp='0.239'>
+<phase name='lirGeneration' stamp='0.239'>
+<phase_done name='lirGeneration' stamp='0.239'/>
+</phase>
+<phase name='linearScan' stamp='0.239'>
+<phase_done name='linearScan' stamp='0.239'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.239'/>
+</phase>
+<phase name='codeemit' stamp='0.239'>
+<phase_done name='codeemit' stamp='0.239'/>
+</phase>
+<phase name='codeinstall' stamp='0.239'>
+<phase_done name='codeinstall' stamp='0.239'/>
+</phase>
+<code_cache total_blobs='389' nmethods='84' adapters='162' free_code_cache='248623360'/>
+<task_done success='1' nmsize='520' count='275' stamp='0.239'/>
+</task>
+<task compile_id='88' method='jdk.internal.module.SystemModuleFinder find (Ljava/lang/String;)Ljava/util/Optional;' bytes='22' count='273' iicount='273' level='3' stamp='0.239'>
+<phase name='setup' stamp='0.239'>
+<phase_done name='setup' stamp='0.239'/>
+</phase>
+<phase name='buildIR' stamp='0.239'>
+<klass id='1094' name='java.util.Optional' flags='17'/>
+<klass id='983' name='java.lang.String' flags='17'/>
+<klass id='1093' name='jdk.internal.module.SystemModuleFinder' flags='1'/>
+<method id='1095' holder='1093' name='find' return='1094' arguments='983' flags='1' bytes='22' iicount='273'/>
+<parse method='1095'  stamp='0.240'>
+<phase name='parse_hir' stamp='0.240'>
+<bc code='184' bci='1'/>
+<klass id='982' name='java.lang.Object' flags='1'/>
+<klass id='1097' name='java.util.Objects' flags='17'/>
+<method id='1098' holder='1097' name='requireNonNull' return='982' arguments='982' flags='9' bytes='14' compile_id='21' compiler='c1' level='3' iicount='2056'/>
+<call method='1098' instr='invokestatic'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1098'>
+<bc code='183' bci='8'/>
+<type id='977' name='void'/>
+<klass id='1089' name='java.lang.NullPointerException' flags='1'/>
+<method id='1100' holder='1089' name='&lt;init&gt;' return='977' flags='1' bytes='5' iicount='1'/>
+<call method='1100' instr='invokespecial'/>
+<inline_fail reason='don&apos;t inline Throwable constructors'/>
+<parse_done stamp='0.240'/>
+</parse>
+<bc code='185' bci='10'/>
+<klass id='1102' name='java.util.Map' flags='1537'/>
+<method id='1103' holder='1102' name='get' return='982' arguments='982' flags='1025' bytes='0' iicount='1'/>
+<call method='1103' instr='invokeinterface'/>
+<inline_fail reason='no static binding'/>
+<bc code='184' bci='18'/>
+<method id='1105' holder='1094' name='ofNullable' return='1094' arguments='982' flags='9' bytes='15' compile_id='83' compiler='c1' level='3' iicount='277'/>
+<call method='1105' instr='invokestatic'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1105'>
+<bc code='184' bci='4'/>
+<method id='1107' holder='1094' name='empty' return='1094' flags='9' bytes='6' iicount='1'/>
+<call method='1107' instr='invokestatic'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1107'>
+<parse_done stamp='0.240'/>
+</parse>
+<bc code='184' bci='11'/>
+<method id='1111' holder='1094' name='of' return='1094' arguments='982' flags='9' bytes='9' compile_id='84' compiler='c1' level='3' iicount='277'/>
+<call method='1111' instr='invokestatic'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1111'>
+<bc code='183' bci='5'/>
+<method id='1113' holder='1094' name='&lt;init&gt;' return='977' arguments='982' flags='2' bytes='13' compile_id='85' compiler='c1' level='3' iicount='277'/>
+<call method='1113' instr='invokespecial'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1113'>
+<bc code='183' bci='1'/>
+<method id='1115' holder='982' name='&lt;init&gt;' return='977' flags='1' bytes='1' compile_id='50' compiler='c1' level='1' iicount='4283'/>
+<call method='1115' instr='invokespecial'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1115'>
+<parse_done stamp='0.240'/>
+</parse>
+<bc code='184' bci='6'/>
+<call method='1098' instr='invokestatic'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1098'>
+<bc code='183' bci='8'/>
+<call method='1100' instr='invokespecial'/>
+<inline_fail reason='don&apos;t inline Throwable constructors'/>
+<parse_done stamp='0.240'/>
+</parse>
+<parse_done stamp='0.240'/>
+</parse>
+<parse_done stamp='0.240'/>
+</parse>
+<parse_done stamp='0.240'/>
+</parse>
+<phase_done name='parse_hir' stamp='0.240'/>
+</phase>
+<parse_done stamp='0.240'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.240'>
+<phase_done name='optimize_blocks' stamp='0.240'/>
+</phase>
+<phase name='gvn' stamp='0.240'>
+<phase_done name='gvn' stamp='0.240'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.240'>
+<phase_done name='rangeCheckElimination' stamp='0.240'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.240'>
+<phase_done name='optimize_null_checks' stamp='0.240'/>
+</phase>
+<phase_done name='buildIR' stamp='0.240'/>
+</phase>
+<phase name='emit_lir' stamp='0.240'>
+<phase name='lirGeneration' stamp='0.240'>
+<phase_done name='lirGeneration' stamp='0.240'/>
+</phase>
+<phase name='linearScan' stamp='0.240'>
+<phase_done name='linearScan' stamp='0.240'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.240'/>
+</phase>
+<phase name='codeemit' stamp='0.240'>
+<phase_done name='codeemit' stamp='0.240'/>
+</phase>
+<phase name='codeinstall' stamp='0.240'>
+<phase_done name='codeinstall' stamp='0.240'/>
+</phase>
+<code_cache total_blobs='397' nmethods='92' adapters='162' free_code_cache='248607616'/>
+<task_done success='1' nmsize='2184' count='273' inlined_bytes='72' stamp='0.240'/>
+</task>
+<task compile_id='99' method='java.lang.module.Resolver computeIfAbsent (Ljava/util/Map;Ljava/lang/String;Ljava/lang/module/Configuration;Ljava/lang/module/ModuleReference;)Ljava/lang/module/ResolvedModule;' bytes='42' count='312' iicount='312' level='3' stamp='0.241'>
+<phase name='setup' stamp='0.241'>
+<phase_done name='setup' stamp='0.241'/>
+</phase>
+<phase name='buildIR' stamp='0.241'>
+<klass id='1097' name='java.lang.module.ResolvedModule' flags='17'/>
+<klass id='1094' name='java.util.Map' flags='1537'/>
+<klass id='983' name='java.lang.String' flags='17'/>
+<klass id='1095' name='java.lang.module.Configuration' flags='17'/>
+<klass id='1096' name='java.lang.module.ModuleReference' flags='1025'/>
+<klass id='1093' name='java.lang.module.Resolver' flags='16'/>
+<method id='1098' holder='1093' name='computeIfAbsent' return='1097' arguments='1094 983 1095 1096' flags='2' bytes='42' iicount='312'/>
+<parse method='1098'  stamp='0.241'>
+<phase name='parse_hir' stamp='0.241'>
+<bc code='185' bci='2'/>
+<klass id='982' name='java.lang.Object' flags='1'/>
+<method id='1100' holder='1094' name='get' return='982' arguments='982' flags='1025' bytes='0' iicount='1'/>
+<call method='1100' instr='invokeinterface'/>
+<inline_fail reason='no static binding'/>
+<bc code='183' bci='24'/>
+<type id='977' name='void'/>
+<method id='1101' holder='1097' name='&lt;init&gt;' return='977' arguments='1095 1096' flags='0' bytes='27' iicount='77'/>
+<call method='1101' instr='invokespecial'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1101'>
+<bc code='183' bci='1'/>
+<method id='1103' holder='982' name='&lt;init&gt;' return='977' flags='1' bytes='1' compile_id='50' compiler='c1' level='1' iicount='4617'/>
+<call method='1103' instr='invokespecial'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1103'>
+<parse_done stamp='0.241'/>
+</parse>
+<bc code='184' bci='6'/>
+<klass id='1105' name='java.util.Objects' flags='17'/>
+<method id='1106' holder='1105' name='requireNonNull' return='982' arguments='982' flags='9' bytes='14' compile_id='21' compiler='c1' level='3' iicount='2198'/>
+<call method='1106' instr='invokestatic'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1106'>
+<bc code='183' bci='8'/>
+<klass id='1089' name='java.lang.NullPointerException' flags='1'/>
+<method id='1108' holder='1089' name='&lt;init&gt;' return='977' flags='1' bytes='5' iicount='1'/>
+<call method='1108' instr='invokespecial'/>
+<inline_fail reason='don&apos;t inline Throwable constructors'/>
+<parse_done stamp='0.241'/>
+</parse>
+<bc code='184' bci='17'/>
+<call method='1106' instr='invokestatic'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1106'>
+<bc code='183' bci='8'/>
+<call method='1108' instr='invokespecial'/>
+<inline_fail reason='don&apos;t inline Throwable constructors'/>
+<parse_done stamp='0.241'/>
+</parse>
+<parse_done stamp='0.241'/>
+</parse>
+<bc code='185' bci='33'/>
+<method id='1110' holder='1094' name='put' return='982' arguments='982 982' flags='1025' bytes='0' iicount='1'/>
+<call method='1110' instr='invokeinterface'/>
+<inline_fail reason='no static binding'/>
+<phase_done name='parse_hir' stamp='0.241'/>
+</phase>
+<parse_done stamp='0.241'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.241'>
+<phase_done name='optimize_blocks' stamp='0.241'/>
+</phase>
+<phase name='gvn' stamp='0.241'>
+<phase_done name='gvn' stamp='0.241'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.241'>
+<phase_done name='rangeCheckElimination' stamp='0.241'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.241'>
+<phase_done name='optimize_null_checks' stamp='0.241'/>
+</phase>
+<phase_done name='buildIR' stamp='0.241'/>
+</phase>
+<phase name='emit_lir' stamp='0.241'>
+<phase name='lirGeneration' stamp='0.241'>
+<phase_done name='lirGeneration' stamp='0.241'/>
+</phase>
+<phase name='linearScan' stamp='0.241'>
+<phase_done name='linearScan' stamp='0.241'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.241'/>
+</phase>
+<phase name='codeemit' stamp='0.241'>
+<phase_done name='codeemit' stamp='0.241'/>
+</phase>
+<phase name='codeinstall' stamp='0.241'>
+<phase_done name='codeinstall' stamp='0.242'/>
+</phase>
+<code_cache total_blobs='406' nmethods='101' adapters='162' free_code_cache='248594688'/>
+<task_done success='1' nmsize='2232' count='312' inlined_bytes='56' stamp='0.242'/>
+</task>
+<task compile_id='106' method='java.util.HashMap$KeySet iterator ()Ljava/util/Iterator;' bytes='12' count='497' iicount='497' level='3' stamp='0.242'>
+<phase name='setup' stamp='0.242'>
+<phase_done name='setup' stamp='0.242'/>
+</phase>
+<phase name='buildIR' stamp='0.242'>
+<klass id='1094' name='java.util.Iterator' flags='1537'/>
+<klass id='1093' name='java.util.HashMap$KeySet' flags='16'/>
+<method id='1095' holder='1093' name='iterator' return='1094' flags='17' bytes='12' iicount='502'/>
+<parse method='1095'  stamp='0.242'>
+<phase name='parse_hir' stamp='0.242'>
+<bc code='183' bci='8'/>
+<type id='977' name='void'/>
+<klass id='1098' name='java.util.HashMap' flags='1'/>
+<klass id='1097' name='java.util.HashMap$KeyIterator' flags='16'/>
+<method id='1099' holder='1097' name='&lt;init&gt;' return='977' arguments='1098' flags='0' bytes='11' iicount='514'/>
+<call method='1099' instr='invokespecial'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1099'>
+<bc code='183' bci='7'/>
+<klass id='1101' name='java.util.HashMap$HashIterator' flags='1024'/>
+<method id='1102' holder='1101' name='&lt;init&gt;' return='977' arguments='1098' flags='0' bytes='79' iicount='522'/>
+<call method='1102' instr='invokespecial'/>
+<inline_fail reason='callee is too large'/>
+<parse_done stamp='0.242'/>
+</parse>
+<phase_done name='parse_hir' stamp='0.242'/>
+</phase>
+<parse_done stamp='0.242'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.242'>
+<phase_done name='optimize_blocks' stamp='0.242'/>
+</phase>
+<phase name='gvn' stamp='0.242'>
+<phase_done name='gvn' stamp='0.242'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.242'>
+<phase_done name='rangeCheckElimination' stamp='0.242'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.242'>
+<phase_done name='optimize_null_checks' stamp='0.242'/>
+</phase>
+<phase_done name='buildIR' stamp='0.242'/>
+</phase>
+<phase name='emit_lir' stamp='0.242'>
+<phase name='lirGeneration' stamp='0.242'>
+<phase_done name='lirGeneration' stamp='0.242'/>
+</phase>
+<phase name='linearScan' stamp='0.242'>
+<phase_done name='linearScan' stamp='0.242'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.242'/>
+</phase>
+<phase name='codeemit' stamp='0.242'>
+<phase_done name='codeemit' stamp='0.242'/>
+</phase>
+<phase name='codeinstall' stamp='0.242'>
+<phase_done name='codeinstall' stamp='0.242'/>
+</phase>
+<code_cache total_blobs='411' nmethods='106' adapters='162' free_code_cache='248586880'/>
+<task_done success='1' nmsize='712' count='656' inlined_bytes='11' stamp='0.242'/>
+</task>
+<task compile_id='111' method='java.lang.module.ResolvedModule reference ()Ljava/lang/module/ModuleReference;' bytes='5' count='154' iicount='154' level='1' stamp='0.243'>
+<phase name='setup' stamp='0.243'>
+<phase_done name='setup' stamp='0.243'/>
+</phase>
+<phase name='buildIR' stamp='0.243'>
+<klass id='1094' name='java.lang.module.ModuleReference' flags='1025'/>
+<klass id='1093' name='java.lang.module.ResolvedModule' flags='17'/>
+<method id='1095' holder='1093' name='reference' return='1094' flags='1' bytes='5' iicount='154'/>
+<parse method='1095'  stamp='0.243'>
+<phase name='parse_hir' stamp='0.243'>
+<phase_done name='parse_hir' stamp='0.243'/>
+</phase>
+<parse_done stamp='0.243'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.243'>
+<phase_done name='optimize_blocks' stamp='0.243'/>
+</phase>
+<phase name='gvn' stamp='0.243'>
+<phase_done name='gvn' stamp='0.243'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.243'>
+<phase_done name='rangeCheckElimination' stamp='0.243'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.243'>
+<phase_done name='optimize_null_checks' stamp='0.243'/>
+</phase>
+<phase_done name='buildIR' stamp='0.243'/>
+</phase>
+<phase name='emit_lir' stamp='0.243'>
+<phase name='lirGeneration' stamp='0.243'>
+<phase_done name='lirGeneration' stamp='0.243'/>
+</phase>
+<phase name='linearScan' stamp='0.243'>
+<phase_done name='linearScan' stamp='0.243'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.243'/>
+</phase>
+<phase name='codeemit' stamp='0.243'>
+<phase_done name='codeemit' stamp='0.243'/>
+</phase>
+<phase name='codeinstall' stamp='0.243'>
+<phase_done name='codeinstall' stamp='0.243'/>
+</phase>
+<code_cache total_blobs='418' nmethods='111' adapters='162' free_code_cache='248582272'/>
+<task_done success='1' nmsize='272' count='156' stamp='0.243'/>
+</task>
+<task compile_id='116' method='java.util.concurrent.ConcurrentHashMap putIfAbsent (Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;' bytes='8' count='277' iicount='278' level='3' stamp='0.243'>
+<phase name='setup' stamp='0.244'>
+<phase_done name='setup' stamp='0.244'/>
+</phase>
+<phase name='buildIR' stamp='0.244'>
+<klass id='982' name='java.lang.Object' flags='1'/>
+<klass id='1093' name='java.util.concurrent.ConcurrentHashMap' flags='1'/>
+<method id='1094' holder='1093' name='putIfAbsent' return='982' arguments='982 982' flags='1' bytes='8' iicount='293'/>
+<parse method='1094'  stamp='0.244'>
+<phase name='parse_hir' stamp='0.244'>
+<bc code='182' bci='4'/>
+<type id='969' name='boolean'/>
+<method id='1096' holder='1093' name='putVal' return='982' arguments='982 982 969' flags='16' bytes='432' compile_id='59' compiler='c1' level='3' iicount='444'/>
+<call method='1096' instr='invokevirtual'/>
+<dependency type='leaf_type' ctxk='1093'/>
+<inline_fail reason='callee is too large'/>
+<phase_done name='parse_hir' stamp='0.244'/>
+</phase>
+<parse_done stamp='0.244'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.244'>
+<phase_done name='optimize_blocks' stamp='0.244'/>
+</phase>
+<phase name='gvn' stamp='0.244'>
+<phase_done name='gvn' stamp='0.244'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.244'>
+<phase_done name='rangeCheckElimination' stamp='0.244'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.244'>
+<phase_done name='optimize_null_checks' stamp='0.244'/>
+</phase>
+<phase_done name='buildIR' stamp='0.244'/>
+</phase>
+<phase name='emit_lir' stamp='0.244'>
+<phase name='lirGeneration' stamp='0.244'>
+<phase_done name='lirGeneration' stamp='0.244'/>
+</phase>
+<phase name='linearScan' stamp='0.244'>
+<phase_done name='linearScan' stamp='0.244'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.244'/>
+</phase>
+<phase name='codeemit' stamp='0.244'>
+<phase_done name='codeemit' stamp='0.244'/>
+</phase>
+<phase name='codeinstall' stamp='0.244'>
+<dependency type='leaf_type' ctxk='1093'/>
+<phase_done name='codeinstall' stamp='0.244'/>
+</phase>
+<code_cache total_blobs='422' nmethods='115' adapters='162' free_code_cache='248575744'/>
+<task_done success='1' nmsize='520' count='577' stamp='0.244'/>
+</task>
+<task compile_id='118' method='java.lang.Math min (II)I' bytes='11' count='256' iicount='256' level='3' stamp='0.244'>
+<phase name='setup' stamp='0.244'>
+<phase_done name='setup' stamp='0.244'/>
+</phase>
+<phase name='buildIR' stamp='0.244'>
+<type id='975' name='int'/>
+<klass id='1093' name='java.lang.Math' flags='17'/>
+<method id='1094' holder='1093' name='min' return='975' arguments='975 975' flags='9' bytes='11' iicount='257'/>
+<parse method='1094'  stamp='0.244'>
+<phase name='parse_hir' stamp='0.244'>
+<phase_done name='parse_hir' stamp='0.244'/>
+</phase>
+<parse_done stamp='0.244'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.244'>
+<phase_done name='optimize_blocks' stamp='0.244'/>
+</phase>
+<phase name='gvn' stamp='0.244'>
+<phase_done name='gvn' stamp='0.244'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.244'>
+<phase_done name='rangeCheckElimination' stamp='0.244'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.244'>
+<phase_done name='optimize_null_checks' stamp='0.244'/>
+</phase>
+<phase_done name='buildIR' stamp='0.244'/>
+</phase>
+<phase name='emit_lir' stamp='0.244'>
+<phase name='lirGeneration' stamp='0.244'>
+<phase_done name='lirGeneration' stamp='0.244'/>
+</phase>
+<phase name='linearScan' stamp='0.244'>
+<phase_done name='linearScan' stamp='0.244'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.244'/>
+</phase>
+<phase name='codeemit' stamp='0.244'>
+<phase_done name='codeemit' stamp='0.244'/>
+</phase>
+<phase name='codeinstall' stamp='0.244'>
+<phase_done name='codeinstall' stamp='0.244'/>
+</phase>
+<code_cache total_blobs='425' nmethods='118' adapters='162' free_code_cache='248572288'/>
+<task_done success='1' nmsize='400' count='264' stamp='0.244'/>
+</task>
+<task compile_id='122' method='java.util.concurrent.ConcurrentHashMap setTabAt ([Ljava/util/concurrent/ConcurrentHashMap$Node;ILjava/util/concurrent/ConcurrentHashMap$Node;)V' bytes='20' count='288' iicount='288' level='3' stamp='0.245'>
+<phase name='setup' stamp='0.245'>
+<phase_done name='setup' stamp='0.245'/>
+</phase>
+<phase name='buildIR' stamp='0.245'>
+<type id='977' name='void'/>
+<klass id='1095' name='[Ljava.util.concurrent.ConcurrentHashMap$Node;' flags='1040'/>
+<type id='975' name='int'/>
+<klass id='1094' name='java.util.concurrent.ConcurrentHashMap$Node' flags='8'/>
+<klass id='1093' name='java.util.concurrent.ConcurrentHashMap' flags='1'/>
+<method id='1096' holder='1093' name='setTabAt' return='977' arguments='1095 975 1094' flags='24' bytes='20' iicount='294'/>
+<parse method='1096'  stamp='0.245'>
+<phase name='parse_hir' stamp='0.245'>
+<bc code='182' bci='16'/>
+<klass id='982' name='java.lang.Object' flags='1'/>
+<type id='976' name='long'/>
+<klass id='1051' name='jdk.internal.misc.Unsafe' flags='17'/>
+<method id='1100' holder='1051' name='putObjectRelease' return='977' arguments='982 976 982' flags='17' bytes='9' iicount='296'/>
+<call method='1100' instr='invokevirtual'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1100'>
+<bc code='182' bci='5'/>
+<method id='1102' holder='1051' name='putObjectVolatile' return='977' arguments='982 976 982' flags='257' bytes='0' compile_id='121' compile_kind='c2n' compiler='' level='0' iicount='256'/>
+<call method='1102' instr='invokevirtual'/>
+<inline_success reason='intrinsic'/>
+<parse_done stamp='0.245'/>
+</parse>
+<phase_done name='parse_hir' stamp='0.245'/>
+</phase>
+<parse_done stamp='0.245'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.245'>
+<phase_done name='optimize_blocks' stamp='0.245'/>
+</phase>
+<phase name='gvn' stamp='0.245'>
+<phase_done name='gvn' stamp='0.245'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.245'>
+<phase_done name='rangeCheckElimination' stamp='0.245'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.245'>
+<phase_done name='optimize_null_checks' stamp='0.245'/>
+</phase>
+<phase_done name='buildIR' stamp='0.245'/>
+</phase>
+<phase name='emit_lir' stamp='0.245'>
+<phase name='lirGeneration' stamp='0.245'>
+<phase_done name='lirGeneration' stamp='0.245'/>
+</phase>
+<phase name='linearScan' stamp='0.245'>
+<phase_done name='linearScan' stamp='0.245'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.245'/>
+</phase>
+<phase name='codeemit' stamp='0.245'>
+<phase_done name='codeemit' stamp='0.245'/>
+</phase>
+<phase name='codeinstall' stamp='0.245'>
+<phase_done name='codeinstall' stamp='0.245'/>
+</phase>
+<code_cache total_blobs='431' nmethods='122' adapters='162' free_code_cache='248568320'/>
+<task_done success='1' nmsize='656' count='294' inlined_bytes='9' stamp='0.245'/>
+</task>
+<task compile_id='129' method='java.lang.AbstractStringBuilder ensureCapacityInternal (I)V' bytes='39' count='259' iicount='259' level='3' stamp='0.247'>
+<phase name='setup' stamp='0.247'>
+<phase_done name='setup' stamp='0.247'/>
+</phase>
+<phase name='buildIR' stamp='0.247'>
+<type id='977' name='void'/>
+<type id='975' name='int'/>
+<klass id='1048' name='java.lang.AbstractStringBuilder' flags='1024'/>
+<method id='1093' holder='1048' name='ensureCapacityInternal' return='977' arguments='975' flags='2' bytes='39' iicount='259'/>
+<parse method='1093'  stamp='0.247'>
+<phase name='parse_hir' stamp='0.247'>
+<bc code='183' bci='24'/>
+<method id='1095' holder='1048' name='newCapacity' return='975' arguments='975' flags='2' bytes='55' iicount='62'/>
+<call method='1095' instr='invokespecial'/>
+<inline_fail reason='callee is too large'/>
+<bc code='184' bci='32'/>
+<klass id='1085' name='[B' flags='1041'/>
+<klass id='1097' name='java.util.Arrays' flags='1'/>
+<method id='1098' holder='1097' name='copyOf' return='1085' arguments='1085 975' flags='9' bytes='19' iicount='179'/>
+<call method='1098' instr='invokestatic'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1098'>
+<bc code='184' bci='11'/>
+<klass id='1100' name='java.lang.Math' flags='17'/>
+<method id='1101' holder='1100' name='min' return='975' arguments='975 975' flags='9' bytes='11' compile_id='118' compiler='c1' level='3' iicount='396'/>
+<call method='1101' instr='invokestatic'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1101'>
+<parse_done stamp='0.247'/>
+</parse>
+<bc code='184' bci='14'/>
+<klass id='982' name='java.lang.Object' flags='1'/>
+<klass id='988' name='java.lang.System' flags='17'/>
+<method id='1103' holder='988' name='arraycopy' return='977' arguments='982 975 982 975 975' flags='265' bytes='0' compile_id='44' compile_kind='c2n' compiler='' level='0' iicount='256'/>
+<call method='1103' instr='invokestatic'/>
+<inline_success reason='intrinsic'/>
+<parse_done stamp='0.247'/>
+</parse>
+<phase_done name='parse_hir' stamp='0.247'/>
+</phase>
+<parse_done stamp='0.247'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.247'>
+<phase_done name='optimize_blocks' stamp='0.247'/>
+</phase>
+<phase name='gvn' stamp='0.247'>
+<phase_done name='gvn' stamp='0.247'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.247'>
+<phase_done name='rangeCheckElimination' stamp='0.247'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.247'>
+<phase_done name='optimize_null_checks' stamp='0.247'/>
+</phase>
+<phase_done name='buildIR' stamp='0.247'/>
+</phase>
+<phase name='emit_lir' stamp='0.247'>
+<phase name='lirGeneration' stamp='0.247'>
+<phase_done name='lirGeneration' stamp='0.247'/>
+</phase>
+<phase name='linearScan' stamp='0.247'>
+<phase_done name='linearScan' stamp='0.248'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.248'/>
+</phase>
+<phase name='codeemit' stamp='0.248'>
+<phase_done name='codeemit' stamp='0.248'/>
+</phase>
+<phase name='codeinstall' stamp='0.248'>
+<phase_done name='codeinstall' stamp='0.248'/>
+</phase>
+<code_cache total_blobs='440' nmethods='129' adapters='162' free_code_cache='248558464'/>
+<task_done success='1' nmsize='1208' count='301' inlined_bytes='30' stamp='0.248'/>
+</task>
+<task compile_id='133' method='java.util.HashSet &lt;init&gt; ()V' bytes='16' count='257' iicount='257' level='3' stamp='0.248'>
+<phase name='setup' stamp='0.248'>
+<phase_done name='setup' stamp='0.248'/>
+</phase>
+<phase name='buildIR' stamp='0.248'>
+<type id='977' name='void'/>
+<klass id='1093' name='java.util.HashSet' flags='1'/>
+<method id='1094' holder='1093' name='&lt;init&gt;' return='977' flags='1' bytes='16' iicount='263'/>
+<parse method='1094'  stamp='0.248'>
+<phase name='parse_hir' stamp='0.248'>
+<bc code='183' bci='1'/>
+<klass id='1096' name='java.util.AbstractSet' flags='1025'/>
+<method id='1097' holder='1096' name='&lt;init&gt;' return='977' flags='4' bytes='5' compile_id='24' compiler='c1' level='3' iicount='937'/>
+<call method='1097' instr='invokespecial'/>
+<dependency type='leaf_type' ctxk='1093'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1097'>
+<bc code='183' bci='1'/>
+<klass id='1099' name='java.util.AbstractCollection' flags='1025'/>
+<method id='1100' holder='1099' name='&lt;init&gt;' return='977' flags='4' bytes='5' compile_id='23' compiler='c1' level='3' iicount='1040'/>
+<call method='1100' instr='invokespecial'/>
+<dependency type='leaf_type' ctxk='1093'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1100'>
+<bc code='183' bci='1'/>
+<klass id='982' name='java.lang.Object' flags='1'/>
+<method id='1102' holder='982' name='&lt;init&gt;' return='977' flags='1' bytes='1' compile_id='50' compiler='c1' level='1' iicount='6681'/>
+<call method='1102' instr='invokespecial'/>
+<dependency type='leaf_type' ctxk='1093'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1102'>
+<bc code='177' bci='0'/>
+<dependency type='leaf_type' ctxk='1093'/>
+<parse_done stamp='0.248'/>
+</parse>
+<parse_done stamp='0.249'/>
+</parse>
+<parse_done stamp='0.249'/>
+</parse>
+<bc code='183' bci='9'/>
+<klass id='1104' name='java.util.HashMap' flags='1'/>
+<method id='1105' holder='1104' name='&lt;init&gt;' return='977' flags='1' bytes='11' compile_id='130' compiler='c1' level='3' iicount='317'/>
+<call method='1105' instr='invokespecial'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1105'>
+<bc code='183' bci='1'/>
+<klass id='1107' name='java.util.AbstractMap' flags='1025'/>
+<method id='1108' holder='1107' name='&lt;init&gt;' return='977' flags='4' bytes='5' iicount='358'/>
+<call method='1108' instr='invokespecial'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1108'>
+<bc code='183' bci='1'/>
+<call method='1102' instr='invokespecial'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1102'>
+<parse_done stamp='0.249'/>
+</parse>
+<parse_done stamp='0.249'/>
+</parse>
+<parse_done stamp='0.249'/>
+</parse>
+<phase_done name='parse_hir' stamp='0.249'/>
+</phase>
+<parse_done stamp='0.249'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.249'>
+<phase_done name='optimize_blocks' stamp='0.249'/>
+</phase>
+<phase name='gvn' stamp='0.249'>
+<phase_done name='gvn' stamp='0.249'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.249'>
+<phase_done name='rangeCheckElimination' stamp='0.249'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.249'>
+<phase_done name='optimize_null_checks' stamp='0.249'/>
+</phase>
+<phase_done name='buildIR' stamp='0.249'/>
+</phase>
+<phase name='emit_lir' stamp='0.249'>
+<phase name='lirGeneration' stamp='0.249'>
+<phase_done name='lirGeneration' stamp='0.249'/>
+</phase>
+<phase name='linearScan' stamp='0.249'>
+<phase_done name='linearScan' stamp='0.249'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.249'/>
+</phase>
+<phase name='codeemit' stamp='0.249'>
+<phase_done name='codeemit' stamp='0.249'/>
+</phase>
+<phase name='codeinstall' stamp='0.249'>
+<dependency type='leaf_type' ctxk='1093'/>
+<phase_done name='codeinstall' stamp='0.249'/>
+</phase>
+<code_cache total_blobs='444' nmethods='133' adapters='162' free_code_cache='248553856'/>
+<task_done success='1' nmsize='1104' count='289' inlined_bytes='28' stamp='0.249'/>
+</task>
+<task compile_id='138' method='java.lang.module.ResolvedModule configuration ()Ljava/lang/module/Configuration;' bytes='5' count='160' iicount='160' level='1' stamp='0.250'>
+<phase name='setup' stamp='0.250'>
+<phase_done name='setup' stamp='0.250'/>
+</phase>
+<phase name='buildIR' stamp='0.250'>
+<klass id='1094' name='java.lang.module.Configuration' flags='17'/>
+<klass id='1093' name='java.lang.module.ResolvedModule' flags='17'/>
+<method id='1095' holder='1093' name='configuration' return='1094' flags='1' bytes='5' iicount='161'/>
+<parse method='1095'  stamp='0.250'>
+<phase name='parse_hir' stamp='0.250'>
+<phase_done name='parse_hir' stamp='0.250'/>
+</phase>
+<parse_done stamp='0.250'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.250'>
+<phase_done name='optimize_blocks' stamp='0.250'/>
+</phase>
+<phase name='gvn' stamp='0.250'>
+<phase_done name='gvn' stamp='0.250'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.250'>
+<phase_done name='rangeCheckElimination' stamp='0.250'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.250'>
+<phase_done name='optimize_null_checks' stamp='0.250'/>
+</phase>
+<phase_done name='buildIR' stamp='0.250'/>
+</phase>
+<phase name='emit_lir' stamp='0.250'>
+<phase name='lirGeneration' stamp='0.250'>
+<phase_done name='lirGeneration' stamp='0.250'/>
+</phase>
+<phase name='linearScan' stamp='0.250'>
+<phase_done name='linearScan' stamp='0.250'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.250'/>
+</phase>
+<phase name='codeemit' stamp='0.250'>
+<phase_done name='codeemit' stamp='0.250'/>
+</phase>
+<phase name='codeinstall' stamp='0.250'>
+<phase_done name='codeinstall' stamp='0.250'/>
+</phase>
+<code_cache total_blobs='450' nmethods='139' adapters='162' free_code_cache='248542208'/>
+<task_done success='1' nmsize='272' count='169' stamp='0.250'/>
+</task>
+<task compile_id='143' method='java.util.ImmutableCollections$SetN$1 &lt;init&gt; (Ljava/util/ImmutableCollections$SetN;)V' bytes='15' count='256' iicount='256' level='3' stamp='0.250'>
+<phase name='setup' stamp='0.250'>
+<phase_done name='setup' stamp='0.250'/>
+</phase>
+<phase name='buildIR' stamp='0.250'>
+<type id='977' name='void'/>
+<klass id='1094' name='java.util.ImmutableCollections$SetN' flags='24'/>
+<klass id='1093' name='java.util.ImmutableCollections$SetN$1' flags='0'/>
+<method id='1095' holder='1093' name='&lt;init&gt;' return='977' arguments='1094' flags='0' bytes='15' iicount='256'/>
+<parse method='1095'  stamp='0.250'>
+<phase name='parse_hir' stamp='0.250'>
+<bc code='183' bci='6'/>
+<klass id='982' name='java.lang.Object' flags='1'/>
+<method id='1097' holder='982' name='&lt;init&gt;' return='977' flags='1' bytes='1' compile_id='50' compiler='c1' level='1' iicount='7575'/>
+<call method='1097' instr='invokespecial'/>
+<dependency type='leaf_type' ctxk='1093'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1097'>
+<bc code='177' bci='0'/>
+<dependency type='leaf_type' ctxk='1093'/>
+<parse_done stamp='0.250'/>
+</parse>
+<phase_done name='parse_hir' stamp='0.250'/>
+</phase>
+<parse_done stamp='0.250'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.250'>
+<phase_done name='optimize_blocks' stamp='0.250'/>
+</phase>
+<phase name='gvn' stamp='0.250'>
+<phase_done name='gvn' stamp='0.250'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.250'>
+<phase_done name='rangeCheckElimination' stamp='0.250'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.250'>
+<phase_done name='optimize_null_checks' stamp='0.250'/>
+</phase>
+<phase_done name='buildIR' stamp='0.250'/>
+</phase>
+<phase name='emit_lir' stamp='0.250'>
+<phase name='lirGeneration' stamp='0.250'>
+<phase_done name='lirGeneration' stamp='0.250'/>
+</phase>
+<phase name='linearScan' stamp='0.250'>
+<phase_done name='linearScan' stamp='0.250'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.250'/>
+</phase>
+<phase name='codeemit' stamp='0.250'>
+<phase_done name='codeemit' stamp='0.250'/>
+</phase>
+<phase name='codeinstall' stamp='0.250'>
+<dependency type='leaf_type' ctxk='1093'/>
+<phase_done name='codeinstall' stamp='0.250'/>
+</phase>
+<code_cache total_blobs='454' nmethods='143' adapters='162' free_code_cache='248537856'/>
+<task_done success='1' nmsize='560' count='262' inlined_bytes='1' stamp='0.250'/>
+</task>
+<task compile_id='146' method='java.util.HashMap isEmpty ()Z' bytes='13' count='256' iicount='256' level='3' stamp='0.250'>
+<phase name='setup' stamp='0.250'>
+<phase_done name='setup' stamp='0.250'/>
+</phase>
+<phase name='buildIR' stamp='0.250'>
+<type id='969' name='boolean'/>
+<klass id='1093' name='java.util.HashMap' flags='1'/>
+<method id='1094' holder='1093' name='isEmpty' return='969' flags='1' bytes='13' iicount='258'/>
+<parse method='1094'  stamp='0.250'>
+<phase name='parse_hir' stamp='0.250'>
+<phase_done name='parse_hir' stamp='0.250'/>
+</phase>
+<parse_done stamp='0.250'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.250'>
+<phase_done name='optimize_blocks' stamp='0.250'/>
+</phase>
+<phase name='gvn' stamp='0.250'>
+<phase_done name='gvn' stamp='0.250'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.250'>
+<phase_done name='rangeCheckElimination' stamp='0.250'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.250'>
+<phase_done name='optimize_null_checks' stamp='0.250'/>
+</phase>
+<phase_done name='buildIR' stamp='0.250'/>
+</phase>
+<phase name='emit_lir' stamp='0.250'>
+<phase name='lirGeneration' stamp='0.250'>
+<phase_done name='lirGeneration' stamp='0.250'/>
+</phase>
+<phase name='linearScan' stamp='0.250'>
+<phase_done name='linearScan' stamp='0.250'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.250'/>
+</phase>
+<phase name='codeemit' stamp='0.251'>
+<phase_done name='codeemit' stamp='0.251'/>
+</phase>
+<phase name='codeinstall' stamp='0.251'>
+<phase_done name='codeinstall' stamp='0.251'/>
+</phase>
+<code_cache total_blobs='456' nmethods='145' adapters='162' free_code_cache='248535424'/>
+<task_done success='1' nmsize='432' count='281' stamp='0.251'/>
+</task>
+<task compile_id='149' method='java.util.ImmutableCollections$Set1 iterator ()Ljava/util/Iterator;' bytes='8' count='260' iicount='260' level='3' stamp='0.251'>
+<phase name='setup' stamp='0.251'>
+<phase_done name='setup' stamp='0.251'/>
+</phase>
+<phase name='buildIR' stamp='0.251'>
+<klass id='1094' name='java.util.Iterator' flags='1537'/>
+<klass id='1093' name='java.util.ImmutableCollections$Set1' flags='24'/>
+<method id='1095' holder='1093' name='iterator' return='1094' flags='1' bytes='8' iicount='260'/>
+<parse method='1095'  stamp='0.251'>
+<phase name='parse_hir' stamp='0.251'>
+<bc code='184' bci='4'/>
+<klass id='982' name='java.lang.Object' flags='1'/>
+<klass id='1097' name='java.util.Collections' flags='1'/>
+<method id='1098' holder='1097' name='singletonIterator' return='1094' arguments='982' flags='8' bytes='9' iicount='267'/>
+<call method='1098' instr='invokestatic'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1098'>
+<bc code='183' bci='5'/>
+<type id='977' name='void'/>
+<klass id='1100' name='java.util.Collections$1' flags='0'/>
+<method id='1101' holder='1100' name='&lt;init&gt;' return='977' arguments='982' flags='0' bytes='15' iicount='267'/>
+<call method='1101' instr='invokespecial'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1101'>
+<bc code='183' bci='6'/>
+<method id='1103' holder='982' name='&lt;init&gt;' return='977' flags='1' bytes='1' compile_id='50' compiler='c1' level='1' iicount='8220'/>
+<call method='1103' instr='invokespecial'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1103'>
+<parse_done stamp='0.251'/>
+</parse>
+<parse_done stamp='0.251'/>
+</parse>
+<parse_done stamp='0.251'/>
+</parse>
+<phase_done name='parse_hir' stamp='0.251'/>
+</phase>
+<parse_done stamp='0.251'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.251'>
+<phase_done name='optimize_blocks' stamp='0.251'/>
+</phase>
+<phase name='gvn' stamp='0.251'>
+<phase_done name='gvn' stamp='0.251'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.251'>
+<phase_done name='rangeCheckElimination' stamp='0.251'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.251'>
+<phase_done name='optimize_null_checks' stamp='0.251'/>
+</phase>
+<phase_done name='buildIR' stamp='0.251'/>
+</phase>
+<phase name='emit_lir' stamp='0.251'>
+<phase name='lirGeneration' stamp='0.251'>
+<phase_done name='lirGeneration' stamp='0.251'/>
+</phase>
+<phase name='linearScan' stamp='0.251'>
+<phase_done name='linearScan' stamp='0.251'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.251'/>
+</phase>
+<phase name='codeemit' stamp='0.251'>
+<phase_done name='codeemit' stamp='0.251'/>
+</phase>
+<phase name='codeinstall' stamp='0.251'>
+<phase_done name='codeinstall' stamp='0.251'/>
+</phase>
+<code_cache total_blobs='464' nmethods='153' adapters='162' free_code_cache='248522752'/>
+<task_done success='1' nmsize='816' count='279' inlined_bytes='25' stamp='0.251'/>
+</task>
+<task compile_id='154' method='java.util.Collections$UnmodifiableCollection$1 next ()Ljava/lang/Object;' bytes='10' count='256' iicount='256' level='3' stamp='0.251'>
+<phase name='setup' stamp='0.251'>
+<phase_done name='setup' stamp='0.251'/>
+</phase>
+<phase name='buildIR' stamp='0.251'>
+<klass id='982' name='java.lang.Object' flags='1'/>
+<klass id='1093' name='java.util.Collections$UnmodifiableCollection$1' flags='0'/>
+<method id='1094' holder='1093' name='next' return='982' flags='1' bytes='10' iicount='256'/>
+<parse method='1094'  stamp='0.251'>
+<phase name='parse_hir' stamp='0.251'>
+<bc code='185' bci='4'/>
+<klass id='1096' name='java.util.Iterator' flags='1537'/>
+<method id='1097' holder='1096' name='next' return='982' flags='1025' bytes='0' iicount='1'/>
+<call method='1097' instr='invokeinterface'/>
+<inline_fail reason='no static binding'/>
+<phase_done name='parse_hir' stamp='0.251'/>
+</phase>
+<parse_done stamp='0.251'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.251'>
+<phase_done name='optimize_blocks' stamp='0.251'/>
+</phase>
+<phase name='gvn' stamp='0.251'>
+<phase_done name='gvn' stamp='0.251'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.251'>
+<phase_done name='rangeCheckElimination' stamp='0.251'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.251'>
+<phase_done name='optimize_null_checks' stamp='0.251'/>
+</phase>
+<phase_done name='buildIR' stamp='0.251'/>
+</phase>
+<phase name='emit_lir' stamp='0.251'>
+<phase name='lirGeneration' stamp='0.251'>
+<phase_done name='lirGeneration' stamp='0.251'/>
+</phase>
+<phase name='linearScan' stamp='0.251'>
+<phase_done name='linearScan' stamp='0.252'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.252'/>
+</phase>
+<phase name='codeemit' stamp='0.252'>
+<phase_done name='codeemit' stamp='0.252'/>
+</phase>
+<phase name='codeinstall' stamp='0.252'>
+<phase_done name='codeinstall' stamp='0.252'/>
+</phase>
+<code_cache total_blobs='466' nmethods='155' adapters='162' free_code_cache='248520576'/>
+<task_done success='1' nmsize='552' count='257' stamp='0.252'/>
+</task>
+<task compile_id='157' method='java.lang.reflect.Field getName ()Ljava/lang/String;' bytes='5' count='270' iicount='270' level='1' stamp='0.252'>
+<phase name='setup' stamp='0.252'>
+<phase_done name='setup' stamp='0.252'/>
+</phase>
+<phase name='buildIR' stamp='0.252'>
+<klass id='983' name='java.lang.String' flags='17'/>
+<klass id='1021' name='java.lang.reflect.Field' flags='17'/>
+<method id='1093' holder='1021' name='getName' return='983' flags='1' bytes='5' iicount='270'/>
+<parse method='1093'  stamp='0.252'>
+<phase name='parse_hir' stamp='0.252'>
+<phase_done name='parse_hir' stamp='0.252'/>
+</phase>
+<parse_done stamp='0.252'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.252'>
+<phase_done name='optimize_blocks' stamp='0.252'/>
+</phase>
+<phase name='gvn' stamp='0.252'>
+<phase_done name='gvn' stamp='0.252'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.252'>
+<phase_done name='rangeCheckElimination' stamp='0.252'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.252'>
+<phase_done name='optimize_null_checks' stamp='0.252'/>
+</phase>
+<phase_done name='buildIR' stamp='0.252'/>
+</phase>
+<phase name='emit_lir' stamp='0.252'>
+<phase name='lirGeneration' stamp='0.252'>
+<phase_done name='lirGeneration' stamp='0.252'/>
+</phase>
+<phase name='linearScan' stamp='0.252'>
+<phase_done name='linearScan' stamp='0.253'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.253'/>
+</phase>
+<phase name='codeemit' stamp='0.253'>
+<phase_done name='codeemit' stamp='0.253'/>
+</phase>
+<phase name='codeinstall' stamp='0.253'>
+<phase_done name='codeinstall' stamp='0.253'/>
+</phase>
+<code_cache total_blobs='468' nmethods='157' adapters='162' free_code_cache='248519040'/>
+<task_done success='1' nmsize='272' count='270' stamp='0.253'/>
+</task>
+<task compile_id='164' method='jdk.internal.module.ModuleBootstrap$2 next ()Ljava/lang/Object;' bytes='52' count='262' iicount='262' level='3' stamp='0.254'>
+<phase name='setup' stamp='0.254'>
+<phase_done name='setup' stamp='0.254'/>
+</phase>
+<phase name='buildIR' stamp='0.254'>
+<klass id='982' name='java.lang.Object' flags='1'/>
+<klass id='1093' name='jdk.internal.module.ModuleBootstrap$2' flags='0'/>
+<method id='1094' holder='1093' name='next' return='982' flags='1' bytes='52' iicount='276'/>
+<parse method='1094'  stamp='0.254'>
+<phase name='parse_hir' stamp='0.254'>
+<bc code='185' bci='4'/>
+<type id='969' name='boolean'/>
+<klass id='1097' name='java.util.Iterator' flags='1537'/>
+<method id='1098' holder='1097' name='hasNext' return='969' flags='1025' bytes='0' iicount='1'/>
+<call method='1098' instr='invokeinterface'/>
+<inline_fail reason='no static binding'/>
+<bc code='185' bci='16'/>
+<method id='1099' holder='1097' name='next' return='982' flags='1025' bytes='0' iicount='1'/>
+<call method='1099' instr='invokeinterface'/>
+<inline_fail reason='no static binding'/>
+<bc code='185' bci='26'/>
+<call method='1098' instr='invokeinterface'/>
+<inline_fail reason='no static binding'/>
+<bc code='185' bci='38'/>
+<call method='1099' instr='invokeinterface'/>
+<inline_fail reason='no static binding'/>
+<bc code='183' bci='48'/>
+<type id='977' name='void'/>
+<klass id='1100' name='java.util.NoSuchElementException' unloaded='1'/>
+<method id='1101' holder='1100' name='&lt;init&gt;' return='977' unloaded='1'/>
+<call method='1101' instr='invokespecial'/>
+<inline_fail reason='not inlineable'/>
+<phase_done name='parse_hir' stamp='0.255'/>
+</phase>
+<parse_done stamp='0.255'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.255'>
+<phase_done name='optimize_blocks' stamp='0.255'/>
+</phase>
+<phase name='gvn' stamp='0.255'>
+<phase_done name='gvn' stamp='0.255'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.255'>
+<phase_done name='rangeCheckElimination' stamp='0.255'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.255'>
+<phase_done name='optimize_null_checks' stamp='0.255'/>
+</phase>
+<phase_done name='buildIR' stamp='0.255'/>
+</phase>
+<phase name='emit_lir' stamp='0.255'>
+<phase name='lirGeneration' stamp='0.255'>
+<phase_done name='lirGeneration' stamp='0.255'/>
+</phase>
+<phase name='linearScan' stamp='0.255'>
+<phase_done name='linearScan' stamp='0.255'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.255'/>
+</phase>
+<phase name='codeemit' stamp='0.255'>
+<phase_done name='codeemit' stamp='0.255'/>
+</phase>
+<phase name='codeinstall' stamp='0.255'>
+<phase_done name='codeinstall' stamp='0.255'/>
+</phase>
+<code_cache total_blobs='478' nmethods='165' adapters='162' free_code_cache='248507008'/>
+<task_done success='1' nmsize='1384' count='465' stamp='0.255'/>
+</task>
+<task compile_id='170' method='java.lang.CharacterDataLatin1 toLowerCase (I)I' bytes='39' count='256' iicount='256' level='3' stamp='0.258'>
+<phase name='setup' stamp='0.258'>
+<phase_done name='setup' stamp='0.258'/>
+</phase>
+<phase name='buildIR' stamp='0.258'>
+<type id='975' name='int'/>
+<klass id='1093' name='java.lang.CharacterDataLatin1' flags='0'/>
+<method id='1094' holder='1093' name='toLowerCase' return='975' arguments='975' flags='0' bytes='39' iicount='256'/>
+<parse method='1094'  stamp='0.258'>
+<phase name='parse_hir' stamp='0.258'>
+<bc code='182' bci='4'/>
+<method id='1096' holder='1093' name='getProperties' return='975' arguments='975' flags='0' bytes='11' compile_id='124' compiler='c1' level='3' iicount='272'/>
+<call method='1096' instr='invokevirtual'/>
+<dependency type='leaf_type' ctxk='1093'/>
+<inline_success reason='receiver is statically known'/>
+<dependency type='leaf_type' ctxk='1093'/>
+<parse method='1096'>
+<parse_done stamp='0.258'/>
+</parse>
+<phase_done name='parse_hir' stamp='0.258'/>
+</phase>
+<parse_done stamp='0.258'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.258'>
+<phase_done name='optimize_blocks' stamp='0.258'/>
+</phase>
+<phase name='gvn' stamp='0.258'>
+<phase_done name='gvn' stamp='0.258'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.258'>
+<phase_done name='rangeCheckElimination' stamp='0.258'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.258'>
+<phase_done name='optimize_null_checks' stamp='0.258'/>
+</phase>
+<phase_done name='buildIR' stamp='0.258'/>
+</phase>
+<phase name='emit_lir' stamp='0.258'>
+<phase name='lirGeneration' stamp='0.258'>
+<phase_done name='lirGeneration' stamp='0.258'/>
+</phase>
+<phase name='linearScan' stamp='0.258'>
+<phase_done name='linearScan' stamp='0.258'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.258'/>
+</phase>
+<phase name='codeemit' stamp='0.258'>
+<phase_done name='codeemit' stamp='0.258'/>
+</phase>
+<phase name='codeinstall' stamp='0.258'>
+<dependency type='leaf_type' ctxk='1093'/>
+<phase_done name='codeinstall' stamp='0.258'/>
+</phase>
+<code_cache total_blobs='484' nmethods='170' adapters='163' free_code_cache='248500352'/>
+<task_done success='1' nmsize='656' count='256' inlined_bytes='11' stamp='0.258'/>
+</task>
+<task compile_id='174' method='java.lang.String &lt;init&gt; ([BB)V' bytes='15' count='285' iicount='285' level='3' stamp='0.283'>
+<phase name='setup' stamp='0.283'>
+<phase_done name='setup' stamp='0.283'/>
+</phase>
+<phase name='buildIR' stamp='0.283'>
+<type id='977' name='void'/>
+<klass id='1085' name='[B' flags='1041'/>
+<type id='973' name='byte'/>
+<klass id='983' name='java.lang.String' flags='17'/>
+<method id='1093' holder='983' name='&lt;init&gt;' return='977' arguments='1085 973' flags='0' bytes='15' iicount='285'/>
+<parse method='1093'  stamp='0.283'>
+<phase name='parse_hir' stamp='0.283'>
+<bc code='183' bci='1'/>
+<klass id='982' name='java.lang.Object' flags='1'/>
+<method id='1095' holder='982' name='&lt;init&gt;' return='977' flags='1' bytes='1' compile_id='50' compiler='c1' level='1' iicount='9918'/>
+<call method='1095' instr='invokespecial'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1095'>
+<parse_done stamp='0.284'/>
+</parse>
+<phase_done name='parse_hir' stamp='0.284'/>
+</phase>
+<parse_done stamp='0.284'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.284'>
+<phase_done name='optimize_blocks' stamp='0.284'/>
+</phase>
+<phase name='gvn' stamp='0.284'>
+<phase_done name='gvn' stamp='0.284'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.284'>
+<phase_done name='rangeCheckElimination' stamp='0.284'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.284'>
+<phase_done name='optimize_null_checks' stamp='0.284'/>
+</phase>
+<phase_done name='buildIR' stamp='0.284'/>
+</phase>
+<phase name='emit_lir' stamp='0.284'>
+<phase name='lirGeneration' stamp='0.284'>
+<phase_done name='lirGeneration' stamp='0.284'/>
+</phase>
+<phase name='linearScan' stamp='0.284'>
+<phase_done name='linearScan' stamp='0.284'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.284'/>
+</phase>
+<phase name='codeemit' stamp='0.284'>
+<phase_done name='codeemit' stamp='0.284'/>
+</phase>
+<phase name='codeinstall' stamp='0.284'>
+<phase_done name='codeinstall' stamp='0.284'/>
+</phase>
+<code_cache total_blobs='521' nmethods='175' adapters='195' free_code_cache='248476416'/>
+<task_done success='1' nmsize='528' count='285' inlined_bytes='1' stamp='0.284'/>
+</task>
+<task compile_id='179' method='java.lang.AbstractStringBuilder getCoder ()B' bytes='15' count='256' iicount='256' level='3' stamp='0.309'>
+<phase name='setup' stamp='0.309'>
+<phase_done name='setup' stamp='0.309'/>
+</phase>
+<phase name='buildIR' stamp='0.309'>
+<type id='973' name='byte'/>
+<klass id='1048' name='java.lang.AbstractStringBuilder' flags='1024'/>
+<method id='1093' holder='1048' name='getCoder' return='973' flags='16' bytes='15' iicount='256'/>
+<parse method='1093'  stamp='0.309'>
+<phase name='parse_hir' stamp='0.309'>
+<phase_done name='parse_hir' stamp='0.309'/>
+</phase>
+<parse_done stamp='0.309'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.309'>
+<phase_done name='optimize_blocks' stamp='0.309'/>
+</phase>
+<phase name='gvn' stamp='0.309'>
+<phase_done name='gvn' stamp='0.309'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.309'>
+<phase_done name='rangeCheckElimination' stamp='0.309'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.309'>
+<phase_done name='optimize_null_checks' stamp='0.309'/>
+</phase>
+<phase_done name='buildIR' stamp='0.309'/>
+</phase>
+<phase name='emit_lir' stamp='0.309'>
+<phase name='lirGeneration' stamp='0.309'>
+<phase_done name='lirGeneration' stamp='0.309'/>
+</phase>
+<phase name='linearScan' stamp='0.309'>
+<phase_done name='linearScan' stamp='0.309'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.309'/>
+</phase>
+<phase name='codeemit' stamp='0.309'>
+<phase_done name='codeemit' stamp='0.309'/>
+</phase>
+<phase name='codeinstall' stamp='0.309'>
+<phase_done name='codeinstall' stamp='0.309'/>
+</phase>
+<code_cache total_blobs='527' nmethods='178' adapters='198' free_code_cache='248471296'/>
+<task_done success='1' nmsize='368' count='259' stamp='0.309'/>
+</task>
+<task compile_id='182' method='java.lang.StringBuilder append (Ljava/lang/String;)Ljava/lang/StringBuilder;' bytes='8' count='281' iicount='281' level='3' stamp='0.317'>
+<phase name='setup' stamp='0.317'>
+<phase_done name='setup' stamp='0.317'/>
+</phase>
+<phase name='buildIR' stamp='0.317'>
+<klass id='1050' name='java.lang.StringBuilder' flags='17'/>
+<klass id='983' name='java.lang.String' flags='17'/>
+<method id='1093' holder='1050' name='append' return='1050' arguments='983' flags='1' bytes='8' iicount='281'/>
+<parse method='1093'  stamp='0.317'>
+<phase name='parse_hir' stamp='0.317'>
+<bc code='183' bci='2'/>
+<klass id='1048' name='java.lang.AbstractStringBuilder' flags='1024'/>
+<method id='1095' holder='1048' name='append' return='1048' arguments='983' flags='1' bytes='45' iicount='281'/>
+<call method='1095' instr='invokespecial'/>
+<inline_fail reason='callee is too large'/>
+<phase_done name='parse_hir' stamp='0.317'/>
+</phase>
+<parse_done stamp='0.317'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.317'>
+<phase_done name='optimize_blocks' stamp='0.317'/>
+</phase>
+<phase name='gvn' stamp='0.317'>
+<phase_done name='gvn' stamp='0.317'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.317'>
+<phase_done name='rangeCheckElimination' stamp='0.317'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.317'>
+<phase_done name='optimize_null_checks' stamp='0.317'/>
+</phase>
+<phase_done name='buildIR' stamp='0.317'/>
+</phase>
+<phase name='emit_lir' stamp='0.317'>
+<phase name='lirGeneration' stamp='0.317'>
+<phase_done name='lirGeneration' stamp='0.317'/>
+</phase>
+<phase name='linearScan' stamp='0.317'>
+<phase_done name='linearScan' stamp='0.317'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.317'/>
+</phase>
+<phase name='codeemit' stamp='0.317'>
+<phase_done name='codeemit' stamp='0.317'/>
+</phase>
+<phase name='codeinstall' stamp='0.317'>
+<phase_done name='codeinstall' stamp='0.317'/>
+</phase>
+<code_cache total_blobs='531' nmethods='182' adapters='198' free_code_cache='248464384'/>
+<task_done success='1' nmsize='392' count='281' stamp='0.317'/>
+</task>
+<task compile_id='187' method='java.lang.Enum ordinal ()I' bytes='5' count='133' iicount='133' level='1' stamp='0.323'>
+<phase name='setup' stamp='0.323'>
+<phase_done name='setup' stamp='0.323'/>
+</phase>
+<phase name='buildIR' stamp='0.323'>
+<type id='975' name='int'/>
+<klass id='1093' name='java.lang.Enum' flags='1025'/>
+<method id='1094' holder='1093' name='ordinal' return='975' flags='17' bytes='5' iicount='133'/>
+<parse method='1094'  stamp='0.323'>
+<phase name='parse_hir' stamp='0.323'>
+<phase_done name='parse_hir' stamp='0.323'/>
+</phase>
+<parse_done stamp='0.323'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.323'>
+<phase_done name='optimize_blocks' stamp='0.323'/>
+</phase>
+<phase name='gvn' stamp='0.323'>
+<phase_done name='gvn' stamp='0.323'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.323'>
+<phase_done name='rangeCheckElimination' stamp='0.323'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.323'>
+<phase_done name='optimize_null_checks' stamp='0.323'/>
+</phase>
+<phase_done name='buildIR' stamp='0.323'/>
+</phase>
+<phase name='emit_lir' stamp='0.323'>
+<phase name='lirGeneration' stamp='0.323'>
+<phase_done name='lirGeneration' stamp='0.323'/>
+</phase>
+<phase name='linearScan' stamp='0.323'>
+<phase_done name='linearScan' stamp='0.323'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.323'/>
+</phase>
+<phase name='codeemit' stamp='0.323'>
+<phase_done name='codeemit' stamp='0.323'/>
+</phase>
+<phase name='codeinstall' stamp='0.323'>
+<phase_done name='codeinstall' stamp='0.323'/>
+</phase>
+<code_cache total_blobs='558' nmethods='187' adapters='220' free_code_cache='248439040'/>
+<task_done success='1' nmsize='272' count='133' stamp='0.323'/>
+</task>
+<task compile_id='190' method='java.lang.AbstractStringBuilder isLatin1 ()Z' bytes='19' count='277' iicount='277' level='3' stamp='0.323'>
+<phase name='setup' stamp='0.323'>
+<phase_done name='setup' stamp='0.323'/>
+</phase>
+<phase name='buildIR' stamp='0.323'>
+<type id='969' name='boolean'/>
+<klass id='1048' name='java.lang.AbstractStringBuilder' flags='1024'/>
+<method id='1093' holder='1048' name='isLatin1' return='969' flags='16' bytes='19' iicount='277'/>
+<parse method='1093'  stamp='0.323'>
+<phase name='parse_hir' stamp='0.323'>
+<phase_done name='parse_hir' stamp='0.323'/>
+</phase>
+<parse_done stamp='0.323'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.323'>
+<phase_done name='optimize_blocks' stamp='0.323'/>
+</phase>
+<phase name='gvn' stamp='0.323'>
+<phase_done name='gvn' stamp='0.323'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.323'>
+<phase_done name='rangeCheckElimination' stamp='0.323'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.323'>
+<phase_done name='optimize_null_checks' stamp='0.323'/>
+</phase>
+<phase_done name='buildIR' stamp='0.323'/>
+</phase>
+<phase name='emit_lir' stamp='0.323'>
+<phase name='lirGeneration' stamp='0.324'>
+<phase_done name='lirGeneration' stamp='0.324'/>
+</phase>
+<phase name='linearScan' stamp='0.324'>
+<phase_done name='linearScan' stamp='0.324'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.324'/>
+</phase>
+<phase name='codeemit' stamp='0.324'>
+<phase_done name='codeemit' stamp='0.324'/>
+</phase>
+<phase name='codeinstall' stamp='0.324'>
+<phase_done name='codeinstall' stamp='0.324'/>
+</phase>
+<code_cache total_blobs='561' nmethods='190' adapters='220' free_code_cache='248436096'/>
+<task_done success='1' nmsize='464' count='277' stamp='0.324'/>
+</task>
+<task compile_id='198' method='java.lang.StringLatin1 newString ([BII)Ljava/lang/String;' bytes='17' count='283' iicount='283' level='3' stamp='0.328'>
+<phase name='setup' stamp='0.328'>
+<phase_done name='setup' stamp='0.328'/>
+</phase>
+<phase name='buildIR' stamp='0.328'>
+<klass id='983' name='java.lang.String' flags='17'/>
+<klass id='1085' name='[B' flags='1041'/>
+<type id='975' name='int'/>
+<klass id='1093' name='java.lang.StringLatin1' flags='16'/>
+<method id='1094' holder='1093' name='newString' return='983' arguments='1085 975 975' flags='9' bytes='17' iicount='284'/>
+<parse method='1094'  stamp='0.328'>
+<phase name='parse_hir' stamp='0.328'>
+<bc code='184' bci='9'/>
+<klass id='1096' name='java.util.Arrays' flags='1'/>
+<method id='1097' holder='1096' name='copyOfRange' return='1085' arguments='1085 975 975' flags='9' bytes='63' compile_id='186' compiler='c1' level='3' iicount='301'/>
+<call method='1097' instr='invokestatic'/>
+<inline_fail reason='callee is too large'/>
+<bc code='183' bci='13'/>
+<type id='977' name='void'/>
+<type id='973' name='byte'/>
+<method id='1099' holder='983' name='&lt;init&gt;' return='977' arguments='1085 973' flags='0' bytes='15' compile_id='174' compiler='c1' level='3' iicount='448'/>
+<call method='1099' instr='invokespecial'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1099'>
+<bc code='183' bci='1'/>
+<klass id='982' name='java.lang.Object' flags='1'/>
+<method id='1101' holder='982' name='&lt;init&gt;' return='977' flags='1' bytes='1' compile_id='50' compiler='c1' level='1' iicount='10344'/>
+<call method='1101' instr='invokespecial'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1101'>
+<parse_done stamp='0.328'/>
+</parse>
+<parse_done stamp='0.328'/>
+</parse>
+<phase_done name='parse_hir' stamp='0.328'/>
+</phase>
+<parse_done stamp='0.328'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.328'>
+<phase_done name='optimize_blocks' stamp='0.328'/>
+</phase>
+<phase name='gvn' stamp='0.328'>
+<phase_done name='gvn' stamp='0.328'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.328'>
+<phase_done name='rangeCheckElimination' stamp='0.328'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.328'>
+<phase_done name='optimize_null_checks' stamp='0.328'/>
+</phase>
+<phase_done name='buildIR' stamp='0.328'/>
+</phase>
+<phase name='emit_lir' stamp='0.328'>
+<phase name='lirGeneration' stamp='0.328'>
+<phase_done name='lirGeneration' stamp='0.328'/>
+</phase>
+<phase name='linearScan' stamp='0.328'>
+<phase_done name='linearScan' stamp='0.328'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.328'/>
+</phase>
+<phase name='codeemit' stamp='0.328'>
+<phase_done name='codeemit' stamp='0.328'/>
+</phase>
+<phase name='codeinstall' stamp='0.328'>
+<phase_done name='codeinstall' stamp='0.328'/>
+</phase>
+<code_cache total_blobs='576' nmethods='201' adapters='224' free_code_cache='248422016'/>
+<task_done success='1' nmsize='776' count='287' inlined_bytes='16' stamp='0.328'/>
+</task>
+<task compile_id='202' method='java.lang.invoke.MethodType returnType ()Ljava/lang/Class;' bytes='5' count='128' iicount='128' level='1' stamp='0.328'>
+<phase name='setup' stamp='0.329'>
+<phase_done name='setup' stamp='0.329'/>
+</phase>
+<phase name='buildIR' stamp='0.329'>
+<klass id='984' name='java.lang.Class' flags='17'/>
+<klass id='1041' name='java.lang.invoke.MethodType' flags='17'/>
+<method id='1093' holder='1041' name='returnType' return='984' flags='1' bytes='5' iicount='128'/>
+<parse method='1093'  stamp='0.329'>
+<phase name='parse_hir' stamp='0.329'>
+<phase_done name='parse_hir' stamp='0.329'/>
+</phase>
+<parse_done stamp='0.329'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.329'>
+<phase_done name='optimize_blocks' stamp='0.329'/>
+</phase>
+<phase name='gvn' stamp='0.329'>
+<phase_done name='gvn' stamp='0.329'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.329'>
+<phase_done name='rangeCheckElimination' stamp='0.329'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.329'>
+<phase_done name='optimize_null_checks' stamp='0.329'/>
+</phase>
+<phase_done name='buildIR' stamp='0.329'/>
+</phase>
+<phase name='emit_lir' stamp='0.329'>
+<phase name='lirGeneration' stamp='0.329'>
+<phase_done name='lirGeneration' stamp='0.329'/>
+</phase>
+<phase name='linearScan' stamp='0.329'>
+<phase_done name='linearScan' stamp='0.329'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.329'/>
+</phase>
+<phase name='codeemit' stamp='0.329'>
+<phase_done name='codeemit' stamp='0.329'/>
+</phase>
+<phase name='codeinstall' stamp='0.329'>
+<phase_done name='codeinstall' stamp='0.329'/>
+</phase>
+<code_cache total_blobs='577' nmethods='202' adapters='224' free_code_cache='248421248'/>
+<task_done success='1' nmsize='272' count='128' stamp='0.329'/>
+</task>
+<task compile_id='210' method='java.lang.invoke.MemberName testFlags (II)Z' bytes='16' count='256' iicount='256' level='3' stamp='0.334'>
+<phase name='setup' stamp='0.334'>
+<phase_done name='setup' stamp='0.334'/>
+</phase>
+<phase name='buildIR' stamp='0.334'>
+<type id='969' name='boolean'/>
+<type id='975' name='int'/>
+<klass id='1038' name='java.lang.invoke.MemberName' flags='16'/>
+<method id='1093' holder='1038' name='testFlags' return='969' arguments='975 975' flags='2' bytes='16' iicount='258'/>
+<parse method='1093'  stamp='0.334'>
+<phase name='parse_hir' stamp='0.334'>
+<phase_done name='parse_hir' stamp='0.334'/>
+</phase>
+<parse_done stamp='0.334'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.334'>
+<phase_done name='optimize_blocks' stamp='0.334'/>
+</phase>
+<phase name='gvn' stamp='0.334'>
+<phase_done name='gvn' stamp='0.334'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.334'>
+<phase_done name='rangeCheckElimination' stamp='0.334'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.334'>
+<phase_done name='optimize_null_checks' stamp='0.334'/>
+</phase>
+<phase_done name='buildIR' stamp='0.334'/>
+</phase>
+<phase name='emit_lir' stamp='0.334'>
+<phase name='lirGeneration' stamp='0.334'>
+<phase_done name='lirGeneration' stamp='0.334'/>
+</phase>
+<phase name='linearScan' stamp='0.334'>
+<phase_done name='linearScan' stamp='0.334'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.334'/>
+</phase>
+<phase name='codeemit' stamp='0.334'>
+<phase_done name='codeemit' stamp='0.334'/>
+</phase>
+<phase name='codeinstall' stamp='0.334'>
+<phase_done name='codeinstall' stamp='0.334'/>
+</phase>
+<code_cache total_blobs='593' nmethods='210' adapters='232' free_code_cache='248405632'/>
+<task_done success='1' nmsize='432' count='269' stamp='0.334'/>
+</task>
+<task compile_id='217' method='java.lang.invoke.MethodType hashCode ()I' bytes='53' count='259' backedge_count='833' iicount='259' level='3' stamp='0.336'>
+<phase name='setup' stamp='0.336'>
+<phase_done name='setup' stamp='0.336'/>
+</phase>
+<phase name='buildIR' stamp='0.336'>
+<type id='975' name='int'/>
+<klass id='1041' name='java.lang.invoke.MethodType' flags='17'/>
+<method id='1093' holder='1041' name='hashCode' return='975' flags='1' bytes='53' iicount='259'/>
+<parse method='1093'  stamp='0.336'>
+<phase name='parse_hir' stamp='0.336'>
+<bc code='182' bci='6'/>
+<klass id='982' name='java.lang.Object' flags='1'/>
+<method id='1095' holder='982' name='hashCode' return='975' flags='257' bytes='0' compile_id='93' compile_kind='c2n' compiler='' level='0' iicount='256'/>
+<call method='1095' instr='invokevirtual'/>
+<inline_fail reason='native method'/>
+<bc code='182' bci='40'/>
+<call method='1095' instr='invokevirtual'/>
+<inline_fail reason='native method'/>
+<phase_done name='parse_hir' stamp='0.336'/>
+</phase>
+<parse_done stamp='0.336'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.336'>
+<phase_done name='optimize_blocks' stamp='0.336'/>
+</phase>
+<phase name='gvn' stamp='0.336'>
+<phase_done name='gvn' stamp='0.336'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.336'>
+<phase_done name='rangeCheckElimination' stamp='0.336'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.336'>
+<phase_done name='optimize_null_checks' stamp='0.336'/>
+</phase>
+<phase_done name='buildIR' stamp='0.336'/>
+</phase>
+<phase name='emit_lir' stamp='0.336'>
+<phase name='lirGeneration' stamp='0.336'>
+<phase_done name='lirGeneration' stamp='0.336'/>
+</phase>
+<phase name='linearScan' stamp='0.336'>
+<phase_done name='linearScan' stamp='0.337'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.337'/>
+</phase>
+<phase name='codeemit' stamp='0.337'>
+<phase_done name='codeemit' stamp='0.337'/>
+</phase>
+<phase name='codeinstall' stamp='0.337'>
+<phase_done name='codeinstall' stamp='0.337'/>
+</phase>
+<code_cache total_blobs='602' nmethods='217' adapters='232' free_code_cache='248397824'/>
+<task_done success='1' nmsize='952' count='265' backedge_count='849' stamp='0.337'/>
+</task>
+<task compile_id='220' method='java.lang.AbstractStringBuilder append (C)Ljava/lang/AbstractStringBuilder;' bytes='77' count='257' iicount='257' level='3' stamp='0.337'>
+<phase name='setup' stamp='0.337'>
+<phase_done name='setup' stamp='0.337'/>
+</phase>
+<phase name='buildIR' stamp='0.337'>
+<klass id='1048' name='java.lang.AbstractStringBuilder' flags='1024'/>
+<type id='970' name='char'/>
+<method id='1093' holder='1048' name='append' return='1048' arguments='970' flags='1' bytes='77' iicount='258'/>
+<parse method='1093'  stamp='0.337'>
+<phase name='parse_hir' stamp='0.337'>
+<bc code='183' bci='7'/>
+<type id='977' name='void'/>
+<type id='975' name='int'/>
+<method id='1095' holder='1048' name='ensureCapacityInternal' return='977' arguments='975' flags='2' bytes='39' compile_id='129' compiler='c1' level='3' iicount='709'/>
+<call method='1095' instr='invokespecial'/>
+<inline_fail reason='callee is too large'/>
+<bc code='182' bci='11'/>
+<type id='969' name='boolean'/>
+<method id='1097' holder='1048' name='isLatin1' return='969' flags='16' bytes='19' compile_id='190' compiler='c1' level='3' iicount='527'/>
+<call method='1097' instr='invokevirtual'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1097'>
+<parse_done stamp='0.337'/>
+</parse>
+<bc code='184' bci='18'/>
+<klass id='1100' name='java.lang.StringLatin1' flags='16'/>
+<method id='1101' holder='1100' name='canEncode' return='969' arguments='975' flags='9' bytes='13' compile_id='49' compiler='c1' level='3' iicount='2001'/>
+<call method='1101' instr='invokestatic'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1101'>
+<parse_done stamp='0.337'/>
+</parse>
+<bc code='182' bci='46'/>
+<call method='1097' instr='invokevirtual'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1097'>
+<parse_done stamp='0.337'/>
+</parse>
+<bc code='183' bci='53'/>
+<method id='1103' holder='1048' name='inflate' return='977' flags='2' bytes='42' iicount='1'/>
+<call method='1103' instr='invokespecial'/>
+<inline_fail reason='callee is too large'/>
+<bc code='184' bci='72'/>
+<klass id='1085' name='[B' flags='1041'/>
+<klass id='1105' name='java.lang.StringUTF16' flags='16'/>
+<method id='1106' holder='1105' name='putCharSB' return='977' arguments='1085 975 975' flags='9' bytes='12' iicount='1'/>
+<call method='1106' instr='invokestatic'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1106'>
+<bc code='184' bci='2'/>
+<method id='1108' holder='1105' name='checkIndex' return='977' arguments='975 1085' flags='9' bytes='9' iicount='1'/>
+<call method='1108' instr='invokestatic'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1108'>
+<bc code='184' bci='2'/>
+<method id='1110' holder='1105' name='length' return='975' arguments='1085' flags='9' bytes='5' iicount='1'/>
+<call method='1110' instr='invokestatic'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1110'>
+<parse_done stamp='0.337'/>
+</parse>
+<bc code='184' bci='5'/>
+<klass id='983' name='java.lang.String' flags='17'/>
+<method id='1112' holder='983' name='checkIndex' return='977' arguments='975 975' flags='8' bytes='46' iicount='21'/>
+<call method='1112' instr='invokestatic'/>
+<inline_fail reason='callee is too large'/>
+<parse_done stamp='0.337'/>
+</parse>
+<bc code='184' bci='8'/>
+<method id='1114' holder='1105' name='putChar' return='977' arguments='1085 975 975' flags='8' bytes='54' iicount='1'/>
+<call method='1114' instr='invokestatic'/>
+<inline_success reason='intrinsic'/>
+<parse_done stamp='0.337'/>
+</parse>
+<phase_done name='parse_hir' stamp='0.337'/>
+</phase>
+<parse_done stamp='0.337'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.337'>
+<phase_done name='optimize_blocks' stamp='0.337'/>
+</phase>
+<phase name='gvn' stamp='0.337'>
+<phase_done name='gvn' stamp='0.337'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.337'>
+<phase_done name='rangeCheckElimination' stamp='0.337'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.337'>
+<phase_done name='optimize_null_checks' stamp='0.337'/>
+</phase>
+<phase_done name='buildIR' stamp='0.337'/>
+</phase>
+<phase name='emit_lir' stamp='0.337'>
+<phase name='lirGeneration' stamp='0.337'>
+<phase_done name='lirGeneration' stamp='0.337'/>
+</phase>
+<phase name='linearScan' stamp='0.337'>
+<phase_done name='linearScan' stamp='0.337'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.337'/>
+</phase>
+<phase name='codeemit' stamp='0.337'>
+<phase_done name='codeemit' stamp='0.337'/>
+</phase>
+<phase name='codeinstall' stamp='0.337'>
+<phase_done name='codeinstall' stamp='0.337'/>
+</phase>
+<code_cache total_blobs='607' nmethods='222' adapters='232' free_code_cache='248388736'/>
+<task_done success='1' nmsize='2024' count='279' inlined_bytes='77' stamp='0.337'/>
+</task>
+<task compile_id='229' method='java.lang.StringLatin1 replace ([BCC)Ljava/lang/String;' bytes='196' count='105' backedge_count='3096' iicount='105' level='3' stamp='0.341'>
+<phase name='setup' stamp='0.341'>
+<phase_done name='setup' stamp='0.341'/>
+</phase>
+<phase name='buildIR' stamp='0.341'>
+<klass id='983' name='java.lang.String' flags='17'/>
+<klass id='1085' name='[B' flags='1041'/>
+<type id='970' name='char'/>
+<klass id='1093' name='java.lang.StringLatin1' flags='16'/>
+<method id='1094' holder='1093' name='replace' return='983' arguments='1085 970 970' flags='9' bytes='196' iicount='105'/>
+<parse method='1094'  stamp='0.341'>
+<phase name='parse_hir' stamp='0.341'>
+<bc code='184' bci='1'/>
+<type id='969' name='boolean'/>
+<type id='975' name='int'/>
+<method id='1096' holder='1093' name='canEncode' return='969' arguments='975' flags='9' bytes='13' compile_id='49' compiler='c1' level='3' iicount='2289'/>
+<call method='1096' instr='invokestatic'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1096'>
+<parse_done stamp='0.341'/>
+</parse>
+<bc code='184' bci='41'/>
+<call method='1096' instr='invokestatic'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1096'>
+<parse_done stamp='0.341'/>
+</parse>
+<bc code='183' bci='121'/>
+<type id='977' name='void'/>
+<type id='973' name='byte'/>
+<method id='1098' holder='983' name='&lt;init&gt;' return='977' arguments='1085 973' flags='0' bytes='15' compile_id='174' compiler='c1' level='3' iicount='740'/>
+<call method='1098' instr='invokespecial'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1098'>
+<bc code='183' bci='1'/>
+<klass id='982' name='java.lang.Object' flags='1'/>
+<method id='1100' holder='982' name='&lt;init&gt;' return='977' flags='1' bytes='1' compile_id='50' compiler='c1' level='1' iicount='10887'/>
+<call method='1100' instr='invokespecial'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1100'>
+<parse_done stamp='0.341'/>
+</parse>
+<parse_done stamp='0.341'/>
+</parse>
+<bc code='184' bci='126'/>
+<klass id='1102' name='java.lang.StringUTF16' flags='16'/>
+<method id='1103' holder='1102' name='newBytesFor' return='1085' arguments='975' flags='9' bytes='61' iicount='1'/>
+<call method='1103' instr='invokestatic'/>
+<inline_fail reason='callee is too large'/>
+<bc code='184' bci='138'/>
+<method id='1105' holder='1093' name='inflate' return='977' arguments='1085 975 1085 975 975' flags='9' bytes='10' iicount='1'/>
+<call method='1105' instr='invokestatic'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1105'>
+<bc code='184' bci='6'/>
+<method id='1107' holder='1102' name='inflate' return='977' arguments='1085 975 1085 975 975' flags='9' bytes='42' iicount='1'/>
+<call method='1107' instr='invokestatic'/>
+<inline_fail reason='callee is too large'/>
+<parse_done stamp='0.341'/>
+</parse>
+<bc code='184' bci='174'/>
+<method id='1109' holder='1102' name='putChar' return='977' arguments='1085 975 975' flags='8' bytes='54' iicount='1'/>
+<call method='1109' instr='invokestatic'/>
+<inline_success reason='intrinsic'/>
+<bc code='183' bci='190'/>
+<call method='1098' instr='invokespecial'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1098'>
+<bc code='183' bci='1'/>
+<call method='1100' instr='invokespecial'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1100'>
+<parse_done stamp='0.342'/>
+</parse>
+<parse_done stamp='0.342'/>
+</parse>
+<phase_done name='parse_hir' stamp='0.342'/>
+</phase>
+<parse_done stamp='0.342'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.342'>
+<phase_done name='optimize_blocks' stamp='0.342'/>
+</phase>
+<phase name='gvn' stamp='0.342'>
+<phase_done name='gvn' stamp='0.342'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.342'>
+<phase_done name='rangeCheckElimination' stamp='0.342'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.342'>
+<phase_done name='optimize_null_checks' stamp='0.342'/>
+</phase>
+<phase_done name='buildIR' stamp='0.342'/>
+</phase>
+<phase name='emit_lir' stamp='0.342'>
+<phase name='lirGeneration' stamp='0.342'>
+<phase_done name='lirGeneration' stamp='0.342'/>
+</phase>
+<phase name='linearScan' stamp='0.342'>
+<phase_done name='linearScan' stamp='0.342'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.342'/>
+</phase>
+<phase name='codeemit' stamp='0.342'>
+<phase_done name='codeemit' stamp='0.342'/>
+</phase>
+<phase name='codeinstall' stamp='0.342'>
+<phase_done name='codeinstall' stamp='0.342'/>
+</phase>
+<code_cache total_blobs='617' nmethods='230' adapters='234' free_code_cache='248374272'/>
+<task_done success='1' nmsize='3160' count='105' backedge_count='3096' inlined_bytes='68' stamp='0.342'/>
+</task>
+</compilation_log>
+<compilation_log thread='23814'>
+<start_compile_thread name='C1 CompilerThread9' thread='23814' process='23756' stamp='0.179'/>
+<task compile_id='2' method='java.lang.StringLatin1 hashCode ([B)I' bytes='42' count='111' backedge_count='2080' iicount='111' level='3' stamp='0.182'>
+<phase name='setup' stamp='0.182'>
+<phase_done name='setup' stamp='0.182'/>
+</phase>
+<phase name='buildIR' stamp='0.182'>
+<type id='975' name='int'/>
+<klass id='1085' name='[B' flags='1041'/>
+<klass id='1093' name='java.lang.StringLatin1' flags='16'/>
+<method id='1094' holder='1093' name='hashCode' return='975' arguments='1085' flags='9' bytes='42' iicount='113'/>
+<parse method='1094'  stamp='0.182'>
+<phase name='parse_hir' stamp='0.182'>
+<phase_done name='parse_hir' stamp='0.182'/>
+</phase>
+<parse_done stamp='0.182'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.182'>
+<phase_done name='optimize_blocks' stamp='0.182'/>
+</phase>
+<phase name='gvn' stamp='0.182'>
+<phase_done name='gvn' stamp='0.182'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.183'>
+<phase_done name='rangeCheckElimination' stamp='0.183'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.183'>
+<phase_done name='optimize_null_checks' stamp='0.183'/>
+</phase>
+<phase_done name='buildIR' stamp='0.183'/>
+</phase>
+<phase name='emit_lir' stamp='0.183'>
+<phase name='lirGeneration' stamp='0.183'>
+<phase_done name='lirGeneration' stamp='0.184'/>
+</phase>
+<phase name='linearScan' stamp='0.184'>
+<phase_done name='linearScan' stamp='0.184'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.184'/>
+</phase>
+<phase name='codeemit' stamp='0.184'>
+<phase_done name='codeemit' stamp='0.184'/>
+</phase>
+<phase name='codeinstall' stamp='0.184'>
+<phase_done name='codeinstall' stamp='0.184'/>
+</phase>
+<code_cache total_blobs='228' nmethods='2' adapters='131' free_code_cache='248790528'/>
+<task_done success='1' nmsize='528' count='115' backedge_count='2260' stamp='0.184'/>
+</task>
+<task compile_id='6' method='java.lang.String charAt (I)C' bytes='25' count='533' iicount='534' level='3' stamp='0.195'>
+<phase name='setup' stamp='0.195'>
+<phase_done name='setup' stamp='0.195'/>
+</phase>
+<phase name='buildIR' stamp='0.195'>
+<type id='970' name='char'/>
+<type id='975' name='int'/>
+<klass id='983' name='java.lang.String' flags='17'/>
+<method id='1093' holder='983' name='charAt' return='970' arguments='975' flags='1' bytes='25' iicount='562'/>
+<parse method='1093'  stamp='0.195'>
+<phase name='parse_hir' stamp='0.195'>
+<bc code='183' bci='1'/>
+<type id='969' name='boolean'/>
+<method id='1095' holder='983' name='isLatin1' return='969' flags='2' bytes='19' compile_id='5' compiler='c1' level='3' iicount='1046'/>
+<call method='1095' instr='invokespecial'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1095'>
+<parse_done stamp='0.195'/>
+</parse>
+<bc code='184' bci='12'/>
+<klass id='1085' name='[B' flags='1041'/>
+<klass id='1098' name='java.lang.StringLatin1' flags='16'/>
+<method id='1099' holder='1098' name='charAt' return='970' arguments='1085 975' flags='9' bytes='28' iicount='622'/>
+<call method='1099' instr='invokestatic'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1099'>
+<bc code='183' bci='15'/>
+<type id='977' name='void'/>
+<klass id='1101' name='java.lang.StringIndexOutOfBoundsException' unloaded='1'/>
+<method id='1102' holder='1101' name='&lt;init&gt;' return='977' arguments='975' unloaded='1'/>
+<call method='1102' instr='invokespecial'/>
+<inline_fail reason='not inlineable'/>
+<parse_done stamp='0.195'/>
+</parse>
+<bc code='184' bci='21'/>
+<klass id='1103' name='java.lang.StringUTF16' flags='16'/>
+<method id='1104' holder='1103' name='charAt' return='970' arguments='1085 975' flags='9' bytes='11' iicount='1'/>
+<call method='1104' instr='invokestatic'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1104'>
+<bc code='184' bci='2'/>
+<method id='1106' holder='1103' name='checkIndex' return='977' arguments='975 1085' flags='9' bytes='9' iicount='1'/>
+<call method='1106' instr='invokestatic'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1106'>
+<bc code='184' bci='2'/>
+<method id='1108' holder='1103' name='length' return='975' arguments='1085' flags='9' bytes='5' iicount='1'/>
+<call method='1108' instr='invokestatic'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1108'>
+<parse_done stamp='0.195'/>
+</parse>
+<bc code='184' bci='5'/>
+<method id='1110' holder='983' name='checkIndex' return='977' arguments='975 975' flags='8' bytes='46' iicount='1'/>
+<call method='1110' instr='invokestatic'/>
+<inline_fail reason='callee is too large'/>
+<parse_done stamp='0.196'/>
+</parse>
+<bc code='184' bci='7'/>
+<method id='1112' holder='1103' name='getChar' return='970' arguments='1085 975' flags='8' bytes='60' compile_id='1' compiler='c1' level='3' iicount='512'/>
+<call method='1112' instr='invokestatic'/>
+<inline_success reason='intrinsic'/>
+<parse_done stamp='0.196'/>
+</parse>
+<phase_done name='parse_hir' stamp='0.196'/>
+</phase>
+<parse_done stamp='0.196'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.196'>
+<phase_done name='optimize_blocks' stamp='0.196'/>
+</phase>
+<phase name='gvn' stamp='0.196'>
+<phase_done name='gvn' stamp='0.196'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.196'>
+<phase_done name='rangeCheckElimination' stamp='0.196'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.196'>
+<phase_done name='optimize_null_checks' stamp='0.196'/>
+</phase>
+<phase_done name='buildIR' stamp='0.196'/>
+</phase>
+<phase name='emit_lir' stamp='0.196'>
+<phase name='lirGeneration' stamp='0.196'>
+<phase_done name='lirGeneration' stamp='0.196'/>
+</phase>
+<phase name='linearScan' stamp='0.196'>
+<phase_done name='linearScan' stamp='0.196'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.196'/>
+</phase>
+<phase name='codeemit' stamp='0.196'>
+<phase_done name='codeemit' stamp='0.196'/>
+</phase>
+<phase name='codeinstall' stamp='0.196'>
+<phase_done name='codeinstall' stamp='0.196'/>
+</phase>
+<code_cache total_blobs='300' nmethods='7' adapters='153' free_code_cache='248766464'/>
+<task_done success='1' nmsize='1400' count='660' inlined_bytes='72' stamp='0.196'/>
+</task>
+<task compile_id='11' method='java.lang.Math floorMod (II)I' bytes='10' count='303' iicount='303' level='3' stamp='0.208'>
+<phase name='setup' stamp='0.208'>
+<phase_done name='setup' stamp='0.208'/>
+</phase>
+<phase name='buildIR' stamp='0.208'>
+<type id='975' name='int'/>
+<klass id='1093' name='java.lang.Math' flags='17'/>
+<method id='1094' holder='1093' name='floorMod' return='975' arguments='975 975' flags='9' bytes='10' iicount='306'/>
+<parse method='1094'  stamp='0.208'>
+<phase name='parse_hir' stamp='0.208'>
+<bc code='184' bci='3'/>
+<method id='1096' holder='1093' name='floorDiv' return='975' arguments='975 975' flags='9' bytes='22' iicount='317'/>
+<call method='1096' instr='invokestatic'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1096'>
+<parse_done stamp='0.208'/>
+</parse>
+<phase_done name='parse_hir' stamp='0.208'/>
+</phase>
+<parse_done stamp='0.208'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.208'>
+<phase_done name='optimize_blocks' stamp='0.208'/>
+</phase>
+<phase name='gvn' stamp='0.208'>
+<phase_done name='gvn' stamp='0.208'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.208'>
+<phase_done name='rangeCheckElimination' stamp='0.208'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.208'>
+<phase_done name='optimize_null_checks' stamp='0.208'/>
+</phase>
+<phase_done name='buildIR' stamp='0.208'/>
+</phase>
+<phase name='emit_lir' stamp='0.208'>
+<phase name='lirGeneration' stamp='0.208'>
+<phase_done name='lirGeneration' stamp='0.208'/>
+</phase>
+<phase name='linearScan' stamp='0.208'>
+<phase_done name='linearScan' stamp='0.208'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.208'/>
+</phase>
+<phase name='codeemit' stamp='0.208'>
+<phase_done name='codeemit' stamp='0.208'/>
+</phase>
+<phase name='codeinstall' stamp='0.208'>
+<phase_done name='codeinstall' stamp='0.208'/>
+</phase>
+<code_cache total_blobs='309' nmethods='11' adapters='158' free_code_cache='248756736'/>
+<task_done success='1' nmsize='560' count='317' inlined_bytes='22' stamp='0.208'/>
+</task>
+<task compile_id='18' method='java.lang.module.ModuleDescriptor$Exports &lt;init&gt; (Ljava/util/Set;Ljava/lang/String;Ljava/util/Set;ZLjava/lang/module/ModuleDescriptor$1;)V' bytes='10' count='273' iicount='273' level='3' stamp='0.212'>
+<phase name='setup' stamp='0.212'>
+<phase_done name='setup' stamp='0.212'/>
+</phase>
+<phase name='buildIR' stamp='0.212'>
+<type id='977' name='void'/>
+<klass id='1094' name='java.util.Set' flags='1537'/>
+<klass id='983' name='java.lang.String' flags='17'/>
+<type id='969' name='boolean'/>
+<klass id='1095' name='java.lang.module.ModuleDescriptor$1' flags='0'/>
+<klass id='1093' name='java.lang.module.ModuleDescriptor$Exports' flags='25'/>
+<method id='1096' holder='1093' name='&lt;init&gt;' return='977' arguments='1094 983 1094 969 1095' flags='4096' bytes='10' iicount='290'/>
+<parse method='1096'  stamp='0.212'>
+<phase name='parse_hir' stamp='0.212'>
+<bc code='183' bci='6'/>
+<method id='1098' holder='1093' name='&lt;init&gt;' return='977' arguments='1094 983 1094 969' flags='2' bytes='20' iicount='290'/>
+<call method='1098' instr='invokespecial'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1098'>
+<bc code='183' bci='1'/>
+<klass id='982' name='java.lang.Object' flags='1'/>
+<method id='1100' holder='982' name='&lt;init&gt;' return='977' flags='1' bytes='1' compile_id='9' compiler='c1' level='3' iicount='1376'/>
+<call method='1100' instr='invokespecial'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1100'>
+<parse_done stamp='0.212'/>
+</parse>
+<parse_done stamp='0.212'/>
+</parse>
+<phase_done name='parse_hir' stamp='0.212'/>
+</phase>
+<parse_done stamp='0.212'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.212'>
+<phase_done name='optimize_blocks' stamp='0.212'/>
+</phase>
+<phase name='gvn' stamp='0.212'>
+<phase_done name='gvn' stamp='0.212'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.212'>
+<phase_done name='rangeCheckElimination' stamp='0.212'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.212'>
+<phase_done name='optimize_null_checks' stamp='0.212'/>
+</phase>
+<phase_done name='buildIR' stamp='0.212'/>
+</phase>
+<phase name='emit_lir' stamp='0.212'>
+<phase name='lirGeneration' stamp='0.212'>
+<phase_done name='lirGeneration' stamp='0.212'/>
+</phase>
+<phase name='linearScan' stamp='0.212'>
+<phase_done name='linearScan' stamp='0.212'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.213'/>
+</phase>
+<phase name='codeemit' stamp='0.213'>
+<phase_done name='codeemit' stamp='0.213'/>
+</phase>
+<phase name='codeinstall' stamp='0.213'>
+<phase_done name='codeinstall' stamp='0.213'/>
+</phase>
+<code_cache total_blobs='318' nmethods='19' adapters='158' free_code_cache='248744192'/>
+<task_done success='1' nmsize='848' count='331' inlined_bytes='21' stamp='0.213'/>
+</task>
+<task compile_id='23' method='java.util.AbstractCollection &lt;init&gt; ()V' bytes='5' count='267' iicount='267' level='3' stamp='0.213'>
+<phase name='setup' stamp='0.213'>
+<phase_done name='setup' stamp='0.213'/>
+</phase>
+<phase name='buildIR' stamp='0.213'>
+<type id='977' name='void'/>
+<klass id='1093' name='java.util.AbstractCollection' flags='1025'/>
+<method id='1094' holder='1093' name='&lt;init&gt;' return='977' flags='4' bytes='5' iicount='270'/>
+<parse method='1094'  stamp='0.213'>
+<phase name='parse_hir' stamp='0.213'>
+<bc code='183' bci='1'/>
+<klass id='982' name='java.lang.Object' flags='1'/>
+<method id='1096' holder='982' name='&lt;init&gt;' return='977' flags='1' bytes='1' compile_id='9' compiler='c1' level='3' iicount='1642'/>
+<call method='1096' instr='invokespecial'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1096'>
+<bc code='177' bci='0'/>
+<dependency type='no_finalizable_subclasses' ctxk='1093'/>
+<parse_done stamp='0.214'/>
+</parse>
+<phase_done name='parse_hir' stamp='0.214'/>
+</phase>
+<parse_done stamp='0.214'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.214'>
+<phase_done name='optimize_blocks' stamp='0.214'/>
+</phase>
+<phase name='gvn' stamp='0.214'>
+<phase_done name='gvn' stamp='0.214'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.214'>
+<phase_done name='rangeCheckElimination' stamp='0.214'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.214'>
+<phase_done name='optimize_null_checks' stamp='0.214'/>
+</phase>
+<phase_done name='buildIR' stamp='0.214'/>
+</phase>
+<phase name='emit_lir' stamp='0.214'>
+<phase name='lirGeneration' stamp='0.214'>
+<phase_done name='lirGeneration' stamp='0.214'/>
+</phase>
+<phase name='linearScan' stamp='0.214'>
+<phase_done name='linearScan' stamp='0.214'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.214'/>
+</phase>
+<phase name='codeemit' stamp='0.214'>
+<phase_done name='codeemit' stamp='0.214'/>
+</phase>
+<phase name='codeinstall' stamp='0.214'>
+<dependency type='no_finalizable_subclasses' ctxk='1093'/>
+<phase_done name='codeinstall' stamp='0.214'/>
+</phase>
+<code_cache total_blobs='321' nmethods='22' adapters='158' free_code_cache='248740224'/>
+<task_done success='1' nmsize='432' count='297' inlined_bytes='1' stamp='0.214'/>
+</task>
+<task compile_id='29' method='java.util.Collections$EmptySet contains (Ljava/lang/Object;)Z' bytes='2' count='128' iicount='128' level='1' stamp='0.215'>
+<phase name='setup' stamp='0.215'>
+<phase_done name='setup' stamp='0.215'/>
+</phase>
+<phase name='buildIR' stamp='0.215'>
+<type id='969' name='boolean'/>
+<klass id='982' name='java.lang.Object' flags='1'/>
+<klass id='1093' name='java.util.Collections$EmptySet' flags='10'/>
+<method id='1094' holder='1093' name='contains' return='969' arguments='982' flags='1' bytes='2' iicount='128'/>
+<parse method='1094'  stamp='0.215'>
+<phase name='parse_hir' stamp='0.215'>
+<phase_done name='parse_hir' stamp='0.215'/>
+</phase>
+<parse_done stamp='0.215'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.215'>
+<phase_done name='optimize_blocks' stamp='0.215'/>
+</phase>
+<phase name='gvn' stamp='0.215'>
+<phase_done name='gvn' stamp='0.215'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.215'>
+<phase_done name='rangeCheckElimination' stamp='0.215'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.215'>
+<phase_done name='optimize_null_checks' stamp='0.215'/>
+</phase>
+<phase_done name='buildIR' stamp='0.215'/>
+</phase>
+<phase name='emit_lir' stamp='0.215'>
+<phase name='lirGeneration' stamp='0.215'>
+<phase_done name='lirGeneration' stamp='0.215'/>
+</phase>
+<phase name='linearScan' stamp='0.215'>
+<phase_done name='linearScan' stamp='0.215'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.215'/>
+</phase>
+<phase name='codeemit' stamp='0.215'>
+<phase_done name='codeemit' stamp='0.215'/>
+</phase>
+<phase name='codeinstall' stamp='0.215'>
+<phase_done name='codeinstall' stamp='0.215'/>
+</phase>
+<code_cache total_blobs='325' nmethods='26' adapters='158' free_code_cache='248735104'/>
+<task_done success='1' nmsize='272' count='132' stamp='0.215'/>
+</task>
+<task compile_id='31' method='java.lang.module.ModuleDescriptor$Exports equals (Ljava/lang/Object;)Z' bytes='62' count='264' iicount='264' level='3' stamp='0.215'>
+<phase name='setup' stamp='0.215'>
+<phase_done name='setup' stamp='0.215'/>
+</phase>
+<phase name='buildIR' stamp='0.215'>
+<type id='969' name='boolean'/>
+<klass id='982' name='java.lang.Object' flags='1'/>
+<klass id='1093' name='java.lang.module.ModuleDescriptor$Exports' flags='25'/>
+<method id='1094' holder='1093' name='equals' return='969' arguments='982' flags='1' bytes='62' iicount='264'/>
+<parse method='1094'  stamp='0.215'>
+<phase name='parse_hir' stamp='0.215'>
+<bc code='184' bci='22'/>
+<klass id='1097' name='java.util.Objects' flags='17'/>
+<method id='1098' holder='1097' name='equals' return='969' arguments='982 982' flags='9' bytes='23' compile_id='15' compiler='c1' level='3' iicount='546'/>
+<call method='1098' instr='invokestatic'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1098'>
+<bc code='182' bci='11'/>
+<method id='1100' holder='982' name='equals' return='969' arguments='982' flags='1' bytes='11' iicount='1'/>
+<call method='1100' instr='invokevirtual'/>
+<inline_fail reason='no static binding'/>
+<parse_done stamp='0.216'/>
+</parse>
+<bc code='184' bci='36'/>
+<call method='1098' instr='invokestatic'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1098'>
+<bc code='182' bci='11'/>
+<call method='1100' instr='invokevirtual'/>
+<inline_fail reason='callee is too large'/>
+<parse_done stamp='0.216'/>
+</parse>
+<bc code='184' bci='50'/>
+<call method='1098' instr='invokestatic'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1098'>
+<bc code='182' bci='11'/>
+<call method='1100' instr='invokevirtual'/>
+<inline_fail reason='no static binding'/>
+<parse_done stamp='0.216'/>
+</parse>
+<phase_done name='parse_hir' stamp='0.216'/>
+</phase>
+<parse_done stamp='0.216'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.216'>
+<phase_done name='optimize_blocks' stamp='0.216'/>
+</phase>
+<phase name='gvn' stamp='0.216'>
+<phase_done name='gvn' stamp='0.216'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.216'>
+<phase_done name='rangeCheckElimination' stamp='0.216'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.216'>
+<phase_done name='optimize_null_checks' stamp='0.216'/>
+</phase>
+<phase_done name='buildIR' stamp='0.216'/>
+</phase>
+<phase name='emit_lir' stamp='0.216'>
+<phase name='lirGeneration' stamp='0.216'>
+<phase_done name='lirGeneration' stamp='0.216'/>
+</phase>
+<phase name='linearScan' stamp='0.216'>
+<phase_done name='linearScan' stamp='0.216'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.216'/>
+</phase>
+<phase name='codeemit' stamp='0.216'>
+<phase_done name='codeemit' stamp='0.216'/>
+</phase>
+<phase name='codeinstall' stamp='0.216'>
+<phase_done name='codeinstall' stamp='0.216'/>
+</phase>
+<code_cache total_blobs='334' nmethods='33' adapters='158' free_code_cache='248720128'/>
+<task_done success='1' nmsize='2504' count='296' inlined_bytes='69' stamp='0.216'/>
+</task>
+<task compile_id='35' method='jdk.internal.module.Builder newRequires (Ljava/util/Set;Ljava/lang/String;)Ljava/lang/module/ModuleDescriptor$Requires;' bytes='7' count='256' iicount='256' level='3' stamp='0.217'>
+<phase name='setup' stamp='0.217'>
+<phase_done name='setup' stamp='0.217'/>
+</phase>
+<phase name='buildIR' stamp='0.217'>
+<klass id='1095' name='java.lang.module.ModuleDescriptor$Requires' flags='25'/>
+<klass id='1094' name='java.util.Set' flags='1537'/>
+<klass id='983' name='java.lang.String' flags='17'/>
+<klass id='1093' name='jdk.internal.module.Builder' flags='16'/>
+<method id='1096' holder='1093' name='newRequires' return='1095' arguments='1094 983' flags='9' bytes='7' iicount='256'/>
+<parse method='1096'  stamp='0.217'>
+<phase name='parse_hir' stamp='0.217'>
+<bc code='184' bci='3'/>
+<method id='1098' holder='1093' name='newRequires' return='1095' arguments='1094 983 983' flags='9' bytes='51' iicount='256'/>
+<call method='1098' instr='invokestatic'/>
+<inline_fail reason='callee is too large'/>
+<phase_done name='parse_hir' stamp='0.217'/>
+</phase>
+<parse_done stamp='0.217'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.217'>
+<phase_done name='optimize_blocks' stamp='0.217'/>
+</phase>
+<phase name='gvn' stamp='0.217'>
+<phase_done name='gvn' stamp='0.217'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.217'>
+<phase_done name='rangeCheckElimination' stamp='0.217'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.217'>
+<phase_done name='optimize_null_checks' stamp='0.217'/>
+</phase>
+<phase_done name='buildIR' stamp='0.217'/>
+</phase>
+<phase name='emit_lir' stamp='0.217'>
+<phase name='lirGeneration' stamp='0.217'>
+<phase_done name='lirGeneration' stamp='0.217'/>
+</phase>
+<phase name='linearScan' stamp='0.217'>
+<phase_done name='linearScan' stamp='0.217'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.217'/>
+</phase>
+<phase name='codeemit' stamp='0.217'>
+<phase_done name='codeemit' stamp='0.217'/>
+</phase>
+<phase name='codeinstall' stamp='0.217'>
+<phase_done name='codeinstall' stamp='0.217'/>
+</phase>
+<code_cache total_blobs='335' nmethods='34' adapters='158' free_code_cache='248719104'/>
+<task_done success='1' nmsize='360' count='262' stamp='0.217'/>
+</task>
+<task compile_id='38' method='java.lang.module.ModuleDescriptor$Requires &lt;init&gt; (Ljava/util/Set;Ljava/lang/String;Ljava/lang/module/ModuleDescriptor$Version;ZLjava/lang/module/ModuleDescriptor$1;)V' bytes='10' count='262' iicount='262' level='3' stamp='0.217'>
+<phase name='setup' stamp='0.217'>
+<phase_done name='setup' stamp='0.217'/>
+</phase>
+<phase name='buildIR' stamp='0.217'>
+<type id='977' name='void'/>
+<klass id='1094' name='java.util.Set' flags='1537'/>
+<klass id='983' name='java.lang.String' flags='17'/>
+<klass id='1095' name='java.lang.module.ModuleDescriptor$Version' flags='25'/>
+<type id='969' name='boolean'/>
+<klass id='1096' name='java.lang.module.ModuleDescriptor$1' flags='0'/>
+<klass id='1093' name='java.lang.module.ModuleDescriptor$Requires' flags='25'/>
+<method id='1097' holder='1093' name='&lt;init&gt;' return='977' arguments='1094 983 1095 969 1096' flags='4096' bytes='10' iicount='267'/>
+<parse method='1097'  stamp='0.217'>
+<phase name='parse_hir' stamp='0.217'>
+<bc code='183' bci='6'/>
+<method id='1099' holder='1093' name='&lt;init&gt;' return='977' arguments='1094 983 1095 969' flags='2' bytes='25' iicount='284'/>
+<call method='1099' instr='invokespecial'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1099'>
+<bc code='183' bci='1'/>
+<klass id='982' name='java.lang.Object' flags='1'/>
+<method id='1101' holder='982' name='&lt;init&gt;' return='977' flags='1' bytes='1' compile_id='9' compiler='c1' level='3' iicount='2528'/>
+<call method='1101' instr='invokespecial'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1101'>
+<parse_done stamp='0.217'/>
+</parse>
+<parse_done stamp='0.217'/>
+</parse>
+<phase_done name='parse_hir' stamp='0.217'/>
+</phase>
+<parse_done stamp='0.217'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.217'>
+<phase_done name='optimize_blocks' stamp='0.217'/>
+</phase>
+<phase name='gvn' stamp='0.217'>
+<phase_done name='gvn' stamp='0.217'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.217'>
+<phase_done name='rangeCheckElimination' stamp='0.217'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.217'>
+<phase_done name='optimize_null_checks' stamp='0.217'/>
+</phase>
+<phase_done name='buildIR' stamp='0.217'/>
+</phase>
+<phase name='emit_lir' stamp='0.217'>
+<phase name='lirGeneration' stamp='0.217'>
+<phase_done name='lirGeneration' stamp='0.217'/>
+</phase>
+<phase name='linearScan' stamp='0.217'>
+<phase_done name='linearScan' stamp='0.217'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.217'/>
+</phase>
+<phase name='codeemit' stamp='0.217'>
+<phase_done name='codeemit' stamp='0.217'/>
+</phase>
+<phase name='codeinstall' stamp='0.217'>
+<phase_done name='codeinstall' stamp='0.217'/>
+</phase>
+<code_cache total_blobs='336' nmethods='35' adapters='158' free_code_cache='248717440'/>
+<task_done success='1' nmsize='880' count='347' inlined_bytes='26' stamp='0.217'/>
+</task>
+<task compile_id='39' method='java.lang.module.ModuleDescriptor$Requires &lt;init&gt; (Ljava/util/Set;Ljava/lang/String;Ljava/lang/module/ModuleDescriptor$Version;Z)V' bytes='25' count='349' iicount='349' level='3' stamp='0.217'>
+<phase name='setup' stamp='0.217'>
+<phase_done name='setup' stamp='0.217'/>
+</phase>
+<phase name='buildIR' stamp='0.217'>
+<type id='977' name='void'/>
+<klass id='1094' name='java.util.Set' flags='1537'/>
+<klass id='983' name='java.lang.String' flags='17'/>
+<klass id='1095' name='java.lang.module.ModuleDescriptor$Version' flags='25'/>
+<type id='969' name='boolean'/>
+<klass id='1093' name='java.lang.module.ModuleDescriptor$Requires' flags='25'/>
+<method id='1096' holder='1093' name='&lt;init&gt;' return='977' arguments='1094 983 1095 969' flags='2' bytes='25' iicount='349'/>
+<parse method='1096'  stamp='0.217'>
+<phase name='parse_hir' stamp='0.217'>
+<bc code='183' bci='1'/>
+<klass id='982' name='java.lang.Object' flags='1'/>
+<method id='1098' holder='982' name='&lt;init&gt;' return='977' flags='1' bytes='1' compile_id='9' compiler='c1' level='3' iicount='2678'/>
+<call method='1098' instr='invokespecial'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1098'>
+<parse_done stamp='0.217'/>
+</parse>
+<phase_done name='parse_hir' stamp='0.217'/>
+</phase>
+<parse_done stamp='0.217'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.217'>
+<phase_done name='optimize_blocks' stamp='0.218'/>
+</phase>
+<phase name='gvn' stamp='0.218'>
+<phase_done name='gvn' stamp='0.218'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.218'>
+<phase_done name='rangeCheckElimination' stamp='0.218'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.218'>
+<phase_done name='optimize_null_checks' stamp='0.218'/>
+</phase>
+<phase_done name='buildIR' stamp='0.218'/>
+</phase>
+<phase name='emit_lir' stamp='0.218'>
+<phase name='lirGeneration' stamp='0.218'>
+<phase_done name='lirGeneration' stamp='0.218'/>
+</phase>
+<phase name='linearScan' stamp='0.218'>
+<phase_done name='linearScan' stamp='0.218'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.218'/>
+</phase>
+<phase name='codeemit' stamp='0.218'>
+<phase_done name='codeemit' stamp='0.218'/>
+</phase>
+<phase name='codeinstall' stamp='0.218'>
+<phase_done name='codeinstall' stamp='0.218'/>
+</phase>
+<code_cache total_blobs='339' nmethods='38' adapters='158' free_code_cache='248707328'/>
+<task_done success='1' nmsize='784' count='349' inlined_bytes='1' stamp='0.218'/>
+</task>
+<task compile_id='43' method='java.nio.DirectLongBufferU ix (I)J' bytes='10' count='278' iicount='278' level='3' stamp='0.221'>
+<phase name='setup' stamp='0.221'>
+<phase_done name='setup' stamp='0.221'/>
+</phase>
+<phase name='buildIR' stamp='0.221'>
+<type id='976' name='long'/>
+<type id='975' name='int'/>
+<klass id='1093' name='java.nio.DirectLongBufferU' flags='0'/>
+<method id='1094' holder='1093' name='ix' return='976' arguments='975' flags='2' bytes='10' iicount='283'/>
+<parse method='1094'  stamp='0.221'>
+<phase name='parse_hir' stamp='0.221'>
+<phase_done name='parse_hir' stamp='0.221'/>
+</phase>
+<parse_done stamp='0.221'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.221'>
+<phase_done name='optimize_blocks' stamp='0.221'/>
+</phase>
+<phase name='gvn' stamp='0.221'>
+<phase_done name='gvn' stamp='0.221'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.221'>
+<phase_done name='rangeCheckElimination' stamp='0.221'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.221'>
+<phase_done name='optimize_null_checks' stamp='0.221'/>
+</phase>
+<phase_done name='buildIR' stamp='0.221'/>
+</phase>
+<phase name='emit_lir' stamp='0.221'>
+<phase name='lirGeneration' stamp='0.221'>
+<phase_done name='lirGeneration' stamp='0.221'/>
+</phase>
+<phase name='linearScan' stamp='0.221'>
+<phase_done name='linearScan' stamp='0.221'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.221'/>
+</phase>
+<phase name='codeemit' stamp='0.221'>
+<phase_done name='codeemit' stamp='0.221'/>
+</phase>
+<phase name='codeinstall' stamp='0.221'>
+<phase_done name='codeinstall' stamp='0.221'/>
+</phase>
+<code_cache total_blobs='343' nmethods='42' adapters='158' free_code_cache='248699904'/>
+<task_done success='1' nmsize='368' count='356' stamp='0.221'/>
+</task>
+<task compile_id='47' method='java.net.URI hash (ILjava/lang/String;)I' bytes='33' count='332' iicount='332' level='3' stamp='0.222'>
+<phase name='setup' stamp='0.222'>
+<phase_done name='setup' stamp='0.222'/>
+</phase>
+<phase name='buildIR' stamp='0.222'>
+<type id='975' name='int'/>
+<klass id='983' name='java.lang.String' flags='17'/>
+<klass id='1093' name='java.net.URI' flags='17'/>
+<method id='1094' holder='1093' name='hash' return='975' arguments='975 983' flags='10' bytes='33' iicount='340'/>
+<parse method='1094'  stamp='0.222'>
+<phase name='parse_hir' stamp='0.222'>
+<bc code='182' bci='9'/>
+<method id='1096' holder='983' name='indexOf' return='975' arguments='975' flags='1' bytes='7' iicount='117'/>
+<call method='1096' instr='invokevirtual'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1096'>
+<bc code='182' bci='3'/>
+<method id='1098' holder='983' name='indexOf' return='975' arguments='975 975' flags='1' bytes='29' iicount='127'/>
+<call method='1098' instr='invokevirtual'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1098'>
+<bc code='183' bci='1'/>
+<type id='969' name='boolean'/>
+<method id='1100' holder='983' name='isLatin1' return='969' flags='2' bytes='19' compile_id='5' compiler='c1' level='3' iicount='5340'/>
+<call method='1100' instr='invokespecial'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1100'>
+<parse_done stamp='0.222'/>
+</parse>
+<bc code='184' bci='13'/>
+<klass id='1085' name='[B' flags='1041'/>
+<klass id='1103' name='java.lang.StringLatin1' flags='16'/>
+<method id='1104' holder='1103' name='indexOf' return='975' arguments='1085 975 975' flags='9' bytes='61' iicount='127'/>
+<call method='1104' instr='invokestatic'/>
+<inline_fail reason='callee is too large'/>
+<bc code='184' bci='25'/>
+<klass id='1106' name='java.lang.StringUTF16' flags='16'/>
+<method id='1107' holder='1106' name='indexOf' return='975' arguments='1085 975 975' flags='9' bytes='43' iicount='1'/>
+<call method='1107' instr='invokestatic'/>
+<inline_fail reason='callee is too large'/>
+<parse_done stamp='0.222'/>
+</parse>
+<parse_done stamp='0.222'/>
+</parse>
+<bc code='182' bci='20'/>
+<method id='1109' holder='983' name='hashCode' return='975' flags='1' bytes='49' compile_id='10' compiler='c1' level='3' iicount='4478'/>
+<call method='1109' instr='invokevirtual'/>
+<inline_fail reason='callee is too large'/>
+<bc code='184' bci='29'/>
+<method id='1111' holder='1093' name='normalizedHash' return='975' arguments='975 983' flags='10' bytes='84' iicount='1'/>
+<call method='1111' instr='invokestatic'/>
+<inline_fail reason='callee is too large'/>
+<phase_done name='parse_hir' stamp='0.222'/>
+</phase>
+<parse_done stamp='0.222'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.222'>
+<phase_done name='optimize_blocks' stamp='0.222'/>
+</phase>
+<phase name='gvn' stamp='0.222'>
+<phase_done name='gvn' stamp='0.222'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.222'>
+<phase_done name='rangeCheckElimination' stamp='0.222'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.222'>
+<phase_done name='optimize_null_checks' stamp='0.222'/>
+</phase>
+<phase_done name='buildIR' stamp='0.222'/>
+</phase>
+<phase name='emit_lir' stamp='0.222'>
+<phase name='lirGeneration' stamp='0.222'>
+<phase_done name='lirGeneration' stamp='0.222'/>
+</phase>
+<phase name='linearScan' stamp='0.222'>
+<phase_done name='linearScan' stamp='0.223'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.223'/>
+</phase>
+<phase name='codeemit' stamp='0.223'>
+<phase_done name='codeemit' stamp='0.223'/>
+</phase>
+<phase name='codeinstall' stamp='0.223'>
+<phase_done name='codeinstall' stamp='0.223'/>
+</phase>
+<code_cache total_blobs='349' nmethods='48' adapters='158' free_code_cache='248691968'/>
+<task_done success='1' nmsize='1592' count='396' inlined_bytes='55' stamp='0.223'/>
+</task>
+<task compile_id='52' method='jdk.internal.misc.Unsafe getObjectAcquire (Ljava/lang/Object;J)Ljava/lang/Object;' bytes='7' count='640' iicount='640' level='3' stamp='0.230'>
+<phase name='setup' stamp='0.230'>
+<phase_done name='setup' stamp='0.230'/>
+</phase>
+<phase name='buildIR' stamp='0.230'>
+<klass id='982' name='java.lang.Object' flags='1'/>
+<type id='976' name='long'/>
+<klass id='1051' name='jdk.internal.misc.Unsafe' flags='17'/>
+<method id='1093' holder='1051' name='getObjectAcquire' return='982' arguments='982 976' flags='17' bytes='7' iicount='640'/>
+<parse method='1093'  stamp='0.230'>
+<phase name='parse_hir' stamp='0.230'>
+<bc code='182' bci='3'/>
+<method id='1095' holder='1051' name='getObjectVolatile' return='982' arguments='982 976' flags='257' bytes='0' compile_id='53' compile_kind='c2n' compiler='' level='0' iicount='640'/>
+<call method='1095' instr='invokevirtual'/>
+<inline_success reason='intrinsic'/>
+<phase_done name='parse_hir' stamp='0.230'/>
+</phase>
+<parse_done stamp='0.230'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.230'>
+<phase_done name='optimize_blocks' stamp='0.230'/>
+</phase>
+<phase name='gvn' stamp='0.230'>
+<phase_done name='gvn' stamp='0.230'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.230'>
+<phase_done name='rangeCheckElimination' stamp='0.230'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.230'>
+<phase_done name='optimize_null_checks' stamp='0.230'/>
+</phase>
+<phase_done name='buildIR' stamp='0.230'/>
+</phase>
+<phase name='emit_lir' stamp='0.230'>
+<phase name='lirGeneration' stamp='0.230'>
+<phase_done name='lirGeneration' stamp='0.230'/>
+</phase>
+<phase name='linearScan' stamp='0.230'>
+<phase_done name='linearScan' stamp='0.230'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.230'/>
+</phase>
+<phase name='codeemit' stamp='0.230'>
+<phase_done name='codeemit' stamp='0.230'/>
+</phase>
+<phase name='codeinstall' stamp='0.230'>
+<phase_done name='codeinstall' stamp='0.230'/>
+</phase>
+<code_cache total_blobs='357' nmethods='52' adapters='162' free_code_cache='248685312'/>
+<task_done success='1' nmsize='432' count='640' stamp='0.230'/>
+</task>
+<task compile_id='55' method='java.util.ImmutableCollections$SetN$1 hasNext ()Z' bytes='47' count='258' backedge_count='139' iicount='258' level='3' stamp='0.231'>
+<phase name='setup' stamp='0.231'>
+<phase_done name='setup' stamp='0.231'/>
+</phase>
+<phase name='buildIR' stamp='0.231'>
+<type id='969' name='boolean'/>
+<klass id='1093' name='java.util.ImmutableCollections$SetN$1' flags='0'/>
+<method id='1094' holder='1093' name='hasNext' return='969' flags='1' bytes='47' iicount='258'/>
+<parse method='1094'  stamp='0.231'>
+<phase name='parse_hir' stamp='0.231'>
+<phase_done name='parse_hir' stamp='0.231'/>
+</phase>
+<parse_done stamp='0.231'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.231'>
+<phase_done name='optimize_blocks' stamp='0.231'/>
+</phase>
+<phase name='gvn' stamp='0.231'>
+<phase_done name='gvn' stamp='0.231'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.231'>
+<phase_done name='rangeCheckElimination' stamp='0.231'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.231'>
+<phase_done name='optimize_null_checks' stamp='0.231'/>
+</phase>
+<phase_done name='buildIR' stamp='0.231'/>
+</phase>
+<phase name='emit_lir' stamp='0.231'>
+<phase name='lirGeneration' stamp='0.231'>
+<phase_done name='lirGeneration' stamp='0.231'/>
+</phase>
+<phase name='linearScan' stamp='0.231'>
+<phase_done name='linearScan' stamp='0.231'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.231'/>
+</phase>
+<phase name='codeemit' stamp='0.231'>
+<phase_done name='codeemit' stamp='0.231'/>
+</phase>
+<phase name='codeinstall' stamp='0.231'>
+<phase_done name='codeinstall' stamp='0.231'/>
+</phase>
+<code_cache total_blobs='362' nmethods='57' adapters='162' free_code_cache='248679424'/>
+<task_done success='1' nmsize='656' count='321' backedge_count='160' stamp='0.231'/>
+</task>
+<task compile_id='63' method='java.util.ImmutableCollections$SetN size ()I' bytes='5' count='133' iicount='133' level='1' stamp='0.232'>
+<phase name='setup' stamp='0.232'>
+<phase_done name='setup' stamp='0.232'/>
+</phase>
+<phase name='buildIR' stamp='0.232'>
+<type id='975' name='int'/>
+<klass id='1093' name='java.util.ImmutableCollections$SetN' flags='24'/>
+<method id='1094' holder='1093' name='size' return='975' flags='1' bytes='5' iicount='134'/>
+<parse method='1094'  stamp='0.232'>
+<phase name='parse_hir' stamp='0.232'>
+<phase_done name='parse_hir' stamp='0.232'/>
+</phase>
+<parse_done stamp='0.232'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.232'>
+<phase_done name='optimize_blocks' stamp='0.232'/>
+</phase>
+<phase name='gvn' stamp='0.232'>
+<phase_done name='gvn' stamp='0.232'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.232'>
+<phase_done name='rangeCheckElimination' stamp='0.232'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.232'>
+<phase_done name='optimize_null_checks' stamp='0.232'/>
+</phase>
+<phase_done name='buildIR' stamp='0.232'/>
+</phase>
+<phase name='emit_lir' stamp='0.232'>
+<phase name='lirGeneration' stamp='0.232'>
+<phase_done name='lirGeneration' stamp='0.233'/>
+</phase>
+<phase name='linearScan' stamp='0.233'>
+<phase_done name='linearScan' stamp='0.233'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.233'/>
+</phase>
+<phase name='codeemit' stamp='0.233'>
+<phase_done name='codeemit' stamp='0.233'/>
+</phase>
+<phase name='codeinstall' stamp='0.233'>
+<phase_done name='codeinstall' stamp='0.233'/>
+</phase>
+<code_cache total_blobs='366' nmethods='61' adapters='162' free_code_cache='248674944'/>
+<task_done success='1' nmsize='272' count='136' stamp='0.233'/>
+</task>
+<task compile_id='66' method='java.util.ImmutableCollections$MapN probe (Ljava/lang/Object;)I' bytes='64' count='286' backedge_count='136' iicount='287' level='3' stamp='0.236'>
+<phase name='setup' stamp='0.236'>
+<phase_done name='setup' stamp='0.236'/>
+</phase>
+<phase name='buildIR' stamp='0.236'>
+<type id='975' name='int'/>
+<klass id='982' name='java.lang.Object' flags='1'/>
+<klass id='1093' name='java.util.ImmutableCollections$MapN' flags='24'/>
+<method id='1094' holder='1093' name='probe' return='975' arguments='982' flags='2' bytes='64' iicount='291'/>
+<parse method='1094'  stamp='0.236'>
+<phase name='parse_hir' stamp='0.236'>
+<bc code='182' bci='1'/>
+<method id='1096' holder='982' name='hashCode' return='975' flags='257' bytes='0' iicount='146'/>
+<call method='1096' instr='invokevirtual'/>
+<inline_fail reason='no static binding'/>
+<bc code='184' bci='15'/>
+<klass id='1100' name='java.lang.Math' flags='17'/>
+<method id='1101' holder='1100' name='floorMod' return='975' arguments='975 975' flags='9' bytes='10' compile_id='11' compiler='c1' level='3' iicount='3450'/>
+<call method='1101' instr='invokestatic'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1101'>
+<bc code='184' bci='3'/>
+<method id='1103' holder='1100' name='floorDiv' return='975' arguments='975 975' flags='9' bytes='22' compile_id='12' compiler='c1' level='3' iicount='3452'/>
+<call method='1103' instr='invokestatic'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1103'>
+<parse_done stamp='0.236'/>
+</parse>
+<parse_done stamp='0.236'/>
+</parse>
+<bc code='182' bci='39'/>
+<type id='969' name='boolean'/>
+<method id='1105' holder='982' name='equals' return='969' arguments='982' flags='1' bytes='11' iicount='1'/>
+<call method='1105' instr='invokevirtual'/>
+<inline_fail reason='no static binding'/>
+<phase_done name='parse_hir' stamp='0.236'/>
+</phase>
+<parse_done stamp='0.236'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.236'>
+<phase_done name='optimize_blocks' stamp='0.236'/>
+</phase>
+<phase name='gvn' stamp='0.236'>
+<phase_done name='gvn' stamp='0.236'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.236'>
+<phase_done name='rangeCheckElimination' stamp='0.236'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.236'>
+<phase_done name='optimize_null_checks' stamp='0.236'/>
+</phase>
+<phase_done name='buildIR' stamp='0.236'/>
+</phase>
+<phase name='emit_lir' stamp='0.236'>
+<phase name='lirGeneration' stamp='0.236'>
+<phase_done name='lirGeneration' stamp='0.236'/>
+</phase>
+<phase name='linearScan' stamp='0.236'>
+<phase_done name='linearScan' stamp='0.236'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.236'/>
+</phase>
+<phase name='codeemit' stamp='0.236'>
+<phase_done name='codeemit' stamp='0.236'/>
+</phase>
+<phase name='codeinstall' stamp='0.236'>
+<phase_done name='codeinstall' stamp='0.236'/>
+</phase>
+<code_cache total_blobs='373' nmethods='68' adapters='162' free_code_cache='248652032'/>
+<task_done success='1' nmsize='1528' count='371' backedge_count='154' inlined_bytes='32' stamp='0.236'/>
+</task>
+<task compile_id='72' method='java.util.HashMap putVal (ILjava/lang/Object;Ljava/lang/Object;ZZ)Ljava/lang/Object;' bytes='300' count='256' backedge_count='38' iicount='256' level='3' stamp='0.236'>
+<phase name='setup' stamp='0.236'>
+<phase_done name='setup' stamp='0.236'/>
+</phase>
+<phase name='buildIR' stamp='0.236'>
+<klass id='982' name='java.lang.Object' flags='1'/>
+<type id='975' name='int'/>
+<type id='969' name='boolean'/>
+<klass id='1093' name='java.util.HashMap' flags='1'/>
+<method id='1094' holder='1093' name='putVal' return='982' arguments='975 982 982 969 969' flags='16' bytes='300' iicount='256'/>
+<parse method='1094'  stamp='0.236'>
+<phase name='parse_hir' stamp='0.236'>
+<bc code='182' bci='20'/>
+<klass id='1097' name='[Ljava.util.HashMap$Node;' flags='1040'/>
+<method id='1098' holder='1093' name='resize' return='1097' flags='16' bytes='356' iicount='23'/>
+<call method='1098' instr='invokevirtual'/>
+<inline_fail reason='callee is too large'/>
+<bc code='182' bci='56'/>
+<klass id='1096' name='java.util.HashMap$Node' flags='8'/>
+<method id='1100' holder='1093' name='newNode' return='1096' arguments='975 982 982 1096' flags='0' bytes='13' iicount='281'/>
+<call method='1100' instr='invokevirtual'/>
+<inline_fail reason='no static binding'/>
+<bc code='182' bci='91'/>
+<method id='1101' holder='982' name='equals' return='969' arguments='982' flags='1' bytes='11' iicount='1'/>
+<call method='1101' instr='invokevirtual'/>
+<inline_fail reason='no static binding'/>
+<bc code='182' bci='123'/>
+<klass id='1102' name='java.util.HashMap$TreeNode' flags='24'/>
+<method id='1103' holder='1102' name='putTreeVal' return='1102' arguments='1093 1097 975 982 982' flags='16' bytes='314' iicount='1'/>
+<call method='1103' instr='invokevirtual'/>
+<inline_fail reason='not inlineable'/>
+<bc code='182' bci='152'/>
+<call method='1100' instr='invokevirtual'/>
+<inline_fail reason='no static binding'/>
+<bc code='182' bci='169'/>
+<type id='977' name='void'/>
+<method id='1104' holder='1093' name='treeifyBin' return='977' arguments='1097 975' flags='16' bytes='110' iicount='1'/>
+<call method='1104' instr='invokevirtual'/>
+<inline_fail reason='callee is too large'/>
+<bc code='182' bci='203'/>
+<call method='1101' instr='invokevirtual'/>
+<inline_fail reason='no static binding'/>
+<bc code='182' bci='253'/>
+<method id='1106' holder='1093' name='afterNodeAccess' return='977' arguments='1096' flags='0' bytes='1' iicount='1'/>
+<call method='1106' instr='invokevirtual'/>
+<inline_fail reason='no static binding'/>
+<bc code='182' bci='288'/>
+<call method='1098' instr='invokevirtual'/>
+<inline_fail reason='callee is too large'/>
+<bc code='182' bci='295'/>
+<method id='1107' holder='1093' name='afterNodeInsertion' return='977' arguments='969' flags='0' bytes='1' iicount='378'/>
+<call method='1107' instr='invokevirtual'/>
+<inline_fail reason='no static binding'/>
+<phase_done name='parse_hir' stamp='0.237'/>
+</phase>
+<parse_done stamp='0.237'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.237'>
+<phase_done name='optimize_blocks' stamp='0.237'/>
+</phase>
+<phase name='gvn' stamp='0.237'>
+<phase_done name='gvn' stamp='0.237'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.237'>
+<phase_done name='rangeCheckElimination' stamp='0.237'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.237'>
+<phase_done name='optimize_null_checks' stamp='0.237'/>
+</phase>
+<phase_done name='buildIR' stamp='0.237'/>
+</phase>
+<phase name='emit_lir' stamp='0.237'>
+<phase name='lirGeneration' stamp='0.237'>
+<phase_done name='lirGeneration' stamp='0.237'/>
+</phase>
+<phase name='linearScan' stamp='0.237'>
+<phase_done name='linearScan' stamp='0.238'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.238'/>
+</phase>
+<phase name='codeemit' stamp='0.238'>
+<phase_done name='codeemit' stamp='0.238'/>
+</phase>
+<phase name='codeinstall' stamp='0.238'>
+<phase_done name='codeinstall' stamp='0.238'/>
+</phase>
+<code_cache total_blobs='383' nmethods='78' adapters='162' free_code_cache='248631680'/>
+<task_done success='1' nmsize='5016' count='448' backedge_count='51' stamp='0.238'/>
+</task>
+<task compile_id='79' method='java.util.AbstractCollection isEmpty ()Z' bytes='13' count='260' iicount='261' level='3' stamp='0.238'>
+<phase name='setup' stamp='0.238'>
+<phase_done name='setup' stamp='0.238'/>
+</phase>
+<phase name='buildIR' stamp='0.238'>
+<type id='969' name='boolean'/>
+<klass id='1093' name='java.util.AbstractCollection' flags='1025'/>
+<method id='1094' holder='1093' name='isEmpty' return='969' flags='1' bytes='13' iicount='273'/>
+<parse method='1094'  stamp='0.238'>
+<phase name='parse_hir' stamp='0.238'>
+<bc code='182' bci='1'/>
+<type id='975' name='int'/>
+<method id='1096' holder='1093' name='size' return='975' flags='1025' bytes='0' iicount='1'/>
+<call method='1096' instr='invokevirtual'/>
+<inline_fail reason='no static binding'/>
+<phase_done name='parse_hir' stamp='0.238'/>
+</phase>
+<parse_done stamp='0.238'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.238'>
+<phase_done name='optimize_blocks' stamp='0.238'/>
+</phase>
+<phase name='gvn' stamp='0.238'>
+<phase_done name='gvn' stamp='0.238'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.238'>
+<phase_done name='rangeCheckElimination' stamp='0.238'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.238'>
+<phase_done name='optimize_null_checks' stamp='0.238'/>
+</phase>
+<phase_done name='buildIR' stamp='0.238'/>
+</phase>
+<phase name='emit_lir' stamp='0.238'>
+<phase name='lirGeneration' stamp='0.238'>
+<phase_done name='lirGeneration' stamp='0.238'/>
+</phase>
+<phase name='linearScan' stamp='0.238'>
+<phase_done name='linearScan' stamp='0.238'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.238'/>
+</phase>
+<phase name='codeemit' stamp='0.238'>
+<phase_done name='codeemit' stamp='0.239'/>
+</phase>
+<phase name='codeinstall' stamp='0.239'>
+<phase_done name='codeinstall' stamp='0.239'/>
+</phase>
+<code_cache total_blobs='384' nmethods='79' adapters='162' free_code_cache='248630400'/>
+<task_done success='1' nmsize='616' count='291' stamp='0.239'/>
+</task>
+<task compile_id='83' method='java.util.Optional ofNullable (Ljava/lang/Object;)Ljava/util/Optional;' bytes='15' count='256' iicount='256' level='3' stamp='0.239'>
+<phase name='setup' stamp='0.239'>
+<phase_done name='setup' stamp='0.239'/>
+</phase>
+<phase name='buildIR' stamp='0.239'>
+<klass id='1093' name='java.util.Optional' flags='17'/>
+<klass id='982' name='java.lang.Object' flags='1'/>
+<method id='1094' holder='1093' name='ofNullable' return='1093' arguments='982' flags='9' bytes='15' iicount='256'/>
+<parse method='1094'  stamp='0.239'>
+<phase name='parse_hir' stamp='0.239'>
+<bc code='184' bci='4'/>
+<method id='1096' holder='1093' name='empty' return='1093' flags='9' bytes='6' iicount='1'/>
+<call method='1096' instr='invokestatic'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1096'>
+<parse_done stamp='0.239'/>
+</parse>
+<bc code='184' bci='11'/>
+<method id='1100' holder='1093' name='of' return='1093' arguments='982' flags='9' bytes='9' iicount='259'/>
+<call method='1100' instr='invokestatic'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1100'>
+<bc code='183' bci='5'/>
+<type id='977' name='void'/>
+<method id='1102' holder='1093' name='&lt;init&gt;' return='977' arguments='982' flags='2' bytes='13' iicount='260'/>
+<call method='1102' instr='invokespecial'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1102'>
+<bc code='183' bci='1'/>
+<method id='1104' holder='982' name='&lt;init&gt;' return='977' flags='1' bytes='1' compile_id='50' compiler='c1' level='1' iicount='3880'/>
+<call method='1104' instr='invokespecial'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1104'>
+<parse_done stamp='0.239'/>
+</parse>
+<bc code='184' bci='6'/>
+<klass id='1106' name='java.util.Objects' flags='17'/>
+<method id='1107' holder='1106' name='requireNonNull' return='982' arguments='982' flags='9' bytes='14' compile_id='21' compiler='c1' level='3' iicount='1922'/>
+<call method='1107' instr='invokestatic'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1107'>
+<bc code='183' bci='8'/>
+<klass id='1089' name='java.lang.NullPointerException' flags='1'/>
+<method id='1109' holder='1089' name='&lt;init&gt;' return='977' flags='1' bytes='5' iicount='1'/>
+<call method='1109' instr='invokespecial'/>
+<inline_fail reason='don&apos;t inline Throwable constructors'/>
+<parse_done stamp='0.239'/>
+</parse>
+<parse_done stamp='0.239'/>
+</parse>
+<parse_done stamp='0.239'/>
+</parse>
+<phase_done name='parse_hir' stamp='0.239'/>
+</phase>
+<parse_done stamp='0.239'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.239'>
+<phase_done name='optimize_blocks' stamp='0.239'/>
+</phase>
+<phase name='gvn' stamp='0.239'>
+<phase_done name='gvn' stamp='0.239'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.239'>
+<phase_done name='rangeCheckElimination' stamp='0.239'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.239'>
+<phase_done name='optimize_null_checks' stamp='0.239'/>
+</phase>
+<phase_done name='buildIR' stamp='0.239'/>
+</phase>
+<phase name='emit_lir' stamp='0.239'>
+<phase name='lirGeneration' stamp='0.239'>
+<phase_done name='lirGeneration' stamp='0.239'/>
+</phase>
+<phase name='linearScan' stamp='0.239'>
+<phase_done name='linearScan' stamp='0.239'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.239'/>
+</phase>
+<phase name='codeemit' stamp='0.239'>
+<phase_done name='codeemit' stamp='0.239'/>
+</phase>
+<phase name='codeinstall' stamp='0.239'>
+<phase_done name='codeinstall' stamp='0.239'/>
+</phase>
+<code_cache total_blobs='388' nmethods='83' adapters='162' free_code_cache='248624512'/>
+<task_done success='1' nmsize='1288' count='277' inlined_bytes='43' stamp='0.239'/>
+</task>
+<task compile_id='87' method='java.util.Optional orElse (Ljava/lang/Object;)Ljava/lang/Object;' bytes='16' count='274' iicount='274' level='3' stamp='0.239'>
+<phase name='setup' stamp='0.239'>
+<phase_done name='setup' stamp='0.239'/>
+</phase>
+<phase name='buildIR' stamp='0.239'>
+<klass id='982' name='java.lang.Object' flags='1'/>
+<klass id='1093' name='java.util.Optional' flags='17'/>
+<method id='1094' holder='1093' name='orElse' return='982' arguments='982' flags='1' bytes='16' iicount='274'/>
+<parse method='1094'  stamp='0.239'>
+<phase name='parse_hir' stamp='0.239'>
+<phase_done name='parse_hir' stamp='0.240'/>
+</phase>
+<parse_done stamp='0.240'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.240'>
+<phase_done name='optimize_blocks' stamp='0.240'/>
+</phase>
+<phase name='gvn' stamp='0.240'>
+<phase_done name='gvn' stamp='0.240'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.240'>
+<phase_done name='rangeCheckElimination' stamp='0.240'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.240'>
+<phase_done name='optimize_null_checks' stamp='0.240'/>
+</phase>
+<phase_done name='buildIR' stamp='0.240'/>
+</phase>
+<phase name='emit_lir' stamp='0.240'>
+<phase name='lirGeneration' stamp='0.240'>
+<phase_done name='lirGeneration' stamp='0.240'/>
+</phase>
+<phase name='linearScan' stamp='0.240'>
+<phase_done name='linearScan' stamp='0.240'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.240'/>
+</phase>
+<phase name='codeemit' stamp='0.240'>
+<phase_done name='codeemit' stamp='0.240'/>
+</phase>
+<phase name='codeinstall' stamp='0.240'>
+<phase_done name='codeinstall' stamp='0.240'/>
+</phase>
+<code_cache total_blobs='392' nmethods='87' adapters='162' free_code_cache='248619392'/>
+<task_done success='1' nmsize='432' count='274' stamp='0.240'/>
+</task>
+<task compile_id='94' method='java.util.HashMap$HashIterator nextNode ()Ljava/util/HashMap$Node;' bytes='100' count='267' backedge_count='528' iicount='267' level='3' stamp='0.240'>
+<phase name='setup' stamp='0.240'>
+<phase_done name='setup' stamp='0.240'/>
+</phase>
+<phase name='buildIR' stamp='0.240'>
+<klass id='1094' name='java.util.HashMap$Node' flags='8'/>
+<klass id='1093' name='java.util.HashMap$HashIterator' flags='1024'/>
+<method id='1095' holder='1093' name='nextNode' return='1094' flags='16' bytes='100' iicount='268'/>
+<parse method='1095'  stamp='0.240'>
+<phase name='parse_hir' stamp='0.240'>
+<bc code='183' bci='23'/>
+<type id='977' name='void'/>
+<klass id='1098' name='java.util.ConcurrentModificationException' unloaded='1'/>
+<method id='1099' holder='1098' name='&lt;init&gt;' return='977' unloaded='1'/>
+<call method='1099' instr='invokespecial'/>
+<inline_fail reason='not inlineable'/>
+<bc code='183' bci='35'/>
+<klass id='1100' name='java.util.NoSuchElementException' unloaded='1'/>
+<method id='1101' holder='1100' name='&lt;init&gt;' return='977' unloaded='1'/>
+<call method='1101' instr='invokespecial'/>
+<inline_fail reason='not inlineable'/>
+<phase_done name='parse_hir' stamp='0.240'/>
+</phase>
+<parse_done stamp='0.240'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.240'>
+<phase_done name='optimize_blocks' stamp='0.240'/>
+</phase>
+<phase name='gvn' stamp='0.240'>
+<phase_done name='gvn' stamp='0.240'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.240'>
+<phase_done name='rangeCheckElimination' stamp='0.240'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.240'>
+<phase_done name='optimize_null_checks' stamp='0.240'/>
+</phase>
+<phase_done name='buildIR' stamp='0.240'/>
+</phase>
+<phase name='emit_lir' stamp='0.240'>
+<phase name='lirGeneration' stamp='0.240'>
+<phase_done name='lirGeneration' stamp='0.240'/>
+</phase>
+<phase name='linearScan' stamp='0.240'>
+<phase_done name='linearScan' stamp='0.240'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.240'/>
+</phase>
+<phase name='codeemit' stamp='0.240'>
+<phase_done name='codeemit' stamp='0.240'/>
+</phase>
+<phase name='codeinstall' stamp='0.240'>
+<phase_done name='codeinstall' stamp='0.240'/>
+</phase>
+<code_cache total_blobs='395' nmethods='90' adapters='162' free_code_cache='248612864'/>
+<task_done success='1' nmsize='1432' count='298' backedge_count='566' stamp='0.240'/>
+</task>
+<task compile_id='96' method='java.lang.module.ResolvedModule hashCode ()I' bytes='16' count='388' iicount='388' level='3' stamp='0.240'>
+<phase name='setup' stamp='0.240'>
+<phase_done name='setup' stamp='0.240'/>
+</phase>
+<phase name='buildIR' stamp='0.240'>
+<type id='975' name='int'/>
+<klass id='1093' name='java.lang.module.ResolvedModule' flags='17'/>
+<method id='1094' holder='1093' name='hashCode' return='975' flags='1' bytes='16' iicount='388'/>
+<parse method='1094'  stamp='0.240'>
+<phase name='parse_hir' stamp='0.240'>
+<bc code='182' bci='4'/>
+<klass id='982' name='java.lang.Object' flags='1'/>
+<method id='1097' holder='982' name='hashCode' return='975' flags='257' bytes='0' compile_id='93' compile_kind='c2n' compiler='' level='0' iicount='256'/>
+<call method='1097' instr='invokevirtual'/>
+<inline_fail reason='native method'/>
+<bc code='182' bci='11'/>
+<call method='1097' instr='invokevirtual'/>
+<inline_fail reason='no static binding'/>
+<phase_done name='parse_hir' stamp='0.240'/>
+</phase>
+<parse_done stamp='0.240'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.240'>
+<phase_done name='optimize_blocks' stamp='0.240'/>
+</phase>
+<phase name='gvn' stamp='0.240'>
+<phase_done name='gvn' stamp='0.241'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.241'>
+<phase_done name='rangeCheckElimination' stamp='0.241'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.241'>
+<phase_done name='optimize_null_checks' stamp='0.241'/>
+</phase>
+<phase_done name='buildIR' stamp='0.241'/>
+</phase>
+<phase name='emit_lir' stamp='0.241'>
+<phase name='lirGeneration' stamp='0.241'>
+<phase_done name='lirGeneration' stamp='0.241'/>
+</phase>
+<phase name='linearScan' stamp='0.241'>
+<phase_done name='linearScan' stamp='0.241'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.241'/>
+</phase>
+<phase name='codeemit' stamp='0.241'>
+<phase_done name='codeemit' stamp='0.241'/>
+</phase>
+<phase name='codeinstall' stamp='0.241'>
+<phase_done name='codeinstall' stamp='0.241'/>
+</phase>
+<code_cache total_blobs='399' nmethods='94' adapters='162' free_code_cache='248603776'/>
+<task_done success='1' nmsize='760' count='458' stamp='0.241'/>
+</task>
+<task compile_id='100' method='java.util.ImmutableCollections$Set1 contains (Ljava/lang/Object;)Z' bytes='9' count='274' iicount='274' level='3' stamp='0.241'>
+<phase name='setup' stamp='0.241'>
+<phase_done name='setup' stamp='0.241'/>
+</phase>
+<phase name='buildIR' stamp='0.241'>
+<type id='969' name='boolean'/>
+<klass id='982' name='java.lang.Object' flags='1'/>
+<klass id='1093' name='java.util.ImmutableCollections$Set1' flags='24'/>
+<method id='1094' holder='1093' name='contains' return='969' arguments='982' flags='1' bytes='9' iicount='274'/>
+<parse method='1094'  stamp='0.241'>
+<phase name='parse_hir' stamp='0.241'>
+<bc code='182' bci='5'/>
+<method id='1096' holder='982' name='equals' return='969' arguments='982' flags='1' bytes='11' iicount='1'/>
+<call method='1096' instr='invokevirtual'/>
+<inline_fail reason='no static binding'/>
+<phase_done name='parse_hir' stamp='0.241'/>
+</phase>
+<parse_done stamp='0.241'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.241'>
+<phase_done name='optimize_blocks' stamp='0.241'/>
+</phase>
+<phase name='gvn' stamp='0.241'>
+<phase_done name='gvn' stamp='0.241'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.241'>
+<phase_done name='rangeCheckElimination' stamp='0.241'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.241'>
+<phase_done name='optimize_null_checks' stamp='0.241'/>
+</phase>
+<phase_done name='buildIR' stamp='0.241'/>
+</phase>
+<phase name='emit_lir' stamp='0.241'>
+<phase name='lirGeneration' stamp='0.241'>
+<phase_done name='lirGeneration' stamp='0.241'/>
+</phase>
+<phase name='linearScan' stamp='0.241'>
+<phase_done name='linearScan' stamp='0.241'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.241'/>
+</phase>
+<phase name='codeemit' stamp='0.241'>
+<phase_done name='codeemit' stamp='0.241'/>
+</phase>
+<phase name='codeinstall' stamp='0.241'>
+<phase_done name='codeinstall' stamp='0.241'/>
+</phase>
+<code_cache total_blobs='404' nmethods='99' adapters='162' free_code_cache='248599296'/>
+<task_done success='1' nmsize='552' count='274' stamp='0.241'/>
+</task>
+<task compile_id='104' method='java.util.HashSet iterator ()Ljava/util/Iterator;' bytes='13' count='297' iicount='297' level='3' stamp='0.241'>
+<phase name='setup' stamp='0.241'>
+<phase_done name='setup' stamp='0.241'/>
+</phase>
+<phase name='buildIR' stamp='0.241'>
+<klass id='1094' name='java.util.Iterator' flags='1537'/>
+<klass id='1093' name='java.util.HashSet' flags='1'/>
+<method id='1095' holder='1093' name='iterator' return='1094' flags='1' bytes='13' iicount='325'/>
+<parse method='1095'  stamp='0.241'>
+<phase name='parse_hir' stamp='0.241'>
+<bc code='182' bci='4'/>
+<klass id='1099' name='java.util.Set' flags='1537'/>
+<klass id='1097' name='java.util.HashMap' flags='1'/>
+<method id='1100' holder='1097' name='keySet' return='1099' flags='1' bytes='25' iicount='360'/>
+<call method='1100' instr='invokevirtual'/>
+<inline_fail reason='no static binding'/>
+<bc code='185' bci='7'/>
+<method id='1101' holder='1099' name='iterator' return='1094' flags='1025' bytes='0' iicount='1'/>
+<call method='1101' instr='invokeinterface'/>
+<inline_fail reason='no static binding'/>
+<phase_done name='parse_hir' stamp='0.241'/>
+</phase>
+<parse_done stamp='0.241'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.241'>
+<phase_done name='optimize_blocks' stamp='0.241'/>
+</phase>
+<phase name='gvn' stamp='0.241'>
+<phase_done name='gvn' stamp='0.241'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.241'>
+<phase_done name='rangeCheckElimination' stamp='0.241'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.241'>
+<phase_done name='optimize_null_checks' stamp='0.241'/>
+</phase>
+<phase_done name='buildIR' stamp='0.241'/>
+</phase>
+<phase name='emit_lir' stamp='0.241'>
+<phase name='lirGeneration' stamp='0.241'>
+<phase_done name='lirGeneration' stamp='0.241'/>
+</phase>
+<phase name='linearScan' stamp='0.241'>
+<phase_done name='linearScan' stamp='0.241'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.241'/>
+</phase>
+<phase name='codeemit' stamp='0.241'>
+<phase_done name='codeemit' stamp='0.241'/>
+</phase>
+<phase name='codeinstall' stamp='0.241'>
+<phase_done name='codeinstall' stamp='0.242'/>
+</phase>
+<code_cache total_blobs='407' nmethods='102' adapters='162' free_code_cache='248593280'/>
+<task_done success='1' nmsize='728' count='498' stamp='0.242'/>
+</task>
+<task compile_id='107' method='java.util.HashMap$KeyIterator &lt;init&gt; (Ljava/util/HashMap;)V' bytes='11' count='502' iicount='503' level='3' stamp='0.242'>
+<phase name='setup' stamp='0.242'>
+<phase_done name='setup' stamp='0.242'/>
+</phase>
+<phase name='buildIR' stamp='0.242'>
+<type id='977' name='void'/>
+<klass id='1094' name='java.util.HashMap' flags='1'/>
+<klass id='1093' name='java.util.HashMap$KeyIterator' flags='16'/>
+<method id='1095' holder='1093' name='&lt;init&gt;' return='977' arguments='1094' flags='0' bytes='11' iicount='511'/>
+<parse method='1095'  stamp='0.242'>
+<phase name='parse_hir' stamp='0.242'>
+<bc code='183' bci='7'/>
+<klass id='1097' name='java.util.HashMap$HashIterator' flags='1024'/>
+<method id='1098' holder='1097' name='&lt;init&gt;' return='977' arguments='1094' flags='0' bytes='79' iicount='518'/>
+<call method='1098' instr='invokespecial'/>
+<inline_fail reason='callee is too large'/>
+<phase_done name='parse_hir' stamp='0.242'/>
+</phase>
+<parse_done stamp='0.242'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.242'>
+<phase_done name='optimize_blocks' stamp='0.242'/>
+</phase>
+<phase name='gvn' stamp='0.242'>
+<phase_done name='gvn' stamp='0.242'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.242'>
+<phase_done name='rangeCheckElimination' stamp='0.242'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.242'>
+<phase_done name='optimize_null_checks' stamp='0.242'/>
+</phase>
+<phase_done name='buildIR' stamp='0.242'/>
+</phase>
+<phase name='emit_lir' stamp='0.242'>
+<phase name='lirGeneration' stamp='0.242'>
+<phase_done name='lirGeneration' stamp='0.242'/>
+</phase>
+<phase name='linearScan' stamp='0.242'>
+<phase_done name='linearScan' stamp='0.242'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.242'/>
+</phase>
+<phase name='codeemit' stamp='0.242'>
+<phase_done name='codeemit' stamp='0.242'/>
+</phase>
+<phase name='codeinstall' stamp='0.242'>
+<phase_done name='codeinstall' stamp='0.242'/>
+</phase>
+<code_cache total_blobs='409' nmethods='104' adapters='162' free_code_cache='248590208'/>
+<task_done success='1' nmsize='488' count='596' stamp='0.242'/>
+</task>
+<task compile_id='108' method='java.util.HashMap$ValueIterator next ()Ljava/lang/Object;' bytes='8' count='278' iicount='278' level='3' stamp='0.242'>
+<phase name='setup' stamp='0.242'>
+<phase_done name='setup' stamp='0.242'/>
+</phase>
+<phase name='buildIR' stamp='0.242'>
+<klass id='982' name='java.lang.Object' flags='1'/>
+<klass id='1093' name='java.util.HashMap$ValueIterator' flags='16'/>
+<method id='1094' holder='1093' name='next' return='982' flags='17' bytes='8' iicount='284'/>
+<parse method='1094'  stamp='0.242'>
+<phase name='parse_hir' stamp='0.242'>
+<bc code='182' bci='1'/>
+<klass id='1097' name='java.util.HashMap$Node' flags='8'/>
+<klass id='1096' name='java.util.HashMap$HashIterator' flags='1024'/>
+<method id='1098' holder='1096' name='nextNode' return='1097' flags='16' bytes='100' compile_id='94' compiler='c1' level='3' iicount='1092'/>
+<call method='1098' instr='invokevirtual'/>
+<inline_fail reason='callee is too large'/>
+<phase_done name='parse_hir' stamp='0.242'/>
+</phase>
+<parse_done stamp='0.242'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.242'>
+<phase_done name='optimize_blocks' stamp='0.242'/>
+</phase>
+<phase name='gvn' stamp='0.242'>
+<phase_done name='gvn' stamp='0.242'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.242'>
+<phase_done name='rangeCheckElimination' stamp='0.242'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.242'>
+<phase_done name='optimize_null_checks' stamp='0.242'/>
+</phase>
+<phase_done name='buildIR' stamp='0.242'/>
+</phase>
+<phase name='emit_lir' stamp='0.242'>
+<phase name='lirGeneration' stamp='0.242'>
+<phase_done name='lirGeneration' stamp='0.242'/>
+</phase>
+<phase name='linearScan' stamp='0.242'>
+<phase_done name='linearScan' stamp='0.242'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.242'/>
+</phase>
+<phase name='codeemit' stamp='0.242'>
+<phase_done name='codeemit' stamp='0.242'/>
+</phase>
+<phase name='codeinstall' stamp='0.242'>
+<phase_done name='codeinstall' stamp='0.242'/>
+</phase>
+<code_cache total_blobs='412' nmethods='107' adapters='162' free_code_cache='248585728'/>
+<task_done success='1' nmsize='520' count='293' stamp='0.242'/>
+</task>
+<task compile_id='112' method='java.util.HashSet contains (Ljava/lang/Object;)Z' bytes='9' count='264' iicount='264' level='3' stamp='0.243'>
+<phase name='setup' stamp='0.243'>
+<phase_done name='setup' stamp='0.243'/>
+</phase>
+<phase name='buildIR' stamp='0.243'>
+<type id='969' name='boolean'/>
+<klass id='982' name='java.lang.Object' flags='1'/>
+<klass id='1093' name='java.util.HashSet' flags='1'/>
+<method id='1094' holder='1093' name='contains' return='969' arguments='982' flags='1' bytes='9' iicount='264'/>
+<parse method='1094'  stamp='0.243'>
+<phase name='parse_hir' stamp='0.243'>
+<bc code='182' bci='5'/>
+<klass id='1096' name='java.util.HashMap' flags='1'/>
+<method id='1097' holder='1096' name='containsKey' return='969' arguments='982' flags='1' bytes='18' compile_id='70' compiler='c1' level='3' iicount='638'/>
+<call method='1097' instr='invokevirtual'/>
+<dependency type='unique_concrete_method' ctxk='1096' x='1097'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1097'>
+<bc code='184' bci='2'/>
+<type id='975' name='int'/>
+<method id='1099' holder='1096' name='hash' return='975' arguments='982' flags='24' bytes='20' compile_id='65' compiler='c1' level='3' iicount='3009'/>
+<call method='1099' instr='invokestatic'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1099'>
+<bc code='182' bci='9'/>
+<method id='1102' holder='982' name='hashCode' return='975' flags='257' bytes='0' compile_id='93' compile_kind='c2n' compiler='' level='0' iicount='256'/>
+<call method='1102' instr='invokevirtual'/>
+<inline_fail reason='no static binding'/>
+<parse_done stamp='0.243'/>
+</parse>
+<bc code='182' bci='6'/>
+<klass id='1103' name='java.util.HashMap$Node' flags='8'/>
+<method id='1104' holder='1096' name='getNode' return='1103' arguments='975 982' flags='16' bytes='148' compile_id='69' compiler='c1' level='3' iicount='1864'/>
+<call method='1104' instr='invokevirtual'/>
+<inline_fail reason='callee is too large'/>
+<parse_done stamp='0.243'/>
+</parse>
+<phase_done name='parse_hir' stamp='0.243'/>
+</phase>
+<parse_done stamp='0.243'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.243'>
+<phase_done name='optimize_blocks' stamp='0.243'/>
+</phase>
+<phase name='gvn' stamp='0.243'>
+<phase_done name='gvn' stamp='0.243'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.243'>
+<phase_done name='rangeCheckElimination' stamp='0.243'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.243'>
+<phase_done name='optimize_null_checks' stamp='0.243'/>
+</phase>
+<phase_done name='buildIR' stamp='0.243'/>
+</phase>
+<phase name='emit_lir' stamp='0.243'>
+<phase name='lirGeneration' stamp='0.243'>
+<phase_done name='lirGeneration' stamp='0.243'/>
+</phase>
+<phase name='linearScan' stamp='0.243'>
+<phase_done name='linearScan' stamp='0.243'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.244'/>
+</phase>
+<phase name='codeemit' stamp='0.244'>
+<phase_done name='codeemit' stamp='0.244'/>
+</phase>
+<phase name='codeinstall' stamp='0.244'>
+<dependency type='unique_concrete_method' ctxk='1096' x='1097'/>
+<phase_done name='codeinstall' stamp='0.244'/>
+</phase>
+<code_cache total_blobs='419' nmethods='112' adapters='162' free_code_cache='248580096'/>
+<task_done success='1' nmsize='1272' count='264' inlined_bytes='38' stamp='0.244'/>
+</task>
+<task compile_id='115' method='java.lang.String indexOf (I)I' bytes='7' count='276' iicount='276' level='3' stamp='0.244'>
+<phase name='setup' stamp='0.244'>
+<phase_done name='setup' stamp='0.244'/>
+</phase>
+<phase name='buildIR' stamp='0.244'>
+<type id='975' name='int'/>
+<klass id='983' name='java.lang.String' flags='17'/>
+<method id='1093' holder='983' name='indexOf' return='975' arguments='975' flags='1' bytes='7' iicount='278'/>
+<parse method='1093'  stamp='0.244'>
+<phase name='parse_hir' stamp='0.244'>
+<bc code='182' bci='3'/>
+<method id='1095' holder='983' name='indexOf' return='975' arguments='975 975' flags='1' bytes='29' iicount='290'/>
+<call method='1095' instr='invokevirtual'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1095'>
+<bc code='183' bci='1'/>
+<type id='969' name='boolean'/>
+<method id='1097' holder='983' name='isLatin1' return='969' flags='2' bytes='19' compile_id='5' compiler='c1' level='3' iicount='6544'/>
+<call method='1097' instr='invokespecial'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1097'>
+<parse_done stamp='0.244'/>
+</parse>
+<bc code='184' bci='13'/>
+<klass id='1085' name='[B' flags='1041'/>
+<klass id='1100' name='java.lang.StringLatin1' flags='16'/>
+<method id='1101' holder='1100' name='indexOf' return='975' arguments='1085 975 975' flags='9' bytes='61' compile_id='114' compiler='c1' level='3' iicount='297'/>
+<call method='1101' instr='invokestatic'/>
+<inline_fail reason='callee is too large'/>
+<bc code='184' bci='25'/>
+<klass id='1103' name='java.lang.StringUTF16' flags='16'/>
+<method id='1104' holder='1103' name='indexOf' return='975' arguments='1085 975 975' flags='9' bytes='43' iicount='1'/>
+<call method='1104' instr='invokestatic'/>
+<inline_fail reason='callee is too large'/>
+<parse_done stamp='0.244'/>
+</parse>
+<phase_done name='parse_hir' stamp='0.244'/>
+</phase>
+<parse_done stamp='0.244'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.244'>
+<phase_done name='optimize_blocks' stamp='0.244'/>
+</phase>
+<phase name='gvn' stamp='0.244'>
+<phase_done name='gvn' stamp='0.244'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.244'>
+<phase_done name='rangeCheckElimination' stamp='0.244'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.244'>
+<phase_done name='optimize_null_checks' stamp='0.244'/>
+</phase>
+<phase_done name='buildIR' stamp='0.244'/>
+</phase>
+<phase name='emit_lir' stamp='0.244'>
+<phase name='lirGeneration' stamp='0.244'>
+<phase_done name='lirGeneration' stamp='0.244'/>
+</phase>
+<phase name='linearScan' stamp='0.244'>
+<phase_done name='linearScan' stamp='0.244'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.244'/>
+</phase>
+<phase name='codeemit' stamp='0.244'>
+<phase_done name='codeemit' stamp='0.244'/>
+</phase>
+<phase name='codeinstall' stamp='0.244'>
+<phase_done name='codeinstall' stamp='0.244'/>
+</phase>
+<code_cache total_blobs='424' nmethods='117' adapters='162' free_code_cache='248573312'/>
+<task_done success='1' nmsize='952' count='318' inlined_bytes='48' stamp='0.244'/>
+</task>
+<task compile_id='120' method='jdk.internal.misc.Unsafe putObjectRelease (Ljava/lang/Object;JLjava/lang/Object;)V' bytes='9' count='256' iicount='256' level='3' stamp='0.244'>
+<phase name='setup' stamp='0.244'>
+<phase_done name='setup' stamp='0.244'/>
+</phase>
+<phase name='buildIR' stamp='0.244'>
+<type id='977' name='void'/>
+<klass id='982' name='java.lang.Object' flags='1'/>
+<type id='976' name='long'/>
+<klass id='1051' name='jdk.internal.misc.Unsafe' flags='17'/>
+<method id='1093' holder='1051' name='putObjectRelease' return='977' arguments='982 976 982' flags='17' bytes='9' iicount='256'/>
+<parse method='1093'  stamp='0.245'>
+<phase name='parse_hir' stamp='0.245'>
+<bc code='182' bci='5'/>
+<method id='1095' holder='1051' name='putObjectVolatile' return='977' arguments='982 976 982' flags='257' bytes='0' compile_id='121' compile_kind='c2n' compiler='' level='0' iicount='256'/>
+<call method='1095' instr='invokevirtual'/>
+<inline_success reason='intrinsic'/>
+<phase_done name='parse_hir' stamp='0.245'/>
+</phase>
+<parse_done stamp='0.245'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.245'>
+<phase_done name='optimize_blocks' stamp='0.245'/>
+</phase>
+<phase name='gvn' stamp='0.245'>
+<phase_done name='gvn' stamp='0.245'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.245'>
+<phase_done name='rangeCheckElimination' stamp='0.245'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.245'>
+<phase_done name='optimize_null_checks' stamp='0.245'/>
+</phase>
+<phase_done name='buildIR' stamp='0.245'/>
+</phase>
+<phase name='emit_lir' stamp='0.245'>
+<phase name='lirGeneration' stamp='0.245'>
+<phase_done name='lirGeneration' stamp='0.245'/>
+</phase>
+<phase name='linearScan' stamp='0.245'>
+<phase_done name='linearScan' stamp='0.245'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.245'/>
+</phase>
+<phase name='codeemit' stamp='0.245'>
+<phase_done name='codeemit' stamp='0.245'/>
+</phase>
+<phase name='codeinstall' stamp='0.245'>
+<phase_done name='codeinstall' stamp='0.245'/>
+</phase>
+<code_cache total_blobs='429' nmethods='120' adapters='162' free_code_cache='248558848'/>
+<task_done success='1' nmsize='432' count='296' stamp='0.245'/>
+</task>
+<task compile_id='128' method='java.util.ImmutableCollections$Set2$1 hasNext ()Z' bytes='14' count='256' iicount='256' level='3' stamp='0.247'>
+<phase name='setup' stamp='0.247'>
+<phase_done name='setup' stamp='0.247'/>
+</phase>
+<phase name='buildIR' stamp='0.247'>
+<type id='969' name='boolean'/>
+<klass id='1093' name='java.util.ImmutableCollections$Set2$1' flags='0'/>
+<method id='1094' holder='1093' name='hasNext' return='969' flags='1' bytes='14' iicount='256'/>
+<parse method='1094'  stamp='0.247'>
+<phase name='parse_hir' stamp='0.247'>
+<phase_done name='parse_hir' stamp='0.247'/>
+</phase>
+<parse_done stamp='0.247'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.247'>
+<phase_done name='optimize_blocks' stamp='0.247'/>
+</phase>
+<phase name='gvn' stamp='0.247'>
+<phase_done name='gvn' stamp='0.247'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.247'>
+<phase_done name='rangeCheckElimination' stamp='0.247'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.247'>
+<phase_done name='optimize_null_checks' stamp='0.247'/>
+</phase>
+<phase_done name='buildIR' stamp='0.247'/>
+</phase>
+<phase name='emit_lir' stamp='0.247'>
+<phase name='lirGeneration' stamp='0.247'>
+<phase_done name='lirGeneration' stamp='0.247'/>
+</phase>
+<phase name='linearScan' stamp='0.247'>
+<phase_done name='linearScan' stamp='0.247'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.247'/>
+</phase>
+<phase name='codeemit' stamp='0.247'>
+<phase_done name='codeemit' stamp='0.247'/>
+</phase>
+<phase name='codeinstall' stamp='0.247'>
+<phase_done name='codeinstall' stamp='0.247'/>
+</phase>
+<code_cache total_blobs='436' nmethods='127' adapters='162' free_code_cache='248561536'/>
+<task_done success='1' nmsize='432' count='256' stamp='0.247'/>
+</task>
+<task compile_id='132' method='java.util.HashMap afterNodeInsertion (Z)V' bytes='1' count='1386' iicount='1386' level='1' stamp='0.248'>
+<phase name='setup' stamp='0.248'>
+<phase_done name='setup' stamp='0.248'/>
+</phase>
+<phase name='buildIR' stamp='0.248'>
+<type id='977' name='void'/>
+<type id='969' name='boolean'/>
+<klass id='1093' name='java.util.HashMap' flags='1'/>
+<method id='1094' holder='1093' name='afterNodeInsertion' return='977' arguments='969' flags='0' bytes='1' compile_id='76' compiler='c1' level='3' iicount='1390'/>
+<parse method='1094'  stamp='0.248'>
+<phase name='parse_hir' stamp='0.248'>
+<phase_done name='parse_hir' stamp='0.248'/>
+</phase>
+<parse_done stamp='0.248'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.248'>
+<phase_done name='optimize_blocks' stamp='0.248'/>
+</phase>
+<phase name='gvn' stamp='0.248'>
+<phase_done name='gvn' stamp='0.248'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.248'>
+<phase_done name='rangeCheckElimination' stamp='0.248'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.248'>
+<phase_done name='optimize_null_checks' stamp='0.248'/>
+</phase>
+<phase_done name='buildIR' stamp='0.248'/>
+</phase>
+<phase name='emit_lir' stamp='0.248'>
+<phase name='lirGeneration' stamp='0.248'>
+<phase_done name='lirGeneration' stamp='0.248'/>
+</phase>
+<phase name='linearScan' stamp='0.248'>
+<phase_done name='linearScan' stamp='0.248'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.248'/>
+</phase>
+<phase name='codeemit' stamp='0.248'>
+<phase_done name='codeemit' stamp='0.248'/>
+</phase>
+<phase name='codeinstall' stamp='0.248'>
+<phase_done name='codeinstall' stamp='0.248'/>
+</phase>
+<code_cache total_blobs='443' nmethods='132' adapters='162' free_code_cache='248555776'/>
+<task_done success='1' nmsize='272' count='1485' stamp='0.248'/>
+</task>
+<task compile_id='136' method='java.lang.module.ModuleDescriptor$Exports source ()Ljava/lang/String;' bytes='5' count='132' iicount='132' level='1' stamp='0.249'>
+<phase name='setup' stamp='0.249'>
+<phase_done name='setup' stamp='0.249'/>
+</phase>
+<phase name='buildIR' stamp='0.249'>
+<klass id='983' name='java.lang.String' flags='17'/>
+<klass id='1093' name='java.lang.module.ModuleDescriptor$Exports' flags='25'/>
+<method id='1094' holder='1093' name='source' return='983' flags='1' bytes='5' iicount='142'/>
+<parse method='1094'  stamp='0.249'>
+<phase name='parse_hir' stamp='0.249'>
+<phase_done name='parse_hir' stamp='0.249'/>
+</phase>
+<parse_done stamp='0.249'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.249'>
+<phase_done name='optimize_blocks' stamp='0.249'/>
+</phase>
+<phase name='gvn' stamp='0.249'>
+<phase_done name='gvn' stamp='0.249'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.249'>
+<phase_done name='rangeCheckElimination' stamp='0.249'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.249'>
+<phase_done name='optimize_null_checks' stamp='0.249'/>
+</phase>
+<phase_done name='buildIR' stamp='0.249'/>
+</phase>
+<phase name='emit_lir' stamp='0.249'>
+<phase name='lirGeneration' stamp='0.249'>
+<phase_done name='lirGeneration' stamp='0.249'/>
+</phase>
+<phase name='linearScan' stamp='0.249'>
+<phase_done name='linearScan' stamp='0.249'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.249'/>
+</phase>
+<phase name='codeemit' stamp='0.249'>
+<phase_done name='codeemit' stamp='0.249'/>
+</phase>
+<phase name='codeinstall' stamp='0.249'>
+<phase_done name='codeinstall' stamp='0.249'/>
+</phase>
+<code_cache total_blobs='446' nmethods='135' adapters='162' free_code_cache='248551808'/>
+<task_done success='1' nmsize='272' count='153' stamp='0.249'/>
+</task>
+<task compile_id='137' method='java.util.Collections$EmptySet isEmpty ()Z' bytes='2' count='135' iicount='135' level='1' stamp='0.249'>
+<phase name='setup' stamp='0.249'>
+<phase_done name='setup' stamp='0.249'/>
+</phase>
+<phase name='buildIR' stamp='0.249'>
+<type id='969' name='boolean'/>
+<klass id='1093' name='java.util.Collections$EmptySet' flags='10'/>
+<method id='1094' holder='1093' name='isEmpty' return='969' flags='1' bytes='2' iicount='137'/>
+<parse method='1094'  stamp='0.249'>
+<phase name='parse_hir' stamp='0.249'>
+<phase_done name='parse_hir' stamp='0.249'/>
+</phase>
+<parse_done stamp='0.249'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.249'>
+<phase_done name='optimize_blocks' stamp='0.249'/>
+</phase>
+<phase name='gvn' stamp='0.249'>
+<phase_done name='gvn' stamp='0.249'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.249'>
+<phase_done name='rangeCheckElimination' stamp='0.249'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.249'>
+<phase_done name='optimize_null_checks' stamp='0.249'/>
+</phase>
+<phase_done name='buildIR' stamp='0.249'/>
+</phase>
+<phase name='emit_lir' stamp='0.249'>
+<phase name='lirGeneration' stamp='0.249'>
+<phase_done name='lirGeneration' stamp='0.249'/>
+</phase>
+<phase name='linearScan' stamp='0.249'>
+<phase_done name='linearScan' stamp='0.249'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.249'/>
+</phase>
+<phase name='codeemit' stamp='0.249'>
+<phase_done name='codeemit' stamp='0.249'/>
+</phase>
+<phase name='codeinstall' stamp='0.249'>
+<phase_done name='codeinstall' stamp='0.249'/>
+</phase>
+<code_cache total_blobs='447' nmethods='136' adapters='162' free_code_cache='248551040'/>
+<task_done success='1' nmsize='272' count='163' stamp='0.249'/>
+</task>
+<task compile_id='144' method='java.lang.Module findModule (Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;Ljava/util/List;)Ljava/lang/Module;' bytes='93' count='263' backedge_count='36' iicount='263' level='3' stamp='0.250'>
+<phase name='setup' stamp='0.250'>
+<phase_done name='setup' stamp='0.250'/>
+</phase>
+<phase name='buildIR' stamp='0.250'>
+<klass id='1019' name='java.lang.Module' flags='17'/>
+<klass id='983' name='java.lang.String' flags='17'/>
+<klass id='1093' name='java.util.Map' flags='1537'/>
+<klass id='1094' name='java.util.List' flags='1537'/>
+<method id='1095' holder='1019' name='findModule' return='1019' arguments='983 1093 1093 1094' flags='10' bytes='93' iicount='283'/>
+<parse method='1095'  stamp='0.250'>
+<phase name='parse_hir' stamp='0.250'>
+<bc code='185' bci='2'/>
+<klass id='982' name='java.lang.Object' flags='1'/>
+<method id='1097' holder='1093' name='get' return='982' arguments='982' flags='1025' bytes='0' iicount='1'/>
+<call method='1097' instr='invokeinterface'/>
+<inline_fail reason='no static binding'/>
+<bc code='185' bci='19'/>
+<call method='1097' instr='invokeinterface'/>
+<inline_fail reason='no static binding'/>
+<bc code='185' bci='35'/>
+<klass id='1098' name='java.util.Iterator' flags='1537'/>
+<method id='1099' holder='1094' name='iterator' return='1098' flags='1025' bytes='0' iicount='1'/>
+<call method='1099' instr='invokeinterface'/>
+<inline_fail reason='no static binding'/>
+<bc code='185' bci='44'/>
+<type id='969' name='boolean'/>
+<method id='1100' holder='1098' name='hasNext' return='969' flags='1025' bytes='0' iicount='1'/>
+<call method='1100' instr='invokeinterface'/>
+<inline_fail reason='no static binding'/>
+<bc code='185' bci='54'/>
+<method id='1101' holder='1098' name='next' return='982' flags='1025' bytes='0' iicount='1'/>
+<call method='1101' instr='invokeinterface'/>
+<inline_fail reason='no static binding'/>
+<bc code='182' bci='67'/>
+<klass id='1103' name='java.util.Optional' flags='17'/>
+<klass id='1102' name='java.lang.ModuleLayer' flags='17'/>
+<method id='1104' holder='1102' name='findModule' return='1103' arguments='983' flags='1' bytes='87' iicount='42'/>
+<call method='1104' instr='invokevirtual'/>
+<inline_fail reason='callee is too large'/>
+<bc code='182' bci='71'/>
+<method id='1106' holder='1103' name='orElse' return='982' arguments='982' flags='1' bytes='16' compile_id='87' compiler='c1' level='3' iicount='471'/>
+<call method='1106' instr='invokevirtual'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1106'>
+<parse_done stamp='0.250'/>
+</parse>
+<phase_done name='parse_hir' stamp='0.250'/>
+</phase>
+<parse_done stamp='0.250'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.250'>
+<phase_done name='optimize_blocks' stamp='0.250'/>
+</phase>
+<phase name='gvn' stamp='0.250'>
+<phase_done name='gvn' stamp='0.250'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.250'>
+<phase_done name='rangeCheckElimination' stamp='0.250'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.250'>
+<phase_done name='optimize_null_checks' stamp='0.251'/>
+</phase>
+<phase_done name='buildIR' stamp='0.251'/>
+</phase>
+<phase name='emit_lir' stamp='0.251'>
+<phase name='lirGeneration' stamp='0.251'>
+<phase_done name='lirGeneration' stamp='0.251'/>
+</phase>
+<phase name='linearScan' stamp='0.251'>
+<phase_done name='linearScan' stamp='0.251'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.251'/>
+</phase>
+<phase name='codeemit' stamp='0.251'>
+<phase_done name='codeemit' stamp='0.251'/>
+</phase>
+<phase name='codeinstall' stamp='0.251'>
+<phase_done name='codeinstall' stamp='0.251'/>
+</phase>
+<code_cache total_blobs='459' nmethods='148' adapters='162' free_code_cache='248529024'/>
+<task_done success='1' nmsize='3160' count='479' backedge_count='83' inlined_bytes='16' stamp='0.251'/>
+</task>
+<task compile_id='152' method='java.util.Collections$1 next ()Ljava/lang/Object;' bytes='25' count='267' iicount='267' level='3' stamp='0.251'>
+<phase name='setup' stamp='0.251'>
+<phase_done name='setup' stamp='0.251'/>
+</phase>
+<phase name='buildIR' stamp='0.251'>
+<klass id='982' name='java.lang.Object' flags='1'/>
+<klass id='1093' name='java.util.Collections$1' flags='0'/>
+<method id='1094' holder='1093' name='next' return='982' flags='1' bytes='25' iicount='268'/>
+<parse method='1094'  stamp='0.251'>
+<phase name='parse_hir' stamp='0.251'>
+<bc code='183' bci='21'/>
+<type id='977' name='void'/>
+<klass id='1096' name='java.util.NoSuchElementException' unloaded='1'/>
+<method id='1097' holder='1096' name='&lt;init&gt;' return='977' unloaded='1'/>
+<call method='1097' instr='invokespecial'/>
+<inline_fail reason='not inlineable'/>
+<phase_done name='parse_hir' stamp='0.251'/>
+</phase>
+<parse_done stamp='0.251'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.251'>
+<phase_done name='optimize_blocks' stamp='0.251'/>
+</phase>
+<phase name='gvn' stamp='0.251'>
+<phase_done name='gvn' stamp='0.251'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.251'>
+<phase_done name='rangeCheckElimination' stamp='0.251'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.251'>
+<phase_done name='optimize_null_checks' stamp='0.251'/>
+</phase>
+<phase_done name='buildIR' stamp='0.251'/>
+</phase>
+<phase name='emit_lir' stamp='0.251'>
+<phase name='lirGeneration' stamp='0.251'>
+<phase_done name='lirGeneration' stamp='0.251'/>
+</phase>
+<phase name='linearScan' stamp='0.251'>
+<phase_done name='linearScan' stamp='0.251'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.251'/>
+</phase>
+<phase name='codeemit' stamp='0.251'>
+<phase_done name='codeemit' stamp='0.251'/>
+</phase>
+<phase name='codeinstall' stamp='0.251'>
+<phase_done name='codeinstall' stamp='0.251'/>
+</phase>
+<code_cache total_blobs='463' nmethods='152' adapters='162' free_code_cache='248524288'/>
+<task_done success='1' nmsize='520' count='276' stamp='0.251'/>
+</task>
+<task compile_id='156' method='java.util.ImmutableCollections$Set2 size ()I' bytes='2' count='129' iicount='129' level='1' stamp='0.252'>
+<phase name='setup' stamp='0.252'>
+<phase_done name='setup' stamp='0.252'/>
+</phase>
+<phase name='buildIR' stamp='0.252'>
+<type id='975' name='int'/>
+<klass id='1093' name='java.util.ImmutableCollections$Set2' flags='24'/>
+<method id='1094' holder='1093' name='size' return='975' flags='1' bytes='2' iicount='129'/>
+<parse method='1094'  stamp='0.252'>
+<phase name='parse_hir' stamp='0.252'>
+<phase_done name='parse_hir' stamp='0.252'/>
+</phase>
+<parse_done stamp='0.252'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.252'>
+<phase_done name='optimize_blocks' stamp='0.252'/>
+</phase>
+<phase name='gvn' stamp='0.252'>
+<phase_done name='gvn' stamp='0.252'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.252'>
+<phase_done name='rangeCheckElimination' stamp='0.252'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.252'>
+<phase_done name='optimize_null_checks' stamp='0.252'/>
+</phase>
+<phase_done name='buildIR' stamp='0.252'/>
+</phase>
+<phase name='emit_lir' stamp='0.252'>
+<phase name='lirGeneration' stamp='0.252'>
+<phase_done name='lirGeneration' stamp='0.252'/>
+</phase>
+<phase name='linearScan' stamp='0.252'>
+<phase_done name='linearScan' stamp='0.252'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.252'/>
+</phase>
+<phase name='codeemit' stamp='0.252'>
+<phase_done name='codeemit' stamp='0.252'/>
+</phase>
+<phase name='codeinstall' stamp='0.252'>
+<phase_done name='codeinstall' stamp='0.252'/>
+</phase>
+<code_cache total_blobs='467' nmethods='156' adapters='162' free_code_cache='248519808'/>
+<task_done success='1' nmsize='272' count='130' stamp='0.252'/>
+</task>
+<task compile_id='159' method='java.util.Map entry (Ljava/lang/Object;Ljava/lang/Object;)Ljava/util/Map$Entry;' bytes='10' count='280' iicount='280' level='3' stamp='0.253'>
+<phase name='setup' stamp='0.253'>
+<phase_done name='setup' stamp='0.253'/>
+</phase>
+<phase name='buildIR' stamp='0.253'>
+<klass id='1094' name='java.util.Map$Entry' flags='1545'/>
+<klass id='982' name='java.lang.Object' flags='1'/>
+<klass id='1093' name='java.util.Map' flags='1537'/>
+<method id='1095' holder='1093' name='entry' return='1094' arguments='982 982' flags='9' bytes='10' iicount='280'/>
+<parse method='1095'  stamp='0.253'>
+<phase name='parse_hir' stamp='0.253'>
+<bc code='183' bci='6'/>
+<type id='977' name='void'/>
+<klass id='1097' name='java.util.KeyValueHolder' flags='16'/>
+<method id='1098' holder='1097' name='&lt;init&gt;' return='977' arguments='982 982' flags='0' bytes='21' iicount='280'/>
+<call method='1098' instr='invokespecial'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1098'>
+<bc code='183' bci='1'/>
+<method id='1100' holder='982' name='&lt;init&gt;' return='977' flags='1' bytes='1' compile_id='50' compiler='c1' level='1' iicount='8727'/>
+<call method='1100' instr='invokespecial'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1100'>
+<parse_done stamp='0.253'/>
+</parse>
+<bc code='184' bci='6'/>
+<klass id='1102' name='java.util.Objects' flags='17'/>
+<method id='1103' holder='1102' name='requireNonNull' return='982' arguments='982' flags='9' bytes='14' compile_id='21' compiler='c1' level='3' iicount='3378'/>
+<call method='1103' instr='invokestatic'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1103'>
+<bc code='183' bci='8'/>
+<klass id='1089' name='java.lang.NullPointerException' flags='1'/>
+<method id='1105' holder='1089' name='&lt;init&gt;' return='977' flags='1' bytes='5' iicount='1'/>
+<call method='1105' instr='invokespecial'/>
+<inline_fail reason='don&apos;t inline Throwable constructors'/>
+<parse_done stamp='0.253'/>
+</parse>
+<bc code='184' bci='14'/>
+<call method='1103' instr='invokestatic'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1103'>
+<bc code='183' bci='8'/>
+<call method='1105' instr='invokespecial'/>
+<inline_fail reason='don&apos;t inline Throwable constructors'/>
+<parse_done stamp='0.253'/>
+</parse>
+<parse_done stamp='0.253'/>
+</parse>
+<phase_done name='parse_hir' stamp='0.253'/>
+</phase>
+<parse_done stamp='0.253'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.253'>
+<phase_done name='optimize_blocks' stamp='0.253'/>
+</phase>
+<phase name='gvn' stamp='0.253'>
+<phase_done name='gvn' stamp='0.253'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.253'>
+<phase_done name='rangeCheckElimination' stamp='0.253'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.253'>
+<phase_done name='optimize_null_checks' stamp='0.253'/>
+</phase>
+<phase_done name='buildIR' stamp='0.253'/>
+</phase>
+<phase name='emit_lir' stamp='0.253'>
+<phase name='lirGeneration' stamp='0.253'>
+<phase_done name='lirGeneration' stamp='0.253'/>
+</phase>
+<phase name='linearScan' stamp='0.253'>
+<phase_done name='linearScan' stamp='0.253'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.253'/>
+</phase>
+<phase name='codeemit' stamp='0.253'>
+<phase_done name='codeemit' stamp='0.253'/>
+</phase>
+<phase name='codeinstall' stamp='0.253'>
+<phase_done name='codeinstall' stamp='0.254'/>
+</phase>
+<code_cache total_blobs='471' nmethods='160' adapters='162' free_code_cache='248513536'/>
+<task_done success='1' nmsize='1464' count='280' inlined_bytes='50' stamp='0.254'/>
+</task>
+<task compile_id='168' method='java.util.ImmutableCollections$Set0 instance ()Ljava/util/ImmutableCollections$Set0;' bytes='4' count='234' iicount='234' level='3' stamp='0.255'>
+<phase name='setup' stamp='0.255'>
+<phase_done name='setup' stamp='0.255'/>
+</phase>
+<phase name='buildIR' stamp='0.255'>
+<klass id='1093' name='java.util.ImmutableCollections$Set0' flags='24'/>
+<method id='1094' holder='1093' name='instance' return='1093' flags='8' bytes='4' iicount='234'/>
+<parse method='1094'  stamp='0.255'>
+<phase name='parse_hir' stamp='0.255'>
+<phase_done name='parse_hir' stamp='0.255'/>
+</phase>
+<parse_done stamp='0.255'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.255'>
+<phase_done name='optimize_blocks' stamp='0.255'/>
+</phase>
+<phase name='gvn' stamp='0.255'>
+<phase_done name='gvn' stamp='0.255'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.255'>
+<phase_done name='rangeCheckElimination' stamp='0.255'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.255'>
+<phase_done name='optimize_null_checks' stamp='0.255'/>
+</phase>
+<phase_done name='buildIR' stamp='0.255'/>
+</phase>
+<phase name='emit_lir' stamp='0.255'>
+<phase name='lirGeneration' stamp='0.255'>
+<phase_done name='lirGeneration' stamp='0.255'/>
+</phase>
+<phase name='linearScan' stamp='0.255'>
+<phase_done name='linearScan' stamp='0.255'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.255'/>
+</phase>
+<phase name='codeemit' stamp='0.255'>
+<phase_done name='codeemit' stamp='0.255'/>
+</phase>
+<phase name='codeinstall' stamp='0.255'>
+<phase_done name='codeinstall' stamp='0.255'/>
+</phase>
+<code_cache total_blobs='480' nmethods='167' adapters='162' free_code_cache='248504320'/>
+<task_done success='1' nmsize='304' count='238' stamp='0.255'/>
+</task>
+<task compile_id='171' method='java.util.zip.ZipUtils SH ([BI)I' bytes='21' count='259' iicount='259' level='3' stamp='0.280'>
+<phase name='setup' stamp='0.280'>
+<phase_done name='setup' stamp='0.280'/>
+</phase>
+<phase name='buildIR' stamp='0.280'>
+<type id='975' name='int'/>
+<klass id='1085' name='[B' flags='1041'/>
+<klass id='1093' name='java.util.zip.ZipUtils' flags='0'/>
+<method id='1094' holder='1093' name='SH' return='975' arguments='1085 975' flags='24' bytes='21' iicount='259'/>
+<parse method='1094'  stamp='0.280'>
+<phase name='parse_hir' stamp='0.280'>
+<phase_done name='parse_hir' stamp='0.280'/>
+</phase>
+<parse_done stamp='0.280'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.280'>
+<phase_done name='optimize_blocks' stamp='0.280'/>
+</phase>
+<phase name='gvn' stamp='0.280'>
+<phase_done name='gvn' stamp='0.280'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.280'>
+<phase_done name='rangeCheckElimination' stamp='0.280'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.280'>
+<phase_done name='optimize_null_checks' stamp='0.280'/>
+</phase>
+<phase_done name='buildIR' stamp='0.280'/>
+</phase>
+<phase name='emit_lir' stamp='0.280'>
+<phase name='lirGeneration' stamp='0.280'>
+<phase_done name='lirGeneration' stamp='0.280'/>
+</phase>
+<phase name='linearScan' stamp='0.280'>
+<phase_done name='linearScan' stamp='0.280'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.280'/>
+</phase>
+<phase name='codeemit' stamp='0.280'>
+<phase_done name='codeemit' stamp='0.280'/>
+</phase>
+<phase name='codeinstall' stamp='0.280'>
+<phase_done name='codeinstall' stamp='0.280'/>
+</phase>
+<code_cache total_blobs='516' nmethods='171' adapters='194' free_code_cache='248481792'/>
+<task_done success='1' nmsize='400' count='259' stamp='0.280'/>
+</task>
+<task compile_id='176' method='sun.nio.fs.UnixPath checkNotNul (Ljava/lang/String;C)V' bytes='16' count='266' iicount='266' level='3' stamp='0.286'>
+<phase name='setup' stamp='0.286'>
+<phase_done name='setup' stamp='0.286'/>
+</phase>
+<phase name='buildIR' stamp='0.286'>
+<type id='977' name='void'/>
+<klass id='983' name='java.lang.String' flags='17'/>
+<type id='970' name='char'/>
+<klass id='1093' name='sun.nio.fs.UnixPath' flags='0'/>
+<method id='1094' holder='1093' name='checkNotNul' return='977' arguments='983 970' flags='10' bytes='16' iicount='266'/>
+<parse method='1094'  stamp='0.286'>
+<phase name='parse_hir' stamp='0.286'>
+<bc code='183' bci='11'/>
+<klass id='1096' name='java.nio.file.InvalidPathException' unloaded='1'/>
+<method id='1098' holder='1096' name='&lt;init&gt;' return='977' arguments='983 983' unloaded='1'/>
+<call method='1098' instr='invokespecial'/>
+<inline_fail reason='not inlineable'/>
+<phase_done name='parse_hir' stamp='0.287'/>
+</phase>
+<parse_done stamp='0.287'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.287'>
+<phase_done name='optimize_blocks' stamp='0.287'/>
+</phase>
+<phase name='gvn' stamp='0.287'>
+<phase_done name='gvn' stamp='0.287'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.287'>
+<phase_done name='rangeCheckElimination' stamp='0.287'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.287'>
+<phase_done name='optimize_null_checks' stamp='0.287'/>
+</phase>
+<phase_done name='buildIR' stamp='0.287'/>
+</phase>
+<phase name='emit_lir' stamp='0.287'>
+<phase name='lirGeneration' stamp='0.287'>
+<phase_done name='lirGeneration' stamp='0.287'/>
+</phase>
+<phase name='linearScan' stamp='0.287'>
+<phase_done name='linearScan' stamp='0.287'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.287'/>
+</phase>
+<phase name='codeemit' stamp='0.287'>
+<phase_done name='codeemit' stamp='0.287'/>
+</phase>
+<phase name='codeinstall' stamp='0.287'>
+<phase_done name='codeinstall' stamp='0.287'/>
+</phase>
+<code_cache total_blobs='524' nmethods='176' adapters='197' free_code_cache='248473728'/>
+<task_done success='1' nmsize='520' count='266' stamp='0.287'/>
+</task>
+<task compile_id='180' method='java.lang.String getBytes ([BIB)V' bytes='44' count='256' iicount='256' level='3' stamp='0.309'>
+<phase name='setup' stamp='0.309'>
+<phase_done name='setup' stamp='0.309'/>
+</phase>
+<phase name='buildIR' stamp='0.309'>
+<type id='977' name='void'/>
+<klass id='1085' name='[B' flags='1041'/>
+<type id='975' name='int'/>
+<type id='973' name='byte'/>
+<klass id='983' name='java.lang.String' flags='17'/>
+<method id='1093' holder='983' name='getBytes' return='977' arguments='1085 975 973' flags='0' bytes='44' iicount='256'/>
+<parse method='1093'  stamp='0.309'>
+<phase name='parse_hir' stamp='0.309'>
+<bc code='182' bci='1'/>
+<method id='1095' holder='983' name='coder' return='973' flags='0' bytes='15' compile_id='4' compiler='c1' level='3' iicount='8510'/>
+<call method='1095' instr='invokevirtual'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1095'>
+<parse_done stamp='0.309'/>
+</parse>
+<bc code='184' bci='22'/>
+<klass id='982' name='java.lang.Object' flags='1'/>
+<klass id='988' name='java.lang.System' flags='17'/>
+<method id='1098' holder='988' name='arraycopy' return='977' arguments='982 975 982 975 975' flags='265' bytes='0' compile_id='44' compile_kind='c2n' compiler='' level='0' iicount='256'/>
+<call method='1098' instr='invokestatic'/>
+<inline_success reason='intrinsic'/>
+<bc code='184' bci='40'/>
+<klass id='1100' name='java.lang.StringLatin1' flags='16'/>
+<method id='1101' holder='1100' name='inflate' return='977' arguments='1085 975 1085 975 975' flags='9' bytes='10' iicount='1'/>
+<call method='1101' instr='invokestatic'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1101'>
+<bc code='184' bci='6'/>
+<klass id='1103' name='java.lang.StringUTF16' flags='16'/>
+<method id='1104' holder='1103' name='inflate' return='977' arguments='1085 975 1085 975 975' flags='9' bytes='42' iicount='1'/>
+<call method='1104' instr='invokestatic'/>
+<inline_fail reason='callee is too large'/>
+<parse_done stamp='0.309'/>
+</parse>
+<phase_done name='parse_hir' stamp='0.309'/>
+</phase>
+<parse_done stamp='0.309'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.309'>
+<phase_done name='optimize_blocks' stamp='0.309'/>
+</phase>
+<phase name='gvn' stamp='0.309'>
+<phase_done name='gvn' stamp='0.309'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.309'>
+<phase_done name='rangeCheckElimination' stamp='0.309'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.309'>
+<phase_done name='optimize_null_checks' stamp='0.310'/>
+</phase>
+<phase_done name='buildIR' stamp='0.310'/>
+</phase>
+<phase name='emit_lir' stamp='0.310'>
+<phase name='lirGeneration' stamp='0.310'>
+<phase_done name='lirGeneration' stamp='0.310'/>
+</phase>
+<phase name='linearScan' stamp='0.310'>
+<phase_done name='linearScan' stamp='0.310'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.310'/>
+</phase>
+<phase name='codeemit' stamp='0.310'>
+<phase_done name='codeemit' stamp='0.310'/>
+</phase>
+<phase name='codeinstall' stamp='0.310'>
+<phase_done name='codeinstall' stamp='0.310'/>
+</phase>
+<code_cache total_blobs='529' nmethods='180' adapters='198' free_code_cache='248467328'/>
+<task_done success='1' nmsize='1016' count='259' inlined_bytes='25' stamp='0.310'/>
+</task>
+<task compile_id='184' method='java.lang.reflect.Method getName ()Ljava/lang/String;' bytes='5' count='434' iicount='434' level='1' stamp='0.319'>
+<phase name='setup' stamp='0.319'>
+<phase_done name='setup' stamp='0.319'/>
+</phase>
+<phase name='buildIR' stamp='0.319'>
+<klass id='983' name='java.lang.String' flags='17'/>
+<klass id='1024' name='java.lang.reflect.Method' flags='17'/>
+<method id='1093' holder='1024' name='getName' return='983' flags='1' bytes='5' iicount='434'/>
+<parse method='1093'  stamp='0.319'>
+<phase name='parse_hir' stamp='0.319'>
+<phase_done name='parse_hir' stamp='0.319'/>
+</phase>
+<parse_done stamp='0.319'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.319'>
+<phase_done name='optimize_blocks' stamp='0.319'/>
+</phase>
+<phase name='gvn' stamp='0.319'>
+<phase_done name='gvn' stamp='0.319'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.319'>
+<phase_done name='rangeCheckElimination' stamp='0.319'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.319'>
+<phase_done name='optimize_null_checks' stamp='0.319'/>
+</phase>
+<phase_done name='buildIR' stamp='0.319'/>
+</phase>
+<phase name='emit_lir' stamp='0.319'>
+<phase name='lirGeneration' stamp='0.319'>
+<phase_done name='lirGeneration' stamp='0.319'/>
+</phase>
+<phase name='linearScan' stamp='0.319'>
+<phase_done name='linearScan' stamp='0.319'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.319'/>
+</phase>
+<phase name='codeemit' stamp='0.319'>
+<phase_done name='codeemit' stamp='0.319'/>
+</phase>
+<phase name='codeinstall' stamp='0.319'>
+<phase_done name='codeinstall' stamp='0.319'/>
+</phase>
+<code_cache total_blobs='533' nmethods='184' adapters='198' free_code_cache='248460544'/>
+<task_done success='1' nmsize='272' count='434' stamp='0.319'/>
+</task>
+<task compile_id='197' method='java.lang.invoke.MethodType$ConcurrentWeakInternSet$WeakEntry hashCode ()I' bytes='5' count='139' iicount='139' level='1' stamp='0.327'>
+<phase name='setup' stamp='0.327'>
+<phase_done name='setup' stamp='0.327'/>
+</phase>
+<phase name='buildIR' stamp='0.327'>
+<type id='975' name='int'/>
+<klass id='1093' name='java.lang.invoke.MethodType$ConcurrentWeakInternSet$WeakEntry' flags='10'/>
+<method id='1094' holder='1093' name='hashCode' return='975' flags='1' bytes='5' iicount='141'/>
+<parse method='1094'  stamp='0.327'>
+<phase name='parse_hir' stamp='0.327'>
+<phase_done name='parse_hir' stamp='0.327'/>
+</phase>
+<parse_done stamp='0.327'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.327'>
+<phase_done name='optimize_blocks' stamp='0.327'/>
+</phase>
+<phase name='gvn' stamp='0.327'>
+<phase_done name='gvn' stamp='0.327'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.327'>
+<phase_done name='rangeCheckElimination' stamp='0.327'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.327'>
+<phase_done name='optimize_null_checks' stamp='0.327'/>
+</phase>
+<phase_done name='buildIR' stamp='0.327'/>
+</phase>
+<phase name='emit_lir' stamp='0.327'>
+<phase name='lirGeneration' stamp='0.327'>
+<phase_done name='lirGeneration' stamp='0.327'/>
+</phase>
+<phase name='linearScan' stamp='0.327'>
+<phase_done name='linearScan' stamp='0.327'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.327'/>
+</phase>
+<phase name='codeemit' stamp='0.327'>
+<phase_done name='codeemit' stamp='0.327'/>
+</phase>
+<phase name='codeinstall' stamp='0.327'>
+<phase_done name='codeinstall' stamp='0.327'/>
+</phase>
+<code_cache total_blobs='571' nmethods='197' adapters='223' free_code_cache='248425728'/>
+<task_done success='1' nmsize='272' count='145' stamp='0.327'/>
+</task>
+<task compile_id='209' method='java.lang.ref.ReferenceQueue poll ()Ljava/lang/ref/Reference;' bytes='28' count='256' iicount='256' level='3' stamp='0.334'>
+<phase name='setup' stamp='0.334'>
+<phase_done name='setup' stamp='0.334'/>
+</phase>
+<phase name='buildIR' stamp='0.334'>
+<klass id='1008' name='java.lang.ref.Reference' flags='1025'/>
+<klass id='1093' name='java.lang.ref.ReferenceQueue' flags='1'/>
+<method id='1094' holder='1093' name='poll' return='1008' flags='1' bytes='28' iicount='256'/>
+<parse method='1094'  stamp='0.334'>
+<phase name='parse_hir' stamp='0.334'>
+<bc code='183' bci='17'/>
+<method id='1097' holder='1093' name='reallyPoll' return='1008' flags='2' bytes='65' iicount='2'/>
+<call method='1097' instr='invokespecial'/>
+<inline_fail reason='callee is too large'/>
+<phase_done name='parse_hir' stamp='0.334'/>
+</phase>
+<parse_done stamp='0.334'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.334'>
+<phase_done name='optimize_blocks' stamp='0.334'/>
+</phase>
+<phase name='gvn' stamp='0.334'>
+<phase_done name='gvn' stamp='0.334'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.334'>
+<phase_done name='rangeCheckElimination' stamp='0.334'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.334'>
+<phase_done name='optimize_null_checks' stamp='0.334'/>
+</phase>
+<phase_done name='buildIR' stamp='0.334'/>
+</phase>
+<phase name='emit_lir' stamp='0.334'>
+<phase name='lirGeneration' stamp='0.334'>
+<phase_done name='lirGeneration' stamp='0.334'/>
+</phase>
+<phase name='linearScan' stamp='0.334'>
+<phase_done name='linearScan' stamp='0.334'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.334'/>
+</phase>
+<phase name='codeemit' stamp='0.334'>
+<phase_done name='codeemit' stamp='0.334'/>
+</phase>
+<phase name='codeinstall' stamp='0.334'>
+<phase_done name='codeinstall' stamp='0.334'/>
+</phase>
+<code_cache total_blobs='592' nmethods='209' adapters='232' free_code_cache='248406656'/>
+<task_done success='1' nmsize='904' count='263' stamp='0.334'/>
+</task>
+<task compile_id='213' method='java.lang.invoke.MethodType checkPtype (Ljava/lang/Class;)V' bytes='19' count='261' iicount='261' level='3' stamp='0.335'>
+<phase name='setup' stamp='0.335'>
+<phase_done name='setup' stamp='0.335'/>
+</phase>
+<phase name='buildIR' stamp='0.335'>
+<type id='977' name='void'/>
+<klass id='984' name='java.lang.Class' flags='17'/>
+<klass id='1041' name='java.lang.invoke.MethodType' flags='17'/>
+<method id='1093' holder='1041' name='checkPtype' return='977' arguments='984' flags='10' bytes='19' iicount='261'/>
+<parse method='1093'  stamp='0.335'>
+<phase name='parse_hir' stamp='0.335'>
+<bc code='184' bci='1'/>
+<klass id='982' name='java.lang.Object' flags='1'/>
+<klass id='1095' name='java.util.Objects' flags='17'/>
+<method id='1096' holder='1095' name='requireNonNull' return='982' arguments='982' flags='9' bytes='14' compile_id='21' compiler='c1' level='3' iicount='3894'/>
+<call method='1096' instr='invokestatic'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1096'>
+<bc code='183' bci='8'/>
+<klass id='1089' name='java.lang.NullPointerException' flags='1'/>
+<method id='1098' holder='1089' name='&lt;init&gt;' return='977' flags='1' bytes='5' iicount='1'/>
+<call method='1098' instr='invokespecial'/>
+<inline_fail reason='don&apos;t inline Throwable constructors'/>
+<parse_done stamp='0.335'/>
+</parse>
+<bc code='184' bci='14'/>
+<klass id='993' name='java.lang.RuntimeException' flags='1'/>
+<klass id='983' name='java.lang.String' flags='17'/>
+<klass id='1104' name='java.lang.invoke.MethodHandleStatics' flags='0'/>
+<method id='1105' holder='1104' name='newIllegalArgumentException' return='993' arguments='983' flags='8' bytes='9' iicount='1'/>
+<call method='1105' instr='invokestatic'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1105'>
+<bc code='183' bci='5'/>
+<klass id='1107' name='java.lang.IllegalArgumentException' flags='1'/>
+<method id='1108' holder='1107' name='&lt;init&gt;' return='977' arguments='983' flags='1' bytes='6' iicount='1'/>
+<call method='1108' instr='invokespecial'/>
+<inline_fail reason='don&apos;t inline Throwable constructors'/>
+<parse_done stamp='0.335'/>
+</parse>
+<phase_done name='parse_hir' stamp='0.335'/>
+</phase>
+<parse_done stamp='0.335'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.335'>
+<phase_done name='optimize_blocks' stamp='0.335'/>
+</phase>
+<phase name='gvn' stamp='0.335'>
+<phase_done name='gvn' stamp='0.335'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.335'>
+<phase_done name='rangeCheckElimination' stamp='0.335'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.335'>
+<phase_done name='optimize_null_checks' stamp='0.335'/>
+</phase>
+<phase_done name='buildIR' stamp='0.335'/>
+</phase>
+<phase name='emit_lir' stamp='0.335'>
+<phase name='lirGeneration' stamp='0.335'>
+<phase_done name='lirGeneration' stamp='0.335'/>
+</phase>
+<phase name='linearScan' stamp='0.335'>
+<phase_done name='linearScan' stamp='0.335'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.335'/>
+</phase>
+<phase name='codeemit' stamp='0.335'>
+<phase_done name='codeemit' stamp='0.335'/>
+</phase>
+<phase name='codeinstall' stamp='0.335'>
+<phase_done name='codeinstall' stamp='0.335'/>
+</phase>
+<code_cache total_blobs='597' nmethods='213' adapters='232' free_code_cache='248397312'/>
+<task_done success='1' nmsize='1016' count='265' inlined_bytes='23' stamp='0.335'/>
+</task>
+<task compile_id='221' method='java.lang.invoke.MemberName isInvocable ()Z' bytes='7' count='258' iicount='258' level='3' stamp='0.336'>
+<phase name='setup' stamp='0.336'>
+<phase_done name='setup' stamp='0.336'/>
+</phase>
+<phase name='buildIR' stamp='0.336'>
+<type id='969' name='boolean'/>
+<klass id='1038' name='java.lang.invoke.MemberName' flags='16'/>
+<method id='1093' holder='1038' name='isInvocable' return='969' flags='1' bytes='7' iicount='261'/>
+<parse method='1093'  stamp='0.336'>
+<phase name='parse_hir' stamp='0.336'>
+<bc code='183' bci='3'/>
+<type id='975' name='int'/>
+<method id='1095' holder='1038' name='testAnyFlags' return='969' arguments='975' flags='2' bytes='15' iicount='263'/>
+<call method='1095' instr='invokespecial'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1095'>
+<bc code='183' bci='3'/>
+<method id='1097' holder='1038' name='testFlags' return='969' arguments='975 975' flags='2' bytes='16' compile_id='210' compiler='c1' level='3' iicount='400'/>
+<call method='1097' instr='invokespecial'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1097'>
+<parse_done stamp='0.336'/>
+</parse>
+<parse_done stamp='0.336'/>
+</parse>
+<phase_done name='parse_hir' stamp='0.337'/>
+</phase>
+<parse_done stamp='0.337'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.337'>
+<phase_done name='optimize_blocks' stamp='0.337'/>
+</phase>
+<phase name='gvn' stamp='0.337'>
+<phase_done name='gvn' stamp='0.337'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.337'>
+<phase_done name='rangeCheckElimination' stamp='0.337'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.337'>
+<phase_done name='optimize_null_checks' stamp='0.337'/>
+</phase>
+<phase_done name='buildIR' stamp='0.337'/>
+</phase>
+<phase name='emit_lir' stamp='0.337'>
+<phase name='lirGeneration' stamp='0.337'>
+<phase_done name='lirGeneration' stamp='0.337'/>
+</phase>
+<phase name='linearScan' stamp='0.337'>
+<phase_done name='linearScan' stamp='0.337'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.337'/>
+</phase>
+<phase name='codeemit' stamp='0.337'>
+<phase_done name='codeemit' stamp='0.337'/>
+</phase>
+<phase name='codeinstall' stamp='0.337'>
+<phase_done name='codeinstall' stamp='0.337'/>
+</phase>
+<code_cache total_blobs='603' nmethods='218' adapters='232' free_code_cache='248396416'/>
+<task_done success='1' nmsize='720' count='265' inlined_bytes='31' stamp='0.337'/>
+</task>
+<task compile_id='216' method='java.lang.invoke.MemberName getDeclaringClass ()Ljava/lang/Class;' bytes='5' count='142' iicount='142' level='1' stamp='0.337'>
+<phase name='setup' stamp='0.337'>
+<phase_done name='setup' stamp='0.337'/>
+</phase>
+<phase name='buildIR' stamp='0.337'>
+<klass id='984' name='java.lang.Class' flags='17'/>
+<klass id='1038' name='java.lang.invoke.MemberName' flags='16'/>
+<method id='1093' holder='1038' name='getDeclaringClass' return='984' flags='1' bytes='5' iicount='144'/>
+<parse method='1093'  stamp='0.337'>
+<phase name='parse_hir' stamp='0.337'>
+<phase_done name='parse_hir' stamp='0.337'/>
+</phase>
+<parse_done stamp='0.337'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.337'>
+<phase_done name='optimize_blocks' stamp='0.337'/>
+</phase>
+<phase name='gvn' stamp='0.337'>
+<phase_done name='gvn' stamp='0.337'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.337'>
+<phase_done name='rangeCheckElimination' stamp='0.337'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.337'>
+<phase_done name='optimize_null_checks' stamp='0.337'/>
+</phase>
+<phase_done name='buildIR' stamp='0.337'/>
+</phase>
+<phase name='emit_lir' stamp='0.337'>
+<phase name='lirGeneration' stamp='0.337'>
+<phase_done name='lirGeneration' stamp='0.337'/>
+</phase>
+<phase name='linearScan' stamp='0.337'>
+<phase_done name='linearScan' stamp='0.337'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.337'/>
+</phase>
+<phase name='codeemit' stamp='0.337'>
+<phase_done name='codeemit' stamp='0.337'/>
+</phase>
+<phase name='codeinstall' stamp='0.337'>
+<phase_done name='codeinstall' stamp='0.337'/>
+</phase>
+<code_cache total_blobs='606' nmethods='221' adapters='232' free_code_cache='248391936'/>
+<task_done success='1' nmsize='272' count='152' stamp='0.337'/>
+</task>
+<task compile_id='226' method='java.lang.invoke.MethodType parameterType (I)Ljava/lang/Class;' bytes='7' count='257' iicount='257' level='3' stamp='0.340'>
+<phase name='setup' stamp='0.340'>
+<phase_done name='setup' stamp='0.340'/>
+</phase>
+<phase name='buildIR' stamp='0.340'>
+<klass id='984' name='java.lang.Class' flags='17'/>
+<type id='975' name='int'/>
+<klass id='1041' name='java.lang.invoke.MethodType' flags='17'/>
+<method id='1093' holder='1041' name='parameterType' return='984' arguments='975' flags='1' bytes='7' iicount='257'/>
+<parse method='1093'  stamp='0.340'>
+<phase name='parse_hir' stamp='0.340'>
+<phase_done name='parse_hir' stamp='0.340'/>
+</phase>
+<parse_done stamp='0.340'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.340'>
+<phase_done name='optimize_blocks' stamp='0.340'/>
+</phase>
+<phase name='gvn' stamp='0.340'>
+<phase_done name='gvn' stamp='0.340'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.340'>
+<phase_done name='rangeCheckElimination' stamp='0.340'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.340'>
+<phase_done name='optimize_null_checks' stamp='0.340'/>
+</phase>
+<phase_done name='buildIR' stamp='0.340'/>
+</phase>
+<phase name='emit_lir' stamp='0.340'>
+<phase name='lirGeneration' stamp='0.340'>
+<phase_done name='lirGeneration' stamp='0.340'/>
+</phase>
+<phase name='linearScan' stamp='0.340'>
+<phase_done name='linearScan' stamp='0.340'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.340'/>
+</phase>
+<phase name='codeemit' stamp='0.340'>
+<phase_done name='codeemit' stamp='0.340'/>
+</phase>
+<phase name='codeinstall' stamp='0.340'>
+<phase_done name='codeinstall' stamp='0.340'/>
+</phase>
+<code_cache total_blobs='615' nmethods='228' adapters='234' free_code_cache='248380032'/>
+<task_done success='1' nmsize='368' count='265' stamp='0.340'/>
+</task>
+</compilation_log>
+<compilation_log thread='23813'>
+<start_compile_thread name='C1 CompilerThread8' thread='23813' process='23756' stamp='0.179'/>
+<task compile_id='1' method='java.lang.StringUTF16 getChar ([BI)C' bytes='60' count='512' iicount='512' level='3' stamp='0.182'>
+<phase name='setup' stamp='0.182'>
+<phase_done name='setup' stamp='0.182'/>
+</phase>
+<phase name='buildIR' stamp='0.182'>
+<type id='970' name='char'/>
+<klass id='1085' name='[B' flags='1041'/>
+<type id='975' name='int'/>
+<klass id='1093' name='java.lang.StringUTF16' flags='16'/>
+<method id='1094' holder='1093' name='getChar' return='970' arguments='1085 975' flags='8' bytes='60' iicount='512'/>
+<parse method='1094'  stamp='0.182'>
+<phase name='parse_hir' stamp='0.182'>
+<phase_done name='parse_hir' stamp='0.182'/>
+</phase>
+<parse_done stamp='0.182'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.182'>
+<phase_done name='optimize_blocks' stamp='0.182'/>
+</phase>
+<phase name='gvn' stamp='0.183'>
+<phase_done name='gvn' stamp='0.183'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.183'>
+<phase_done name='rangeCheckElimination' stamp='0.183'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.183'>
+<phase_done name='optimize_null_checks' stamp='0.183'/>
+</phase>
+<phase_done name='buildIR' stamp='0.183'/>
+</phase>
+<phase name='emit_lir' stamp='0.183'>
+<phase name='lirGeneration' stamp='0.183'>
+<phase_done name='lirGeneration' stamp='0.184'/>
+</phase>
+<phase name='linearScan' stamp='0.184'>
+<phase_done name='linearScan' stamp='0.184'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.184'/>
+</phase>
+<phase name='codeemit' stamp='0.184'>
+<phase_done name='codeemit' stamp='0.184'/>
+</phase>
+<phase name='codeinstall' stamp='0.184'>
+<phase_done name='codeinstall' stamp='0.184'/>
+</phase>
+<code_cache total_blobs='227' nmethods='1' adapters='131' free_code_cache='248780288'/>
+<task_done success='1' nmsize='432' count='512' stamp='0.184'/>
+</task>
+<task compile_id='5' method='java.lang.String isLatin1 ()Z' bytes='19' count='909' iicount='909' level='3' stamp='0.189'>
+<phase name='setup' stamp='0.189'>
+<phase_done name='setup' stamp='0.189'/>
+</phase>
+<phase name='buildIR' stamp='0.189'>
+<type id='969' name='boolean'/>
+<klass id='983' name='java.lang.String' flags='17'/>
+<method id='1093' holder='983' name='isLatin1' return='969' flags='2' bytes='19' iicount='912'/>
+<parse method='1093'  stamp='0.189'>
+<phase name='parse_hir' stamp='0.189'>
+<phase_done name='parse_hir' stamp='0.189'/>
+</phase>
+<parse_done stamp='0.189'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.190'>
+<phase_done name='optimize_blocks' stamp='0.190'/>
+</phase>
+<phase name='gvn' stamp='0.190'>
+<phase_done name='gvn' stamp='0.190'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.190'>
+<phase_done name='rangeCheckElimination' stamp='0.190'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.190'>
+<phase_done name='optimize_null_checks' stamp='0.190'/>
+</phase>
+<phase_done name='buildIR' stamp='0.190'/>
+</phase>
+<phase name='emit_lir' stamp='0.190'>
+<phase name='lirGeneration' stamp='0.190'>
+<phase_done name='lirGeneration' stamp='0.190'/>
+</phase>
+<phase name='linearScan' stamp='0.190'>
+<phase_done name='linearScan' stamp='0.190'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.190'/>
+</phase>
+<phase name='codeemit' stamp='0.190'>
+<phase_done name='codeemit' stamp='0.190'/>
+</phase>
+<phase name='codeinstall' stamp='0.190'>
+<phase_done name='codeinstall' stamp='0.190'/>
+</phase>
+<code_cache total_blobs='270' nmethods='5' adapters='146' free_code_cache='248776448'/>
+<task_done success='1' nmsize='464' count='935' stamp='0.190'/>
+</task>
+<task compile_id='9' method='java.lang.Object &lt;init&gt; ()V' bytes='1' count='770' iicount='770' level='3' stamp='0.203'>
+<phase name='setup' stamp='0.203'>
+<phase_done name='setup' stamp='0.203'/>
+</phase>
+<phase name='buildIR' stamp='0.203'>
+<type id='977' name='void'/>
+<klass id='982' name='java.lang.Object' flags='1'/>
+<method id='1093' holder='982' name='&lt;init&gt;' return='977' flags='1' bytes='1' iicount='774'/>
+<parse method='1093'  stamp='0.203'>
+<phase name='parse_hir' stamp='0.203'>
+<phase_done name='parse_hir' stamp='0.203'/>
+</phase>
+<parse_done stamp='0.203'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.203'>
+<phase_done name='optimize_blocks' stamp='0.203'/>
+</phase>
+<phase name='gvn' stamp='0.203'>
+<phase_done name='gvn' stamp='0.203'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.203'>
+<phase_done name='rangeCheckElimination' stamp='0.203'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.203'>
+<phase_done name='optimize_null_checks' stamp='0.203'/>
+</phase>
+<phase_done name='buildIR' stamp='0.203'/>
+</phase>
+<phase name='emit_lir' stamp='0.203'>
+<phase name='lirGeneration' stamp='0.203'>
+<phase_done name='lirGeneration' stamp='0.203'/>
+</phase>
+<phase name='linearScan' stamp='0.203'>
+<phase_done name='linearScan' stamp='0.203'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.203'/>
+</phase>
+<phase name='codeemit' stamp='0.203'>
+<phase_done name='codeemit' stamp='0.203'/>
+</phase>
+<phase name='codeinstall' stamp='0.204'>
+<phase_done name='codeinstall' stamp='0.204'/>
+</phase>
+<code_cache total_blobs='306' nmethods='9' adapters='157' free_code_cache='248760704'/>
+<task_done success='1' nmsize='336' count='776' stamp='0.204'/>
+</task>
+<task compile_id='12' method='java.lang.Math floorDiv (II)I' bytes='22' count='306' iicount='306' level='3' stamp='0.208'>
+<phase name='setup' stamp='0.208'>
+<phase_done name='setup' stamp='0.208'/>
+</phase>
+<phase name='buildIR' stamp='0.208'>
+<type id='975' name='int'/>
+<klass id='1093' name='java.lang.Math' flags='17'/>
+<method id='1094' holder='1093' name='floorDiv' return='975' arguments='975 975' flags='9' bytes='22' iicount='311'/>
+<parse method='1094'  stamp='0.208'>
+<phase name='parse_hir' stamp='0.208'>
+<phase_done name='parse_hir' stamp='0.208'/>
+</phase>
+<parse_done stamp='0.208'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.208'>
+<phase_done name='optimize_blocks' stamp='0.208'/>
+</phase>
+<phase name='gvn' stamp='0.208'>
+<phase_done name='gvn' stamp='0.208'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.208'>
+<phase_done name='rangeCheckElimination' stamp='0.208'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.208'>
+<phase_done name='optimize_null_checks' stamp='0.208'/>
+</phase>
+<phase_done name='buildIR' stamp='0.208'/>
+</phase>
+<phase name='emit_lir' stamp='0.208'>
+<phase name='lirGeneration' stamp='0.208'>
+<phase_done name='lirGeneration' stamp='0.208'/>
+</phase>
+<phase name='linearScan' stamp='0.208'>
+<phase_done name='linearScan' stamp='0.208'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.208'/>
+</phase>
+<phase name='codeemit' stamp='0.208'>
+<phase_done name='codeemit' stamp='0.208'/>
+</phase>
+<phase name='codeinstall' stamp='0.208'>
+<phase_done name='codeinstall' stamp='0.208'/>
+</phase>
+<code_cache total_blobs='310' nmethods='12' adapters='158' free_code_cache='248755584'/>
+<task_done success='1' nmsize='464' count='317' stamp='0.208'/>
+</task>
+<task compile_id='19' method='java.lang.module.ModuleDescriptor$Exports &lt;init&gt; (Ljava/util/Set;Ljava/lang/String;Ljava/util/Set;Z)V' bytes='20' count='278' iicount='278' level='3' stamp='0.212'>
+<phase name='setup' stamp='0.212'>
+<phase_done name='setup' stamp='0.212'/>
+</phase>
+<phase name='buildIR' stamp='0.212'>
+<type id='977' name='void'/>
+<klass id='1094' name='java.util.Set' flags='1537'/>
+<klass id='983' name='java.lang.String' flags='17'/>
+<type id='969' name='boolean'/>
+<klass id='1093' name='java.lang.module.ModuleDescriptor$Exports' flags='25'/>
+<method id='1095' holder='1093' name='&lt;init&gt;' return='977' arguments='1094 983 1094 969' flags='2' bytes='20' iicount='290'/>
+<parse method='1095'  stamp='0.212'>
+<phase name='parse_hir' stamp='0.212'>
+<bc code='183' bci='1'/>
+<klass id='982' name='java.lang.Object' flags='1'/>
+<method id='1097' holder='982' name='&lt;init&gt;' return='977' flags='1' bytes='1' compile_id='9' compiler='c1' level='3' iicount='1366'/>
+<call method='1097' instr='invokespecial'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1097'>
+<parse_done stamp='0.212'/>
+</parse>
+<phase_done name='parse_hir' stamp='0.212'/>
+</phase>
+<parse_done stamp='0.212'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.212'>
+<phase_done name='optimize_blocks' stamp='0.212'/>
+</phase>
+<phase name='gvn' stamp='0.212'>
+<phase_done name='gvn' stamp='0.212'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.212'>
+<phase_done name='rangeCheckElimination' stamp='0.212'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.212'>
+<phase_done name='optimize_null_checks' stamp='0.212'/>
+</phase>
+<phase_done name='buildIR' stamp='0.212'/>
+</phase>
+<phase name='emit_lir' stamp='0.212'>
+<phase name='lirGeneration' stamp='0.212'>
+<phase_done name='lirGeneration' stamp='0.212'/>
+</phase>
+<phase name='linearScan' stamp='0.212'>
+<phase_done name='linearScan' stamp='0.212'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.212'/>
+</phase>
+<phase name='codeemit' stamp='0.212'>
+<phase_done name='codeemit' stamp='0.213'/>
+</phase>
+<phase name='codeinstall' stamp='0.213'>
+<phase_done name='codeinstall' stamp='0.213'/>
+</phase>
+<code_cache total_blobs='317' nmethods='18' adapters='158' free_code_cache='248745728'/>
+<task_done success='1' nmsize='752' count='331' inlined_bytes='1' stamp='0.213'/>
+</task>
+<task compile_id='24' method='java.util.AbstractSet &lt;init&gt; ()V' bytes='5' count='262' iicount='262' level='3' stamp='0.214'>
+<phase name='setup' stamp='0.214'>
+<phase_done name='setup' stamp='0.214'/>
+</phase>
+<phase name='buildIR' stamp='0.214'>
+<type id='977' name='void'/>
+<klass id='1093' name='java.util.AbstractSet' flags='1025'/>
+<method id='1094' holder='1093' name='&lt;init&gt;' return='977' flags='4' bytes='5' iicount='263'/>
+<parse method='1094'  stamp='0.214'>
+<phase name='parse_hir' stamp='0.214'>
+<bc code='183' bci='1'/>
+<klass id='1096' name='java.util.AbstractCollection' flags='1025'/>
+<method id='1097' holder='1096' name='&lt;init&gt;' return='977' flags='4' bytes='5' compile_id='23' compiler='c1' level='3' iicount='320'/>
+<call method='1097' instr='invokespecial'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1097'>
+<bc code='183' bci='1'/>
+<klass id='982' name='java.lang.Object' flags='1'/>
+<method id='1099' holder='982' name='&lt;init&gt;' return='977' flags='1' bytes='1' compile_id='9' compiler='c1' level='3' iicount='1790'/>
+<call method='1099' instr='invokespecial'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1099'>
+<bc code='177' bci='0'/>
+<dependency type='no_finalizable_subclasses' ctxk='1093'/>
+<parse_done stamp='0.214'/>
+</parse>
+<parse_done stamp='0.214'/>
+</parse>
+<phase_done name='parse_hir' stamp='0.214'/>
+</phase>
+<parse_done stamp='0.214'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.214'>
+<phase_done name='optimize_blocks' stamp='0.214'/>
+</phase>
+<phase name='gvn' stamp='0.214'>
+<phase_done name='gvn' stamp='0.214'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.214'>
+<phase_done name='rangeCheckElimination' stamp='0.214'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.214'>
+<phase_done name='optimize_null_checks' stamp='0.214'/>
+</phase>
+<phase_done name='buildIR' stamp='0.214'/>
+</phase>
+<phase name='emit_lir' stamp='0.214'>
+<phase name='lirGeneration' stamp='0.214'>
+<phase_done name='lirGeneration' stamp='0.214'/>
+</phase>
+<phase name='linearScan' stamp='0.214'>
+<phase_done name='linearScan' stamp='0.214'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.214'/>
+</phase>
+<phase name='codeemit' stamp='0.214'>
+<phase_done name='codeemit' stamp='0.214'/>
+</phase>
+<phase name='codeinstall' stamp='0.214'>
+<dependency type='no_finalizable_subclasses' ctxk='1093'/>
+<phase_done name='codeinstall' stamp='0.214'/>
+</phase>
+<code_cache total_blobs='322' nmethods='23' adapters='158' free_code_cache='248739072'/>
+<task_done success='1' nmsize='528' count='299' inlined_bytes='6' stamp='0.214'/>
+</task>
+<task compile_id='27' method='jdk.internal.module.Builder newExports (Ljava/util/Set;Ljava/lang/String;Ljava/util/Set;)Ljava/lang/module/ModuleDescriptor$Exports;' bytes='12' count='268' iicount='268' level='3' stamp='0.215'>
+<phase name='setup' stamp='0.215'>
+<phase_done name='setup' stamp='0.215'/>
+</phase>
+<phase name='buildIR' stamp='0.215'>
+<klass id='1095' name='java.lang.module.ModuleDescriptor$Exports' flags='25'/>
+<klass id='1094' name='java.util.Set' flags='1537'/>
+<klass id='983' name='java.lang.String' flags='17'/>
+<klass id='1093' name='jdk.internal.module.Builder' flags='16'/>
+<method id='1096' holder='1093' name='newExports' return='1095' arguments='1094 983 1094' flags='9' bytes='12' iicount='268'/>
+<parse method='1096'  stamp='0.215'>
+<phase name='parse_hir' stamp='0.215'>
+<bc code='185' bci='6'/>
+<klass id='1098' name='jdk.internal.misc.JavaLangModuleAccess' flags='1537'/>
+<method id='1102' holder='1098' name='newExports' return='1095' arguments='1094 983 1094' flags='1025' bytes='0' iicount='1'/>
+<call method='1102' instr='invokeinterface'/>
+<inline_success reason='receiver is statically known'/>
+<klass id='1100' name='java.lang.module.ModuleDescriptor$1' flags='0'/>
+<dependency type='leaf_type' ctxk='1100'/>
+<method id='1103' holder='1100' name='newExports' return='1095' arguments='1094 983 1094' flags='1' bytes='13' iicount='271'/>
+<parse method='1103'>
+<bc code='183' bci='9'/>
+<type id='977' name='void'/>
+<type id='969' name='boolean'/>
+<method id='1105' holder='1095' name='&lt;init&gt;' return='977' arguments='1094 983 1094 969 1100' flags='4096' bytes='10' compile_id='18' compiler='c1' level='3' iicount='521'/>
+<call method='1105' instr='invokespecial'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1105'>
+<bc code='183' bci='6'/>
+<method id='1107' holder='1095' name='&lt;init&gt;' return='977' arguments='1094 983 1094 969' flags='2' bytes='20' compile_id='19' compiler='c1' level='3' iicount='541'/>
+<call method='1107' instr='invokespecial'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1107'>
+<bc code='183' bci='1'/>
+<klass id='982' name='java.lang.Object' flags='1'/>
+<method id='1109' holder='982' name='&lt;init&gt;' return='977' flags='1' bytes='1' compile_id='9' compiler='c1' level='3' iicount='2145'/>
+<call method='1109' instr='invokespecial'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1109'>
+<parse_done stamp='0.215'/>
+</parse>
+<parse_done stamp='0.215'/>
+</parse>
+<parse_done stamp='0.215'/>
+</parse>
+<parse_done stamp='0.215'/>
+</parse>
+<phase_done name='parse_hir' stamp='0.215'/>
+</phase>
+<parse_done stamp='0.215'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.215'>
+<phase_done name='optimize_blocks' stamp='0.215'/>
+</phase>
+<phase name='gvn' stamp='0.215'>
+<phase_done name='gvn' stamp='0.215'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.215'>
+<phase_done name='rangeCheckElimination' stamp='0.215'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.215'>
+<phase_done name='optimize_null_checks' stamp='0.215'/>
+</phase>
+<phase_done name='buildIR' stamp='0.215'/>
+</phase>
+<phase name='emit_lir' stamp='0.215'>
+<phase name='lirGeneration' stamp='0.215'>
+<phase_done name='lirGeneration' stamp='0.215'/>
+</phase>
+<phase name='linearScan' stamp='0.215'>
+<phase_done name='linearScan' stamp='0.215'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.215'/>
+</phase>
+<phase name='codeemit' stamp='0.215'>
+<phase_done name='codeemit' stamp='0.215'/>
+</phase>
+<phase name='codeinstall' stamp='0.215'>
+<dependency type='leaf_type' ctxk='1100'/>
+<phase_done name='codeinstall' stamp='0.215'/>
+</phase>
+<code_cache total_blobs='326' nmethods='27' adapters='158' free_code_cache='248733184'/>
+<task_done success='1' nmsize='1104' count='305' inlined_bytes='44' stamp='0.215'/>
+</task>
+<task compile_id='32' method='jdk.internal.module.Builder newExports (Ljava/util/Set;Ljava/lang/String;)Ljava/lang/module/ModuleDescriptor$Exports;' bytes='11' count='259' iicount='259' level='3' stamp='0.215'>
+<phase name='setup' stamp='0.215'>
+<phase_done name='setup' stamp='0.215'/>
+</phase>
+<phase name='buildIR' stamp='0.215'>
+<klass id='1095' name='java.lang.module.ModuleDescriptor$Exports' flags='25'/>
+<klass id='1094' name='java.util.Set' flags='1537'/>
+<klass id='983' name='java.lang.String' flags='17'/>
+<klass id='1093' name='jdk.internal.module.Builder' flags='16'/>
+<method id='1096' holder='1093' name='newExports' return='1095' arguments='1094 983' flags='9' bytes='11' iicount='260'/>
+<parse method='1096'  stamp='0.215'>
+<phase name='parse_hir' stamp='0.215'>
+<bc code='185' bci='5'/>
+<klass id='1098' name='jdk.internal.misc.JavaLangModuleAccess' flags='1537'/>
+<method id='1102' holder='1098' name='newExports' return='1095' arguments='1094 983' flags='1025' bytes='0' iicount='1'/>
+<call method='1102' instr='invokeinterface'/>
+<inline_success reason='receiver is statically known'/>
+<klass id='1100' name='java.lang.module.ModuleDescriptor$1' flags='0'/>
+<dependency type='leaf_type' ctxk='1100'/>
+<method id='1103' holder='1100' name='newExports' return='1095' arguments='1094 983' flags='1' bytes='15' iicount='272'/>
+<parse method='1103'>
+<bc code='184' bci='6'/>
+<klass id='1105' name='java.util.Collections' flags='1'/>
+<method id='1106' holder='1105' name='emptySet' return='1094' flags='25' bytes='4' compile_id='16' compiler='c1' level='3' iicount='693'/>
+<call method='1106' instr='invokestatic'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1106'>
+<parse_done stamp='0.216'/>
+</parse>
+<bc code='183' bci='11'/>
+<type id='977' name='void'/>
+<type id='969' name='boolean'/>
+<method id='1111' holder='1095' name='&lt;init&gt;' return='977' arguments='1094 983 1094 969 1100' flags='4096' bytes='10' compile_id='18' compiler='c1' level='3' iicount='601'/>
+<call method='1111' instr='invokespecial'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1111'>
+<bc code='183' bci='6'/>
+<method id='1113' holder='1095' name='&lt;init&gt;' return='977' arguments='1094 983 1094 969' flags='2' bytes='20' compile_id='19' compiler='c1' level='3' iicount='601'/>
+<call method='1113' instr='invokespecial'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1113'>
+<bc code='183' bci='1'/>
+<klass id='982' name='java.lang.Object' flags='1'/>
+<method id='1115' holder='982' name='&lt;init&gt;' return='977' flags='1' bytes='1' compile_id='9' compiler='c1' level='3' iicount='2262'/>
+<call method='1115' instr='invokespecial'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1115'>
+<parse_done stamp='0.216'/>
+</parse>
+<parse_done stamp='0.216'/>
+</parse>
+<parse_done stamp='0.216'/>
+</parse>
+<parse_done stamp='0.216'/>
+</parse>
+<phase_done name='parse_hir' stamp='0.216'/>
+</phase>
+<parse_done stamp='0.216'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.216'>
+<phase_done name='optimize_blocks' stamp='0.216'/>
+</phase>
+<phase name='gvn' stamp='0.216'>
+<phase_done name='gvn' stamp='0.216'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.216'>
+<phase_done name='rangeCheckElimination' stamp='0.216'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.216'>
+<phase_done name='optimize_null_checks' stamp='0.216'/>
+</phase>
+<phase_done name='buildIR' stamp='0.216'/>
+</phase>
+<phase name='emit_lir' stamp='0.216'>
+<phase name='lirGeneration' stamp='0.216'>
+<phase_done name='lirGeneration' stamp='0.216'/>
+</phase>
+<phase name='linearScan' stamp='0.216'>
+<phase_done name='linearScan' stamp='0.216'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.216'/>
+</phase>
+<phase name='codeemit' stamp='0.216'>
+<phase_done name='codeemit' stamp='0.216'/>
+</phase>
+<phase name='codeinstall' stamp='0.216'>
+<dependency type='leaf_type' ctxk='1100'/>
+<phase_done name='codeinstall' stamp='0.216'/>
+</phase>
+<code_cache total_blobs='330' nmethods='29' adapters='158' free_code_cache='248716160'/>
+<task_done success='1' nmsize='1232' count='303' inlined_bytes='50' stamp='0.216'/>
+</task>
+<task compile_id='34' method='java.util.ImmutableCollections$Set1 hashCode ()I' bytes='8' count='277' iicount='277' level='3' stamp='0.216'>
+<phase name='setup' stamp='0.216'>
+<phase_done name='setup' stamp='0.216'/>
+</phase>
+<phase name='buildIR' stamp='0.216'>
+<type id='975' name='int'/>
+<klass id='1093' name='java.util.ImmutableCollections$Set1' flags='24'/>
+<method id='1094' holder='1093' name='hashCode' return='975' flags='1' bytes='8' iicount='277'/>
+<parse method='1094'  stamp='0.216'>
+<phase name='parse_hir' stamp='0.216'>
+<bc code='182' bci='4'/>
+<klass id='982' name='java.lang.Object' flags='1'/>
+<method id='1096' holder='982' name='hashCode' return='975' flags='257' bytes='0' iicount='81'/>
+<call method='1096' instr='invokevirtual'/>
+<inline_fail reason='no static binding'/>
+<phase_done name='parse_hir' stamp='0.216'/>
+</phase>
+<parse_done stamp='0.216'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.216'>
+<phase_done name='optimize_blocks' stamp='0.216'/>
+</phase>
+<phase name='gvn' stamp='0.216'>
+<phase_done name='gvn' stamp='0.216'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.216'>
+<phase_done name='rangeCheckElimination' stamp='0.216'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.216'>
+<phase_done name='optimize_null_checks' stamp='0.216'/>
+</phase>
+<phase_done name='buildIR' stamp='0.216'/>
+</phase>
+<phase name='emit_lir' stamp='0.216'>
+<phase name='lirGeneration' stamp='0.216'>
+<phase_done name='lirGeneration' stamp='0.216'/>
+</phase>
+<phase name='linearScan' stamp='0.216'>
+<phase_done name='linearScan' stamp='0.216'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.216'/>
+</phase>
+<phase name='codeemit' stamp='0.216'>
+<phase_done name='codeemit' stamp='0.216'/>
+</phase>
+<phase name='codeinstall' stamp='0.216'>
+<phase_done name='codeinstall' stamp='0.216'/>
+</phase>
+<code_cache total_blobs='333' nmethods='32' adapters='158' free_code_cache='248723712'/>
+<task_done success='1' nmsize='552' count='284' stamp='0.216'/>
+</task>
+<task compile_id='37' method='java.lang.module.ModuleDescriptor$1 newRequires (Ljava/util/Set;Ljava/lang/String;Ljava/lang/module/ModuleDescriptor$Version;)Ljava/lang/module/ModuleDescriptor$Requires;' bytes='13' count='262' iicount='262' level='3' stamp='0.217'>
+<phase name='setup' stamp='0.217'>
+<phase_done name='setup' stamp='0.217'/>
+</phase>
+<phase name='buildIR' stamp='0.217'>
+<klass id='1096' name='java.lang.module.ModuleDescriptor$Requires' flags='25'/>
+<klass id='1094' name='java.util.Set' flags='1537'/>
+<klass id='983' name='java.lang.String' flags='17'/>
+<klass id='1095' name='java.lang.module.ModuleDescriptor$Version' flags='25'/>
+<klass id='1093' name='java.lang.module.ModuleDescriptor$1' flags='0'/>
+<method id='1097' holder='1093' name='newRequires' return='1096' arguments='1094 983 1095' flags='1' bytes='13' iicount='262'/>
+<parse method='1097'  stamp='0.217'>
+<phase name='parse_hir' stamp='0.217'>
+<bc code='183' bci='9'/>
+<type id='977' name='void'/>
+<type id='969' name='boolean'/>
+<method id='1099' holder='1096' name='&lt;init&gt;' return='977' arguments='1094 983 1095 969 1093' flags='4096' bytes='10' iicount='271'/>
+<call method='1099' instr='invokespecial'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1099'>
+<bc code='183' bci='6'/>
+<method id='1101' holder='1096' name='&lt;init&gt;' return='977' arguments='1094 983 1095 969' flags='2' bytes='25' iicount='282'/>
+<call method='1101' instr='invokespecial'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1101'>
+<bc code='183' bci='1'/>
+<klass id='982' name='java.lang.Object' flags='1'/>
+<method id='1103' holder='982' name='&lt;init&gt;' return='977' flags='1' bytes='1' compile_id='9' compiler='c1' level='3' iicount='2525'/>
+<call method='1103' instr='invokespecial'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1103'>
+<parse_done stamp='0.217'/>
+</parse>
+<parse_done stamp='0.217'/>
+</parse>
+<parse_done stamp='0.217'/>
+</parse>
+<phase_done name='parse_hir' stamp='0.217'/>
+</phase>
+<parse_done stamp='0.217'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.217'>
+<phase_done name='optimize_blocks' stamp='0.217'/>
+</phase>
+<phase name='gvn' stamp='0.217'>
+<phase_done name='gvn' stamp='0.217'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.217'>
+<phase_done name='rangeCheckElimination' stamp='0.217'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.217'>
+<phase_done name='optimize_null_checks' stamp='0.217'/>
+</phase>
+<phase_done name='buildIR' stamp='0.217'/>
+</phase>
+<phase name='emit_lir' stamp='0.217'>
+<phase name='lirGeneration' stamp='0.217'>
+<phase_done name='lirGeneration' stamp='0.217'/>
+</phase>
+<phase name='linearScan' stamp='0.217'>
+<phase_done name='linearScan' stamp='0.217'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.217'/>
+</phase>
+<phase name='codeemit' stamp='0.217'>
+<phase_done name='codeemit' stamp='0.217'/>
+</phase>
+<phase name='codeinstall' stamp='0.217'>
+<phase_done name='codeinstall' stamp='0.217'/>
+</phase>
+<code_cache total_blobs='337' nmethods='36' adapters='158' free_code_cache='248715520'/>
+<task_done success='1' nmsize='1040' count='349' inlined_bytes='36' stamp='0.217'/>
+</task>
+<task compile_id='40' method='java.lang.module.ModuleDescriptor$Requires hashCode ()I' bytes='63' count='283' iicount='283' level='3' stamp='0.217'>
+<phase name='setup' stamp='0.217'>
+<phase_done name='setup' stamp='0.217'/>
+</phase>
+<phase name='buildIR' stamp='0.217'>
+<type id='975' name='int'/>
+<klass id='1093' name='java.lang.module.ModuleDescriptor$Requires' flags='25'/>
+<method id='1094' holder='1093' name='hashCode' return='975' flags='1' bytes='63' iicount='283'/>
+<parse method='1094'  stamp='0.217'>
+<phase name='parse_hir' stamp='0.217'>
+<bc code='182' bci='4'/>
+<klass id='983' name='java.lang.String' flags='17'/>
+<method id='1096' holder='983' name='hashCode' return='975' flags='1' bytes='49' compile_id='10' compiler='c1' level='3' iicount='4098'/>
+<call method='1096' instr='invokevirtual'/>
+<inline_fail reason='callee is too large'/>
+<bc code='185' bci='14'/>
+<klass id='1098' name='java.util.Set' flags='1537'/>
+<method id='1099' holder='1098' name='hashCode' return='975' flags='1025' bytes='0' iicount='1'/>
+<call method='1099' instr='invokeinterface'/>
+<inline_fail reason='no static binding'/>
+<bc code='182' bci='36'/>
+<klass id='1100' name='java.lang.module.ModuleDescriptor$Version' flags='25'/>
+<method id='1101' holder='1100' name='hashCode' return='975' flags='1' bytes='8' iicount='1'/>
+<call method='1101' instr='invokevirtual'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1101'>
+<bc code='182' bci='4'/>
+<call method='1096' instr='invokevirtual'/>
+<inline_fail reason='callee is too large'/>
+<parse_done stamp='0.218'/>
+</parse>
+<bc code='182' bci='56'/>
+<call method='1096' instr='invokevirtual'/>
+<inline_fail reason='callee is too large'/>
+<phase_done name='parse_hir' stamp='0.218'/>
+</phase>
+<parse_done stamp='0.218'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.218'>
+<phase_done name='optimize_blocks' stamp='0.218'/>
+</phase>
+<phase name='gvn' stamp='0.218'>
+<phase_done name='gvn' stamp='0.218'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.218'>
+<phase_done name='rangeCheckElimination' stamp='0.218'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.218'>
+<phase_done name='optimize_null_checks' stamp='0.218'/>
+</phase>
+<phase_done name='buildIR' stamp='0.218'/>
+</phase>
+<phase name='emit_lir' stamp='0.218'>
+<phase name='lirGeneration' stamp='0.218'>
+<phase_done name='lirGeneration' stamp='0.218'/>
+</phase>
+<phase name='linearScan' stamp='0.218'>
+<phase_done name='linearScan' stamp='0.218'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.218'/>
+</phase>
+<phase name='codeemit' stamp='0.218'>
+<phase_done name='codeemit' stamp='0.218'/>
+</phase>
+<phase name='codeinstall' stamp='0.218'>
+<phase_done name='codeinstall' stamp='0.218'/>
+</phase>
+<code_cache total_blobs='341' nmethods='40' adapters='158' free_code_cache='248701568'/>
+<task_done success='1' nmsize='1528' count='283' inlined_bytes='8' stamp='0.218'/>
+</task>
+<task compile_id='45' method='java.lang.String length ()I' bytes='11' count='259' iicount='259' level='3' stamp='0.221'>
+<phase name='setup' stamp='0.221'>
+<phase_done name='setup' stamp='0.221'/>
+</phase>
+<phase name='buildIR' stamp='0.221'>
+<type id='975' name='int'/>
+<klass id='983' name='java.lang.String' flags='17'/>
+<method id='1093' holder='983' name='length' return='975' flags='1' bytes='11' iicount='259'/>
+<parse method='1093'  stamp='0.221'>
+<phase name='parse_hir' stamp='0.221'>
+<bc code='182' bci='6'/>
+<type id='973' name='byte'/>
+<method id='1095' holder='983' name='coder' return='973' flags='0' bytes='15' compile_id='4' compiler='c1' level='3' iicount='4089'/>
+<call method='1095' instr='invokevirtual'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1095'>
+<parse_done stamp='0.222'/>
+</parse>
+<phase_done name='parse_hir' stamp='0.222'/>
+</phase>
+<parse_done stamp='0.222'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.222'>
+<phase_done name='optimize_blocks' stamp='0.222'/>
+</phase>
+<phase name='gvn' stamp='0.222'>
+<phase_done name='gvn' stamp='0.222'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.222'>
+<phase_done name='rangeCheckElimination' stamp='0.222'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.222'>
+<phase_done name='optimize_null_checks' stamp='0.222'/>
+</phase>
+<phase_done name='buildIR' stamp='0.222'/>
+</phase>
+<phase name='emit_lir' stamp='0.222'>
+<phase name='lirGeneration' stamp='0.222'>
+<phase_done name='lirGeneration' stamp='0.222'/>
+</phase>
+<phase name='linearScan' stamp='0.222'>
+<phase_done name='linearScan' stamp='0.222'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.222'/>
+</phase>
+<phase name='codeemit' stamp='0.222'>
+<phase_done name='codeemit' stamp='0.222'/>
+</phase>
+<phase name='codeinstall' stamp='0.222'>
+<phase_done name='codeinstall' stamp='0.222'/>
+</phase>
+<code_cache total_blobs='346' nmethods='45' adapters='158' free_code_cache='248696320'/>
+<task_done success='1' nmsize='624' count='314' inlined_bytes='15' stamp='0.222'/>
+</task>
+<task compile_id='50' method='java.lang.Object &lt;init&gt; ()V' bytes='1' count='3627' iicount='3628' level='1' stamp='0.227'>
+<phase name='setup' stamp='0.227'>
+<phase_done name='setup' stamp='0.227'/>
+</phase>
+<phase name='buildIR' stamp='0.227'>
+<type id='977' name='void'/>
+<klass id='982' name='java.lang.Object' flags='1'/>
+<method id='1093' holder='982' name='&lt;init&gt;' return='977' flags='1' bytes='1' compile_id='9' compiler='c1' level='3' iicount='3638'/>
+<parse method='1093'  stamp='0.227'>
+<phase name='parse_hir' stamp='0.227'>
+<phase_done name='parse_hir' stamp='0.227'/>
+</phase>
+<parse_done stamp='0.227'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.227'>
+<phase_done name='optimize_blocks' stamp='0.227'/>
+</phase>
+<phase name='gvn' stamp='0.227'>
+<phase_done name='gvn' stamp='0.227'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.227'>
+<phase_done name='rangeCheckElimination' stamp='0.227'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.227'>
+<phase_done name='optimize_null_checks' stamp='0.227'/>
+</phase>
+<phase_done name='buildIR' stamp='0.227'/>
+</phase>
+<phase name='emit_lir' stamp='0.227'>
+<phase name='lirGeneration' stamp='0.227'>
+<phase_done name='lirGeneration' stamp='0.227'/>
+</phase>
+<phase name='linearScan' stamp='0.227'>
+<phase_done name='linearScan' stamp='0.227'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.227'/>
+</phase>
+<phase name='codeemit' stamp='0.227'>
+<phase_done name='codeemit' stamp='0.227'/>
+</phase>
+<phase name='codeinstall' stamp='0.227'>
+<phase_done name='codeinstall' stamp='0.227'/>
+</phase>
+<code_cache total_blobs='353' nmethods='50' adapters='160' free_code_cache='248688768'/>
+<task_done success='1' nmsize='272' count='3675' stamp='0.227'/>
+</task>
+<task compile_id='57' method='java.util.concurrent.ConcurrentHashMap$Node &lt;init&gt; (ILjava/lang/Object;Ljava/lang/Object;)V' bytes='20' count='257' iicount='257' level='3' stamp='0.231'>
+<phase name='setup' stamp='0.231'>
+<phase_done name='setup' stamp='0.231'/>
+</phase>
+<phase name='buildIR' stamp='0.231'>
+<type id='977' name='void'/>
+<type id='975' name='int'/>
+<klass id='982' name='java.lang.Object' flags='1'/>
+<klass id='1093' name='java.util.concurrent.ConcurrentHashMap$Node' flags='8'/>
+<method id='1094' holder='1093' name='&lt;init&gt;' return='977' arguments='975 982 982' flags='0' bytes='20' iicount='262'/>
+<parse method='1094'  stamp='0.231'>
+<phase name='parse_hir' stamp='0.231'>
+<bc code='183' bci='1'/>
+<method id='1096' holder='982' name='&lt;init&gt;' return='977' flags='1' bytes='1' compile_id='50' compiler='c1' level='1' iicount='3683'/>
+<call method='1096' instr='invokespecial'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1096'>
+<bc code='177' bci='0'/>
+<dependency type='no_finalizable_subclasses' ctxk='1093'/>
+<parse_done stamp='0.231'/>
+</parse>
+<phase_done name='parse_hir' stamp='0.231'/>
+</phase>
+<parse_done stamp='0.231'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.231'>
+<phase_done name='optimize_blocks' stamp='0.231'/>
+</phase>
+<phase name='gvn' stamp='0.231'>
+<phase_done name='gvn' stamp='0.231'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.231'>
+<phase_done name='rangeCheckElimination' stamp='0.231'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.231'>
+<phase_done name='optimize_null_checks' stamp='0.231'/>
+</phase>
+<phase_done name='buildIR' stamp='0.231'/>
+</phase>
+<phase name='emit_lir' stamp='0.231'>
+<phase name='lirGeneration' stamp='0.231'>
+<phase_done name='lirGeneration' stamp='0.231'/>
+</phase>
+<phase name='linearScan' stamp='0.231'>
+<phase_done name='linearScan' stamp='0.231'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.231'/>
+</phase>
+<phase name='codeemit' stamp='0.231'>
+<phase_done name='codeemit' stamp='0.231'/>
+</phase>
+<phase name='codeinstall' stamp='0.231'>
+<dependency type='no_finalizable_subclasses' ctxk='1093'/>
+<phase_done name='codeinstall' stamp='0.231'/>
+</phase>
+<code_cache total_blobs='363' nmethods='58' adapters='162' free_code_cache='248678144'/>
+<task_done success='1' nmsize='656' count='277' inlined_bytes='1' stamp='0.231'/>
+</task>
+<task compile_id='60' method='java.util.concurrent.ConcurrentHashMap addCount (JI)V' bytes='289' count='259' backedge_count='3' iicount='259' level='3' stamp='0.231'>
+<phase name='setup' stamp='0.231'>
+<phase_done name='setup' stamp='0.231'/>
+</phase>
+<phase name='buildIR' stamp='0.231'>
+<type id='977' name='void'/>
+<type id='976' name='long'/>
+<type id='975' name='int'/>
+<klass id='1093' name='java.util.concurrent.ConcurrentHashMap' flags='1'/>
+<method id='1094' holder='1093' name='addCount' return='977' arguments='976 975' flags='18' bytes='289' iicount='259'/>
+<parse method='1094'  stamp='0.231'>
+<phase name='parse_hir' stamp='0.231'>
+<bc code='182' bci='31'/>
+<type id='969' name='boolean'/>
+<klass id='982' name='java.lang.Object' flags='1'/>
+<klass id='1051' name='jdk.internal.misc.Unsafe' flags='17'/>
+<method id='1100' holder='1051' name='compareAndSetLong' return='969' arguments='982 976 976 976' flags='273' bytes='0' compile_id='61' compile_kind='c2n' compiler='' level='0' iicount='256'/>
+<call method='1100' instr='invokevirtual'/>
+<inline_success reason='intrinsic'/>
+<bc code='184' bci='58'/>
+<klass id='1101' name='java.util.concurrent.ThreadLocalRandom' unloaded='1'/>
+<method id='1102' holder='1101' name='getProbe' return='975' unloaded='1'/>
+<call method='1102' instr='invokestatic'/>
+<inline_fail reason='not inlineable'/>
+<bc code='182' bci='91'/>
+<call method='1100' instr='invokevirtual'/>
+<inline_success reason='intrinsic'/>
+<bc code='182' bci='115'/>
+<method id='1103' holder='1093' name='sumCount' return='976' flags='16' bytes='48' iicount='4'/>
+<call method='1103' instr='invokevirtual'/>
+<dependency type='leaf_type' ctxk='1093'/>
+<inline_fail reason='callee is too large'/>
+<bc code='184' bci='161'/>
+<method id='1107' holder='1093' name='resizeStamp' return='975' arguments='975' flags='24' bytes='8' iicount='6'/>
+<call method='1107' instr='invokestatic'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1107'>
+<bc code='184' bci='1'/>
+<klass id='1076' name='java.lang.Integer' flags='17'/>
+<method id='1109' holder='1076' name='numberOfLeadingZeros' return='975' arguments='975' flags='9' bytes='76' iicount='7'/>
+<call method='1109' instr='invokestatic'/>
+<inline_fail reason='callee is too large'/>
+<parse_done stamp='0.231'/>
+</parse>
+<bc code='182' bci='233'/>
+<method id='1111' holder='1051' name='compareAndSetInt' return='969' arguments='982 976 975 975' flags='273' bytes='0' iicount='24'/>
+<call method='1111' instr='invokevirtual'/>
+<inline_success reason='intrinsic'/>
+<bc code='183' bci='244'/>
+<klass id='1106' name='[Ljava.util.concurrent.ConcurrentHashMap$Node;' flags='1040'/>
+<method id='1112' holder='1093' name='transfer' return='977' arguments='1106 1106' flags='18' bytes='828' iicount='3'/>
+<call method='1112' instr='invokespecial'/>
+<dependency type='leaf_type' ctxk='1093'/>
+<inline_fail reason='callee is too large'/>
+<bc code='182' bci='266'/>
+<call method='1111' instr='invokevirtual'/>
+<inline_success reason='intrinsic'/>
+<bc code='183' bci='276'/>
+<call method='1112' instr='invokespecial'/>
+<dependency type='leaf_type' ctxk='1093'/>
+<inline_fail reason='callee is too large'/>
+<bc code='182' bci='280'/>
+<call method='1103' instr='invokevirtual'/>
+<dependency type='leaf_type' ctxk='1093'/>
+<inline_fail reason='callee is too large'/>
+<bc code='183' bci='104'/>
+<method id='1114' holder='1093' name='fullAddCount' return='977' arguments='976 969' flags='18' bytes='487' iicount='1'/>
+<call method='1114' instr='invokespecial'/>
+<dependency type='leaf_type' ctxk='1093'/>
+<inline_fail reason='callee is too large'/>
+<phase_done name='parse_hir' stamp='0.232'/>
+</phase>
+<parse_done stamp='0.232'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.232'>
+<phase_done name='optimize_blocks' stamp='0.232'/>
+</phase>
+<phase name='gvn' stamp='0.232'>
+<phase_done name='gvn' stamp='0.232'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.232'>
+<phase_done name='rangeCheckElimination' stamp='0.232'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.232'>
+<phase_done name='optimize_null_checks' stamp='0.232'/>
+</phase>
+<phase_done name='buildIR' stamp='0.232'/>
+</phase>
+<phase name='emit_lir' stamp='0.232'>
+<phase name='lirGeneration' stamp='0.232'>
+<phase_done name='lirGeneration' stamp='0.232'/>
+</phase>
+<phase name='linearScan' stamp='0.232'>
+<phase_done name='linearScan' stamp='0.233'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.233'/>
+</phase>
+<phase name='codeemit' stamp='0.233'>
+<phase_done name='codeemit' stamp='0.233'/>
+</phase>
+<phase name='codeinstall' stamp='0.233'>
+<dependency type='leaf_type' ctxk='1093'/>
+<phase_done name='codeinstall' stamp='0.233'/>
+</phase>
+<code_cache total_blobs='368' nmethods='63' adapters='162' free_code_cache='248670080'/>
+<task_done success='1' nmsize='2760' count='259' backedge_count='3' inlined_bytes='8' stamp='0.233'/>
+</task>
+<task compile_id='68' method='java.lang.module.ModuleDescriptor$Requires name ()Ljava/lang/String;' bytes='5' count='141' iicount='141' level='1' stamp='0.236'>
+<phase name='setup' stamp='0.236'>
+<phase_done name='setup' stamp='0.236'/>
+</phase>
+<phase name='buildIR' stamp='0.236'>
+<klass id='983' name='java.lang.String' flags='17'/>
+<klass id='1093' name='java.lang.module.ModuleDescriptor$Requires' flags='25'/>
+<method id='1094' holder='1093' name='name' return='983' flags='1' bytes='5' iicount='142'/>
+<parse method='1094'  stamp='0.236'>
+<phase name='parse_hir' stamp='0.236'>
+<phase_done name='parse_hir' stamp='0.236'/>
+</phase>
+<parse_done stamp='0.236'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.236'>
+<phase_done name='optimize_blocks' stamp='0.236'/>
+</phase>
+<phase name='gvn' stamp='0.236'>
+<phase_done name='gvn' stamp='0.236'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.236'>
+<phase_done name='rangeCheckElimination' stamp='0.236'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.236'>
+<phase_done name='optimize_null_checks' stamp='0.236'/>
+</phase>
+<phase_done name='buildIR' stamp='0.236'/>
+</phase>
+<phase name='emit_lir' stamp='0.236'>
+<phase name='lirGeneration' stamp='0.236'>
+<phase_done name='lirGeneration' stamp='0.236'/>
+</phase>
+<phase name='linearScan' stamp='0.236'>
+<phase_done name='linearScan' stamp='0.236'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.236'/>
+</phase>
+<phase name='codeemit' stamp='0.236'>
+<phase_done name='codeemit' stamp='0.236'/>
+</phase>
+<phase name='codeinstall' stamp='0.236'>
+<phase_done name='codeinstall' stamp='0.236'/>
+</phase>
+<code_cache total_blobs='371' nmethods='66' adapters='162' free_code_cache='248655360'/>
+<task_done success='1' nmsize='272' count='163' stamp='0.236'/>
+</task>
+<task compile_id='71' method='java.util.HashMap put (Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;' bytes='13' count='256' iicount='256' level='3' stamp='0.236'>
+<phase name='setup' stamp='0.236'>
+<phase_done name='setup' stamp='0.236'/>
+</phase>
+<phase name='buildIR' stamp='0.236'>
+<klass id='982' name='java.lang.Object' flags='1'/>
+<klass id='1093' name='java.util.HashMap' flags='1'/>
+<method id='1094' holder='1093' name='put' return='982' arguments='982 982' flags='1' bytes='13' iicount='257'/>
+<parse method='1094'  stamp='0.236'>
+<phase name='parse_hir' stamp='0.236'>
+<bc code='184' bci='2'/>
+<type id='975' name='int'/>
+<method id='1096' holder='1093' name='hash' return='975' arguments='982' flags='24' bytes='20' compile_id='65' compiler='c1' level='3' iicount='564'/>
+<call method='1096' instr='invokestatic'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1096'>
+<bc code='182' bci='9'/>
+<method id='1099' holder='982' name='hashCode' return='975' flags='257' bytes='0' iicount='146'/>
+<call method='1099' instr='invokevirtual'/>
+<inline_fail reason='no static binding'/>
+<parse_done stamp='0.237'/>
+</parse>
+<bc code='182' bci='9'/>
+<type id='969' name='boolean'/>
+<method id='1100' holder='1093' name='putVal' return='982' arguments='975 982 982 969 969' flags='16' bytes='300' iicount='279'/>
+<call method='1100' instr='invokevirtual'/>
+<inline_fail reason='callee is too large'/>
+<phase_done name='parse_hir' stamp='0.237'/>
+</phase>
+<parse_done stamp='0.237'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.237'>
+<phase_done name='optimize_blocks' stamp='0.237'/>
+</phase>
+<phase name='gvn' stamp='0.237'>
+<phase_done name='gvn' stamp='0.237'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.237'>
+<phase_done name='rangeCheckElimination' stamp='0.237'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.237'>
+<phase_done name='optimize_null_checks' stamp='0.237'/>
+</phase>
+<phase_done name='buildIR' stamp='0.237'/>
+</phase>
+<phase name='emit_lir' stamp='0.237'>
+<phase name='lirGeneration' stamp='0.237'>
+<phase_done name='lirGeneration' stamp='0.237'/>
+</phase>
+<phase name='linearScan' stamp='0.237'>
+<phase_done name='linearScan' stamp='0.237'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.237'/>
+</phase>
+<phase name='codeemit' stamp='0.237'>
+<phase_done name='codeemit' stamp='0.237'/>
+</phase>
+<phase name='codeinstall' stamp='0.237'>
+<phase_done name='codeinstall' stamp='0.237'/>
+</phase>
+<code_cache total_blobs='376' nmethods='71' adapters='162' free_code_cache='248644864'/>
+<task_done success='1' nmsize='952' count='364' inlined_bytes='20' stamp='0.237'/>
+</task>
+<task compile_id='76' method='java.util.HashMap afterNodeInsertion (Z)V' bytes='1' count='361' iicount='361' level='3' stamp='0.237'>
+<phase name='setup' stamp='0.237'>
+<phase_done name='setup' stamp='0.237'/>
+</phase>
+<phase name='buildIR' stamp='0.237'>
+<type id='977' name='void'/>
+<type id='969' name='boolean'/>
+<klass id='1093' name='java.util.HashMap' flags='1'/>
+<method id='1094' holder='1093' name='afterNodeInsertion' return='977' arguments='969' flags='0' bytes='1' iicount='361'/>
+<parse method='1094'  stamp='0.237'>
+<phase name='parse_hir' stamp='0.237'>
+<phase_done name='parse_hir' stamp='0.237'/>
+</phase>
+<parse_done stamp='0.237'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.237'>
+<phase_done name='optimize_blocks' stamp='0.237'/>
+</phase>
+<phase name='gvn' stamp='0.237'>
+<phase_done name='gvn' stamp='0.237'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.237'>
+<phase_done name='rangeCheckElimination' stamp='0.237'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.237'>
+<phase_done name='optimize_null_checks' stamp='0.237'/>
+</phase>
+<phase_done name='buildIR' stamp='0.237'/>
+</phase>
+<phase name='emit_lir' stamp='0.237'>
+<phase name='lirGeneration' stamp='0.237'>
+<phase_done name='lirGeneration' stamp='0.237'/>
+</phase>
+<phase name='linearScan' stamp='0.237'>
+<phase_done name='linearScan' stamp='0.237'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.237'/>
+</phase>
+<phase name='codeemit' stamp='0.237'>
+<phase_done name='codeemit' stamp='0.237'/>
+</phase>
+<phase name='codeinstall' stamp='0.237'>
+<phase_done name='codeinstall' stamp='0.237'/>
+</phase>
+<code_cache total_blobs='377' nmethods='72' adapters='162' free_code_cache='248643968'/>
+<task_done success='1' nmsize='336' count='378' stamp='0.237'/>
+</task>
+<task compile_id='74' method='java.util.ImmutableCollections$Set1 size ()I' bytes='2' count='155' iicount='155' level='1' stamp='0.237'>
+<phase name='setup' stamp='0.237'>
+<phase_done name='setup' stamp='0.237'/>
+</phase>
+<phase name='buildIR' stamp='0.237'>
+<type id='975' name='int'/>
+<klass id='1093' name='java.util.ImmutableCollections$Set1' flags='24'/>
+<method id='1094' holder='1093' name='size' return='975' flags='1' bytes='2' iicount='155'/>
+<parse method='1094'  stamp='0.237'>
+<phase name='parse_hir' stamp='0.237'>
+<phase_done name='parse_hir' stamp='0.237'/>
+</phase>
+<parse_done stamp='0.237'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.237'>
+<phase_done name='optimize_blocks' stamp='0.237'/>
+</phase>
+<phase name='gvn' stamp='0.237'>
+<phase_done name='gvn' stamp='0.237'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.237'>
+<phase_done name='rangeCheckElimination' stamp='0.237'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.237'>
+<phase_done name='optimize_null_checks' stamp='0.237'/>
+</phase>
+<phase_done name='buildIR' stamp='0.237'/>
+</phase>
+<phase name='emit_lir' stamp='0.237'>
+<phase name='lirGeneration' stamp='0.237'>
+<phase_done name='lirGeneration' stamp='0.237'/>
+</phase>
+<phase name='linearScan' stamp='0.237'>
+<phase_done name='linearScan' stamp='0.237'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.237'/>
+</phase>
+<phase name='codeemit' stamp='0.237'>
+<phase_done name='codeemit' stamp='0.237'/>
+</phase>
+<phase name='codeinstall' stamp='0.237'>
+<phase_done name='codeinstall' stamp='0.237'/>
+</phase>
+<code_cache total_blobs='379' nmethods='74' adapters='162' free_code_cache='248641792'/>
+<task_done success='1' nmsize='272' count='155' stamp='0.237'/>
+</task>
+<task compile_id='77' method='java.lang.module.ModuleDescriptor provides ()Ljava/util/Set;' bytes='5' count='142' iicount='142' level='1' stamp='0.237'>
+<phase name='setup' stamp='0.237'>
+<phase_done name='setup' stamp='0.237'/>
+</phase>
+<phase name='buildIR' stamp='0.237'>
+<klass id='1094' name='java.util.Set' flags='1537'/>
+<klass id='1093' name='java.lang.module.ModuleDescriptor' flags='1'/>
+<method id='1095' holder='1093' name='provides' return='1094' flags='1' bytes='5' iicount='142'/>
+<parse method='1095'  stamp='0.237'>
+<phase name='parse_hir' stamp='0.237'>
+<phase_done name='parse_hir' stamp='0.237'/>
+</phase>
+<parse_done stamp='0.237'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.237'>
+<phase_done name='optimize_blocks' stamp='0.237'/>
+</phase>
+<phase name='gvn' stamp='0.237'>
+<phase_done name='gvn' stamp='0.238'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.238'>
+<phase_done name='rangeCheckElimination' stamp='0.238'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.238'>
+<phase_done name='optimize_null_checks' stamp='0.238'/>
+</phase>
+<phase_done name='buildIR' stamp='0.238'/>
+</phase>
+<phase name='emit_lir' stamp='0.238'>
+<phase name='lirGeneration' stamp='0.238'>
+<phase_done name='lirGeneration' stamp='0.238'/>
+</phase>
+<phase name='linearScan' stamp='0.238'>
+<phase_done name='linearScan' stamp='0.238'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.238'/>
+</phase>
+<phase name='codeemit' stamp='0.238'>
+<phase_done name='codeemit' stamp='0.238'/>
+</phase>
+<phase name='codeinstall' stamp='0.238'>
+<phase_done name='codeinstall' stamp='0.238'/>
+</phase>
+<code_cache total_blobs='381' nmethods='76' adapters='162' free_code_cache='248639360'/>
+<task_done success='1' nmsize='272' count='142' stamp='0.238'/>
+</task>
+<task compile_id='82' method='java.util.HashMap$HashIterator hasNext ()Z' bytes='13' count='263' iicount='263' level='3' stamp='0.239'>
+<phase name='setup' stamp='0.239'>
+<phase_done name='setup' stamp='0.239'/>
+</phase>
+<phase name='buildIR' stamp='0.239'>
+<type id='969' name='boolean'/>
+<klass id='1093' name='java.util.HashMap$HashIterator' flags='1024'/>
+<method id='1094' holder='1093' name='hasNext' return='969' flags='17' bytes='13' iicount='265'/>
+<parse method='1094'  stamp='0.239'>
+<phase name='parse_hir' stamp='0.239'>
+<phase_done name='parse_hir' stamp='0.239'/>
+</phase>
+<parse_done stamp='0.239'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.239'>
+<phase_done name='optimize_blocks' stamp='0.239'/>
+</phase>
+<phase name='gvn' stamp='0.239'>
+<phase_done name='gvn' stamp='0.239'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.239'>
+<phase_done name='rangeCheckElimination' stamp='0.239'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.239'>
+<phase_done name='optimize_null_checks' stamp='0.239'/>
+</phase>
+<phase_done name='buildIR' stamp='0.239'/>
+</phase>
+<phase name='emit_lir' stamp='0.239'>
+<phase name='lirGeneration' stamp='0.239'>
+<phase_done name='lirGeneration' stamp='0.239'/>
+</phase>
+<phase name='linearScan' stamp='0.239'>
+<phase_done name='linearScan' stamp='0.239'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.239'/>
+</phase>
+<phase name='codeemit' stamp='0.239'>
+<phase_done name='codeemit' stamp='0.239'/>
+</phase>
+<phase name='codeinstall' stamp='0.239'>
+<phase_done name='codeinstall' stamp='0.239'/>
+</phase>
+<code_cache total_blobs='386' nmethods='81' adapters='162' free_code_cache='248628352'/>
+<task_done success='1' nmsize='432' count='265' stamp='0.239'/>
+</task>
+<task compile_id='84' method='java.util.Optional of (Ljava/lang/Object;)Ljava/util/Optional;' bytes='9' count='259' iicount='259' level='3' stamp='0.239'>
+<phase name='setup' stamp='0.239'>
+<phase_done name='setup' stamp='0.239'/>
+</phase>
+<phase name='buildIR' stamp='0.239'>
+<klass id='1093' name='java.util.Optional' flags='17'/>
+<klass id='982' name='java.lang.Object' flags='1'/>
+<method id='1094' holder='1093' name='of' return='1093' arguments='982' flags='9' bytes='9' iicount='261'/>
+<parse method='1094'  stamp='0.239'>
+<phase name='parse_hir' stamp='0.239'>
+<bc code='183' bci='5'/>
+<type id='977' name='void'/>
+<method id='1096' holder='1093' name='&lt;init&gt;' return='977' arguments='982' flags='2' bytes='13' iicount='266'/>
+<call method='1096' instr='invokespecial'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1096'>
+<bc code='183' bci='1'/>
+<method id='1098' holder='982' name='&lt;init&gt;' return='977' flags='1' bytes='1' compile_id='50' compiler='c1' level='1' iicount='3882'/>
+<call method='1098' instr='invokespecial'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1098'>
+<parse_done stamp='0.239'/>
+</parse>
+<bc code='184' bci='6'/>
+<klass id='1100' name='java.util.Objects' flags='17'/>
+<method id='1101' holder='1100' name='requireNonNull' return='982' arguments='982' flags='9' bytes='14' compile_id='21' compiler='c1' level='3' iicount='1946'/>
+<call method='1101' instr='invokestatic'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1101'>
+<bc code='183' bci='8'/>
+<klass id='1089' name='java.lang.NullPointerException' flags='1'/>
+<method id='1103' holder='1089' name='&lt;init&gt;' return='977' flags='1' bytes='5' iicount='1'/>
+<call method='1103' instr='invokespecial'/>
+<inline_fail reason='don&apos;t inline Throwable constructors'/>
+<parse_done stamp='0.239'/>
+</parse>
+<parse_done stamp='0.239'/>
+</parse>
+<phase_done name='parse_hir' stamp='0.239'/>
+</phase>
+<parse_done stamp='0.239'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.239'>
+<phase_done name='optimize_blocks' stamp='0.239'/>
+</phase>
+<phase name='gvn' stamp='0.239'>
+<phase_done name='gvn' stamp='0.239'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.239'>
+<phase_done name='rangeCheckElimination' stamp='0.239'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.239'>
+<phase_done name='optimize_null_checks' stamp='0.239'/>
+</phase>
+<phase_done name='buildIR' stamp='0.239'/>
+</phase>
+<phase name='emit_lir' stamp='0.239'>
+<phase name='lirGeneration' stamp='0.239'>
+<phase_done name='lirGeneration' stamp='0.239'/>
+</phase>
+<phase name='linearScan' stamp='0.239'>
+<phase_done name='linearScan' stamp='0.239'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.239'/>
+</phase>
+<phase name='codeemit' stamp='0.239'>
+<phase_done name='codeemit' stamp='0.239'/>
+</phase>
+<phase name='codeinstall' stamp='0.239'>
+<phase_done name='codeinstall' stamp='0.240'/>
+</phase>
+<code_cache total_blobs='391' nmethods='86' adapters='162' free_code_cache='248620416'/>
+<task_done success='1' nmsize='1032' count='277' inlined_bytes='28' stamp='0.240'/>
+</task>
+<task compile_id='91' method='java.util.HashSet add (Ljava/lang/Object;)Z' bytes='20' count='357' iicount='357' level='3' stamp='0.240'>
+<phase name='setup' stamp='0.240'>
+<phase_done name='setup' stamp='0.240'/>
+</phase>
+<phase name='buildIR' stamp='0.240'>
+<type id='969' name='boolean'/>
+<klass id='982' name='java.lang.Object' flags='1'/>
+<klass id='1093' name='java.util.HashSet' flags='1'/>
+<method id='1094' holder='1093' name='add' return='969' arguments='982' flags='1' bytes='20' iicount='357'/>
+<parse method='1094'  stamp='0.240'>
+<phase name='parse_hir' stamp='0.240'>
+<bc code='182' bci='8'/>
+<klass id='1096' name='java.util.HashMap' flags='1'/>
+<method id='1099' holder='1096' name='put' return='982' arguments='982 982' flags='1' bytes='13' compile_id='71' compiler='c1' level='3' iicount='690'/>
+<call method='1099' instr='invokevirtual'/>
+<dependency type='unique_concrete_method' ctxk='1096' x='1099'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1099'>
+<bc code='184' bci='2'/>
+<type id='975' name='int'/>
+<method id='1101' holder='1096' name='hash' return='975' arguments='982' flags='24' bytes='20' compile_id='65' compiler='c1' level='3' iicount='1508'/>
+<call method='1101' instr='invokestatic'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1101'>
+<bc code='182' bci='9'/>
+<method id='1104' holder='982' name='hashCode' return='975' flags='257' bytes='0' compile_id='93' compile_kind='c2n' compiler='' level='0' iicount='256'/>
+<call method='1104' instr='invokevirtual'/>
+<inline_fail reason='no static binding'/>
+<parse_done stamp='0.240'/>
+</parse>
+<bc code='182' bci='9'/>
+<method id='1105' holder='1096' name='putVal' return='982' arguments='975 982 982 969 969' flags='16' bytes='300' compile_id='72' compiler='c1' level='3' iicount='739'/>
+<call method='1105' instr='invokevirtual'/>
+<inline_fail reason='callee is too large'/>
+<parse_done stamp='0.240'/>
+</parse>
+<phase_done name='parse_hir' stamp='0.240'/>
+</phase>
+<parse_done stamp='0.240'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.240'>
+<phase_done name='optimize_blocks' stamp='0.240'/>
+</phase>
+<phase name='gvn' stamp='0.240'>
+<phase_done name='gvn' stamp='0.240'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.240'>
+<phase_done name='rangeCheckElimination' stamp='0.240'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.240'>
+<phase_done name='optimize_null_checks' stamp='0.240'/>
+</phase>
+<phase_done name='buildIR' stamp='0.240'/>
+</phase>
+<phase name='emit_lir' stamp='0.240'>
+<phase name='lirGeneration' stamp='0.240'>
+<phase_done name='lirGeneration' stamp='0.240'/>
+</phase>
+<phase name='linearScan' stamp='0.240'>
+<phase_done name='linearScan' stamp='0.240'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.240'/>
+</phase>
+<phase name='codeemit' stamp='0.240'>
+<phase_done name='codeemit' stamp='0.240'/>
+</phase>
+<phase name='codeinstall' stamp='0.240'>
+<dependency type='unique_concrete_method' ctxk='1096' x='1099'/>
+<phase_done name='codeinstall' stamp='0.240'/>
+</phase>
+<code_cache total_blobs='394' nmethods='89' adapters='162' free_code_cache='248615296'/>
+<task_done success='1' nmsize='1304' count='478' inlined_bytes='33' stamp='0.240'/>
+</task>
+<task compile_id='92' method='java.util.HashMap get (Ljava/lang/Object;)Ljava/lang/Object;' bytes='23' count='580' iicount='580' level='3' stamp='0.240'>
+<phase name='setup' stamp='0.240'>
+<phase_done name='setup' stamp='0.240'/>
+</phase>
+<phase name='buildIR' stamp='0.240'>
+<klass id='982' name='java.lang.Object' flags='1'/>
+<klass id='1093' name='java.util.HashMap' flags='1'/>
+<method id='1094' holder='1093' name='get' return='982' arguments='982' flags='1' bytes='23' iicount='580'/>
+<parse method='1094'  stamp='0.240'>
+<phase name='parse_hir' stamp='0.240'>
+<bc code='184' bci='2'/>
+<type id='975' name='int'/>
+<method id='1096' holder='1093' name='hash' return='975' arguments='982' flags='24' bytes='20' compile_id='65' compiler='c1' level='3' iicount='1846'/>
+<call method='1096' instr='invokestatic'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1096'>
+<bc code='182' bci='9'/>
+<method id='1099' holder='982' name='hashCode' return='975' flags='257' bytes='0' compile_id='93' compile_kind='c2n' compiler='' level='0' iicount='256'/>
+<call method='1099' instr='invokevirtual'/>
+<inline_fail reason='no static binding'/>
+<parse_done stamp='0.240'/>
+</parse>
+<bc code='182' bci='6'/>
+<klass id='1100' name='java.util.HashMap$Node' flags='8'/>
+<method id='1101' holder='1093' name='getNode' return='1100' arguments='975 982' flags='16' bytes='148' compile_id='69' compiler='c1' level='3' iicount='999'/>
+<call method='1101' instr='invokevirtual'/>
+<inline_fail reason='callee is too large'/>
+<phase_done name='parse_hir' stamp='0.240'/>
+</phase>
+<parse_done stamp='0.240'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.240'>
+<phase_done name='optimize_blocks' stamp='0.240'/>
+</phase>
+<phase name='gvn' stamp='0.240'>
+<phase_done name='gvn' stamp='0.240'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.240'>
+<phase_done name='rangeCheckElimination' stamp='0.240'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.240'>
+<phase_done name='optimize_null_checks' stamp='0.240'/>
+</phase>
+<phase_done name='buildIR' stamp='0.240'/>
+</phase>
+<phase name='emit_lir' stamp='0.240'>
+<phase name='lirGeneration' stamp='0.240'>
+<phase_done name='lirGeneration' stamp='0.240'/>
+</phase>
+<phase name='linearScan' stamp='0.240'>
+<phase_done name='linearScan' stamp='0.240'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.240'/>
+</phase>
+<phase name='codeemit' stamp='0.240'>
+<phase_done name='codeemit' stamp='0.240'/>
+</phase>
+<phase name='codeinstall' stamp='0.240'>
+<phase_done name='codeinstall' stamp='0.240'/>
+</phase>
+<code_cache total_blobs='396' nmethods='91' adapters='162' free_code_cache='248611072'/>
+<task_done success='1' nmsize='1016' count='681' inlined_bytes='20' stamp='0.240'/>
+</task>
+<task compile_id='97' method='java.lang.module.ModuleDescriptor requires ()Ljava/util/Set;' bytes='5' count='154' iicount='154' level='1' stamp='0.241'>
+<phase name='setup' stamp='0.241'>
+<phase_done name='setup' stamp='0.241'/>
+</phase>
+<phase name='buildIR' stamp='0.241'>
+<klass id='1094' name='java.util.Set' flags='1537'/>
+<klass id='1093' name='java.lang.module.ModuleDescriptor' flags='1'/>
+<method id='1095' holder='1093' name='requires' return='1094' flags='1' bytes='5' iicount='154'/>
+<parse method='1095'  stamp='0.241'>
+<phase name='parse_hir' stamp='0.241'>
+<phase_done name='parse_hir' stamp='0.241'/>
+</phase>
+<parse_done stamp='0.241'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.241'>
+<phase_done name='optimize_blocks' stamp='0.241'/>
+</phase>
+<phase name='gvn' stamp='0.241'>
+<phase_done name='gvn' stamp='0.241'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.241'>
+<phase_done name='rangeCheckElimination' stamp='0.241'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.241'>
+<phase_done name='optimize_null_checks' stamp='0.241'/>
+</phase>
+<phase_done name='buildIR' stamp='0.241'/>
+</phase>
+<phase name='emit_lir' stamp='0.241'>
+<phase name='lirGeneration' stamp='0.241'>
+<phase_done name='lirGeneration' stamp='0.241'/>
+</phase>
+<phase name='linearScan' stamp='0.241'>
+<phase_done name='linearScan' stamp='0.241'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.241'/>
+</phase>
+<phase name='codeemit' stamp='0.241'>
+<phase_done name='codeemit' stamp='0.241'/>
+</phase>
+<phase name='codeinstall' stamp='0.241'>
+<phase_done name='codeinstall' stamp='0.241'/>
+</phase>
+<code_cache total_blobs='400' nmethods='95' adapters='162' free_code_cache='248603008'/>
+<task_done success='1' nmsize='272' count='154' stamp='0.241'/>
+</task>
+<task compile_id='101' method='java.lang.Enum equals (Ljava/lang/Object;)Z' bytes='11' count='274' iicount='274' level='3' stamp='0.241'>
+<phase name='setup' stamp='0.241'>
+<phase_done name='setup' stamp='0.241'/>
+</phase>
+<phase name='buildIR' stamp='0.241'>
+<type id='969' name='boolean'/>
+<klass id='982' name='java.lang.Object' flags='1'/>
+<klass id='1093' name='java.lang.Enum' flags='1025'/>
+<method id='1094' holder='1093' name='equals' return='969' arguments='982' flags='17' bytes='11' iicount='274'/>
+<parse method='1094'  stamp='0.241'>
+<phase name='parse_hir' stamp='0.241'>
+<phase_done name='parse_hir' stamp='0.241'/>
+</phase>
+<parse_done stamp='0.241'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.241'>
+<phase_done name='optimize_blocks' stamp='0.241'/>
+</phase>
+<phase name='gvn' stamp='0.241'>
+<phase_done name='gvn' stamp='0.241'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.241'>
+<phase_done name='rangeCheckElimination' stamp='0.241'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.241'>
+<phase_done name='optimize_null_checks' stamp='0.241'/>
+</phase>
+<phase_done name='buildIR' stamp='0.241'/>
+</phase>
+<phase name='emit_lir' stamp='0.241'>
+<phase name='lirGeneration' stamp='0.241'>
+<phase_done name='lirGeneration' stamp='0.241'/>
+</phase>
+<phase name='linearScan' stamp='0.241'>
+<phase_done name='linearScan' stamp='0.241'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.241'/>
+</phase>
+<phase name='codeemit' stamp='0.241'>
+<phase_done name='codeemit' stamp='0.241'/>
+</phase>
+<phase name='codeinstall' stamp='0.241'>
+<phase_done name='codeinstall' stamp='0.241'/>
+</phase>
+<code_cache total_blobs='403' nmethods='98' adapters='162' free_code_cache='248600448'/>
+<task_done success='1' nmsize='432' count='274' stamp='0.241'/>
+</task>
+<task compile_id='102' method='java.util.HashMap$KeyIterator next ()Ljava/lang/Object;' bytes='8' count='322' iicount='322' level='3' stamp='0.241'>
+<phase name='setup' stamp='0.241'>
+<phase_done name='setup' stamp='0.241'/>
+</phase>
+<phase name='buildIR' stamp='0.241'>
+<klass id='982' name='java.lang.Object' flags='1'/>
+<klass id='1093' name='java.util.HashMap$KeyIterator' flags='16'/>
+<method id='1094' holder='1093' name='next' return='982' flags='17' bytes='8' iicount='356'/>
+<parse method='1094'  stamp='0.241'>
+<phase name='parse_hir' stamp='0.241'>
+<bc code='182' bci='1'/>
+<klass id='1097' name='java.util.HashMap$Node' flags='8'/>
+<klass id='1096' name='java.util.HashMap$HashIterator' flags='1024'/>
+<method id='1098' holder='1096' name='nextNode' return='1097' flags='16' bytes='100' compile_id='94' compiler='c1' level='3' iicount='565'/>
+<call method='1098' instr='invokevirtual'/>
+<inline_fail reason='callee is too large'/>
+<phase_done name='parse_hir' stamp='0.241'/>
+</phase>
+<parse_done stamp='0.241'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.241'>
+<phase_done name='optimize_blocks' stamp='0.241'/>
+</phase>
+<phase name='gvn' stamp='0.241'>
+<phase_done name='gvn' stamp='0.241'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.241'>
+<phase_done name='rangeCheckElimination' stamp='0.241'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.241'>
+<phase_done name='optimize_null_checks' stamp='0.241'/>
+</phase>
+<phase_done name='buildIR' stamp='0.241'/>
+</phase>
+<phase name='emit_lir' stamp='0.241'>
+<phase name='lirGeneration' stamp='0.241'>
+<phase_done name='lirGeneration' stamp='0.241'/>
+</phase>
+<phase name='linearScan' stamp='0.241'>
+<phase_done name='linearScan' stamp='0.241'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.241'/>
+</phase>
+<phase name='codeemit' stamp='0.241'>
+<phase_done name='codeemit' stamp='0.241'/>
+</phase>
+<phase name='codeinstall' stamp='0.241'>
+<phase_done name='codeinstall' stamp='0.241'/>
+</phase>
+<code_cache total_blobs='405' nmethods='100' adapters='162' free_code_cache='248598144'/>
+<task_done success='1' nmsize='520' count='442' stamp='0.241'/>
+</task>
+<task compile_id='105' method='java.util.HashMap keySet ()Ljava/util/Set;' bytes='25' count='335' iicount='336' level='3' stamp='0.241'>
+<phase name='setup' stamp='0.241'>
+<phase_done name='setup' stamp='0.241'/>
+</phase>
+<phase name='buildIR' stamp='0.241'>
+<klass id='1094' name='java.util.Set' flags='1537'/>
+<klass id='1093' name='java.util.HashMap' flags='1'/>
+<method id='1095' holder='1093' name='keySet' return='1094' flags='1' bytes='25' iicount='343'/>
+<parse method='1095'  stamp='0.241'>
+<phase name='parse_hir' stamp='0.241'>
+<bc code='183' bci='14'/>
+<type id='977' name='void'/>
+<klass id='1098' name='java.util.HashMap$KeySet' flags='16'/>
+<method id='1099' holder='1098' name='&lt;init&gt;' return='977' arguments='1093' flags='0' bytes='10' iicount='165'/>
+<call method='1099' instr='invokespecial'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1099'>
+<bc code='183' bci='6'/>
+<klass id='1101' name='java.util.AbstractSet' flags='1025'/>
+<method id='1102' holder='1101' name='&lt;init&gt;' return='977' flags='4' bytes='5' compile_id='24' compiler='c1' level='3' iicount='880'/>
+<call method='1102' instr='invokespecial'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1102'>
+<bc code='183' bci='1'/>
+<klass id='1104' name='java.util.AbstractCollection' flags='1025'/>
+<method id='1105' holder='1104' name='&lt;init&gt;' return='977' flags='4' bytes='5' compile_id='23' compiler='c1' level='3' iicount='979'/>
+<call method='1105' instr='invokespecial'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1105'>
+<bc code='183' bci='1'/>
+<klass id='982' name='java.lang.Object' flags='1'/>
+<method id='1107' holder='982' name='&lt;init&gt;' return='977' flags='1' bytes='1' compile_id='50' compiler='c1' level='1' iicount='4711'/>
+<call method='1107' instr='invokespecial'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1107'>
+<parse_done stamp='0.241'/>
+</parse>
+<parse_done stamp='0.241'/>
+</parse>
+<parse_done stamp='0.241'/>
+</parse>
+<parse_done stamp='0.241'/>
+</parse>
+<phase_done name='parse_hir' stamp='0.241'/>
+</phase>
+<parse_done stamp='0.241'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.241'>
+<phase_done name='optimize_blocks' stamp='0.241'/>
+</phase>
+<phase name='gvn' stamp='0.241'>
+<phase_done name='gvn' stamp='0.241'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.241'>
+<phase_done name='rangeCheckElimination' stamp='0.241'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.241'>
+<phase_done name='optimize_null_checks' stamp='0.241'/>
+</phase>
+<phase_done name='buildIR' stamp='0.241'/>
+</phase>
+<phase name='emit_lir' stamp='0.241'>
+<phase name='lirGeneration' stamp='0.241'>
+<phase_done name='lirGeneration' stamp='0.242'/>
+</phase>
+<phase name='linearScan' stamp='0.242'>
+<phase_done name='linearScan' stamp='0.242'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.242'/>
+</phase>
+<phase name='codeemit' stamp='0.242'>
+<phase_done name='codeemit' stamp='0.242'/>
+</phase>
+<phase name='codeinstall' stamp='0.242'>
+<phase_done name='codeinstall' stamp='0.242'/>
+</phase>
+<code_cache total_blobs='408' nmethods='103' adapters='162' free_code_cache='248591360'/>
+<task_done success='1' nmsize='1072' count='584' inlined_bytes='21' stamp='0.242'/>
+</task>
+<task compile_id='109' method='java.util.KeyValueHolder getKey ()Ljava/lang/Object;' bytes='5' count='176' iicount='176' level='1' stamp='0.243'>
+<phase name='setup' stamp='0.243'>
+<phase_done name='setup' stamp='0.243'/>
+</phase>
+<phase name='buildIR' stamp='0.243'>
+<klass id='982' name='java.lang.Object' flags='1'/>
+<klass id='1093' name='java.util.KeyValueHolder' flags='16'/>
+<method id='1094' holder='1093' name='getKey' return='982' flags='1' bytes='5' iicount='176'/>
+<parse method='1094'  stamp='0.243'>
+<phase name='parse_hir' stamp='0.243'>
+<phase_done name='parse_hir' stamp='0.243'/>
+</phase>
+<parse_done stamp='0.243'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.243'>
+<phase_done name='optimize_blocks' stamp='0.243'/>
+</phase>
+<phase name='gvn' stamp='0.243'>
+<phase_done name='gvn' stamp='0.243'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.243'>
+<phase_done name='rangeCheckElimination' stamp='0.243'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.243'>
+<phase_done name='optimize_null_checks' stamp='0.243'/>
+</phase>
+<phase_done name='buildIR' stamp='0.243'/>
+</phase>
+<phase name='emit_lir' stamp='0.243'>
+<phase name='lirGeneration' stamp='0.243'>
+<phase_done name='lirGeneration' stamp='0.243'/>
+</phase>
+<phase name='linearScan' stamp='0.243'>
+<phase_done name='linearScan' stamp='0.243'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.243'/>
+</phase>
+<phase name='codeemit' stamp='0.243'>
+<phase_done name='codeemit' stamp='0.243'/>
+</phase>
+<phase name='codeinstall' stamp='0.243'>
+<phase_done name='codeinstall' stamp='0.243'/>
+</phase>
+<code_cache total_blobs='415' nmethods='108' adapters='162' free_code_cache='248573184'/>
+<task_done success='1' nmsize='272' count='176' stamp='0.243'/>
+</task>
+<task compile_id='114' method='java.lang.StringLatin1 indexOf ([BII)I' bytes='61' count='259' backedge_count='2288' iicount='259' level='3' stamp='0.243'>
+<phase name='setup' stamp='0.243'>
+<phase_done name='setup' stamp='0.243'/>
+</phase>
+<phase name='buildIR' stamp='0.243'>
+<type id='975' name='int'/>
+<klass id='1085' name='[B' flags='1041'/>
+<klass id='1093' name='java.lang.StringLatin1' flags='16'/>
+<method id='1094' holder='1093' name='indexOf' return='975' arguments='1085 975 975' flags='9' bytes='61' iicount='259'/>
+<parse method='1094'  stamp='0.243'>
+<phase name='parse_hir' stamp='0.243'>
+<bc code='184' bci='1'/>
+<type id='969' name='boolean'/>
+<method id='1096' holder='1093' name='canEncode' return='969' arguments='975' flags='9' bytes='13' compile_id='49' compiler='c1' level='3' iicount='336'/>
+<call method='1096' instr='invokestatic'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1096'>
+<parse_done stamp='0.244'/>
+</parse>
+<phase_done name='parse_hir' stamp='0.244'/>
+</phase>
+<parse_done stamp='0.244'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.244'>
+<phase_done name='optimize_blocks' stamp='0.244'/>
+</phase>
+<phase name='gvn' stamp='0.244'>
+<phase_done name='gvn' stamp='0.244'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.244'>
+<phase_done name='rangeCheckElimination' stamp='0.244'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.244'>
+<phase_done name='optimize_null_checks' stamp='0.244'/>
+</phase>
+<phase_done name='buildIR' stamp='0.244'/>
+</phase>
+<phase name='emit_lir' stamp='0.244'>
+<phase name='lirGeneration' stamp='0.244'>
+<phase_done name='lirGeneration' stamp='0.244'/>
+</phase>
+<phase name='linearScan' stamp='0.244'>
+<phase_done name='linearScan' stamp='0.244'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.244'/>
+</phase>
+<phase name='codeemit' stamp='0.244'>
+<phase_done name='codeemit' stamp='0.244'/>
+</phase>
+<phase name='codeinstall' stamp='0.244'>
+<phase_done name='codeinstall' stamp='0.244'/>
+</phase>
+<code_cache total_blobs='421' nmethods='114' adapters='162' free_code_cache='248576896'/>
+<task_done success='1' nmsize='1008' count='297' backedge_count='2579' inlined_bytes='13' stamp='0.244'/>
+</task>
+<task compile_id='117' method='java.lang.module.ModuleDescriptor packages ()Ljava/util/Set;' bytes='5' count='128' iicount='128' level='1' stamp='0.244'>
+<phase name='setup' stamp='0.244'>
+<phase_done name='setup' stamp='0.244'/>
+</phase>
+<phase name='buildIR' stamp='0.244'>
+<klass id='1094' name='java.util.Set' flags='1537'/>
+<klass id='1093' name='java.lang.module.ModuleDescriptor' flags='1'/>
+<method id='1095' holder='1093' name='packages' return='1094' flags='1' bytes='5' iicount='129'/>
+<parse method='1095'  stamp='0.244'>
+<phase name='parse_hir' stamp='0.244'>
+<phase_done name='parse_hir' stamp='0.244'/>
+</phase>
+<parse_done stamp='0.244'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.244'>
+<phase_done name='optimize_blocks' stamp='0.244'/>
+</phase>
+<phase name='gvn' stamp='0.244'>
+<phase_done name='gvn' stamp='0.244'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.244'>
+<phase_done name='rangeCheckElimination' stamp='0.244'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.244'>
+<phase_done name='optimize_null_checks' stamp='0.244'/>
+</phase>
+<phase_done name='buildIR' stamp='0.244'/>
+</phase>
+<phase name='emit_lir' stamp='0.244'>
+<phase name='lirGeneration' stamp='0.244'>
+<phase_done name='lirGeneration' stamp='0.244'/>
+</phase>
+<phase name='linearScan' stamp='0.244'>
+<phase_done name='linearScan' stamp='0.244'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.244'/>
+</phase>
+<phase name='codeemit' stamp='0.244'>
+<phase_done name='codeemit' stamp='0.244'/>
+</phase>
+<phase name='codeinstall' stamp='0.244'>
+<phase_done name='codeinstall' stamp='0.244'/>
+</phase>
+<code_cache total_blobs='423' nmethods='116' adapters='162' free_code_cache='248574976'/>
+<task_done success='1' nmsize='272' count='135' stamp='0.244'/>
+</task>
+<task compile_id='123' method='java.lang.CharacterData of (I)Ljava/lang/CharacterData;' bytes='120' count='260' iicount='260' level='3' stamp='0.245'>
+<phase name='setup' stamp='0.245'>
+<phase_done name='setup' stamp='0.245'/>
+</phase>
+<phase name='buildIR' stamp='0.245'>
+<klass id='1093' name='java.lang.CharacterData' flags='1024'/>
+<type id='975' name='int'/>
+<method id='1094' holder='1093' name='of' return='1093' arguments='975' flags='24' bytes='120' iicount='260'/>
+<parse method='1094'  stamp='0.245'>
+<phase name='parse_hir' stamp='0.245'>
+<phase_done name='parse_hir' stamp='0.245'/>
+</phase>
+<parse_done stamp='0.245'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.245'>
+<phase_done name='optimize_blocks' stamp='0.245'/>
+</phase>
+<phase name='gvn' stamp='0.245'>
+<phase_done name='gvn' stamp='0.245'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.245'>
+<phase_done name='rangeCheckElimination' stamp='0.245'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.245'>
+<phase_done name='optimize_null_checks' stamp='0.245'/>
+</phase>
+<phase_done name='buildIR' stamp='0.245'/>
+</phase>
+<phase name='emit_lir' stamp='0.245'>
+<phase name='lirGeneration' stamp='0.245'>
+<phase_done name='lirGeneration' stamp='0.245'/>
+</phase>
+<phase name='linearScan' stamp='0.245'>
+<phase_done name='linearScan' stamp='0.245'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.245'/>
+</phase>
+<phase name='codeemit' stamp='0.245'>
+<phase_done name='codeemit' stamp='0.245'/>
+</phase>
+<phase name='codeinstall' stamp='0.245'>
+<phase_done name='codeinstall' stamp='0.245'/>
+</phase>
+<code_cache total_blobs='433' nmethods='124' adapters='162' free_code_cache='248564736'/>
+<task_done success='1' nmsize='1488' count='260' stamp='0.245'/>
+</task>
+<task compile_id='127' method='java.lang.module.ModuleDescriptor$Version toString ()Ljava/lang/String;' bytes='5' count='130' iicount='130' level='1' stamp='0.246'>
+<phase name='setup' stamp='0.246'>
+<phase_done name='setup' stamp='0.246'/>
+</phase>
+<phase name='buildIR' stamp='0.246'>
+<klass id='983' name='java.lang.String' flags='17'/>
+<klass id='1093' name='java.lang.module.ModuleDescriptor$Version' flags='25'/>
+<method id='1094' holder='1093' name='toString' return='983' flags='1' bytes='5' iicount='131'/>
+<parse method='1094'  stamp='0.246'>
+<phase name='parse_hir' stamp='0.246'>
+<phase_done name='parse_hir' stamp='0.246'/>
+</phase>
+<parse_done stamp='0.246'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.246'>
+<phase_done name='optimize_blocks' stamp='0.246'/>
+</phase>
+<phase name='gvn' stamp='0.246'>
+<phase_done name='gvn' stamp='0.246'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.246'>
+<phase_done name='rangeCheckElimination' stamp='0.246'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.246'>
+<phase_done name='optimize_null_checks' stamp='0.246'/>
+</phase>
+<phase_done name='buildIR' stamp='0.246'/>
+</phase>
+<phase name='emit_lir' stamp='0.246'>
+<phase name='lirGeneration' stamp='0.246'>
+<phase_done name='lirGeneration' stamp='0.246'/>
+</phase>
+<phase name='linearScan' stamp='0.246'>
+<phase_done name='linearScan' stamp='0.246'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.246'/>
+</phase>
+<phase name='codeemit' stamp='0.246'>
+<phase_done name='codeemit' stamp='0.246'/>
+</phase>
+<phase name='codeinstall' stamp='0.246'>
+<phase_done name='codeinstall' stamp='0.246'/>
+</phase>
+<code_cache total_blobs='435' nmethods='126' adapters='162' free_code_cache='248562560'/>
+<task_done success='1' nmsize='272' count='136' stamp='0.246'/>
+</task>
+<task compile_id='131' method='java.util.Collections$EmptyMap get (Ljava/lang/Object;)Ljava/lang/Object;' bytes='2' count='128' iicount='128' level='1' stamp='0.248'>
+<phase name='setup' stamp='0.248'>
+<phase_done name='setup' stamp='0.248'/>
+</phase>
+<phase name='buildIR' stamp='0.248'>
+<klass id='982' name='java.lang.Object' flags='1'/>
+<klass id='1093' name='java.util.Collections$EmptyMap' flags='10'/>
+<method id='1094' holder='1093' name='get' return='982' arguments='982' flags='1' bytes='2' iicount='128'/>
+<parse method='1094'  stamp='0.248'>
+<phase name='parse_hir' stamp='0.248'>
+<phase_done name='parse_hir' stamp='0.248'/>
+</phase>
+<parse_done stamp='0.248'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.248'>
+<phase_done name='optimize_blocks' stamp='0.248'/>
+</phase>
+<phase name='gvn' stamp='0.248'>
+<phase_done name='gvn' stamp='0.248'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.248'>
+<phase_done name='rangeCheckElimination' stamp='0.248'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.248'>
+<phase_done name='optimize_null_checks' stamp='0.248'/>
+</phase>
+<phase_done name='buildIR' stamp='0.248'/>
+</phase>
+<phase name='emit_lir' stamp='0.248'>
+<phase name='lirGeneration' stamp='0.248'>
+<phase_done name='lirGeneration' stamp='0.248'/>
+</phase>
+<phase name='linearScan' stamp='0.248'>
+<phase_done name='linearScan' stamp='0.248'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.248'/>
+</phase>
+<phase name='codeemit' stamp='0.248'>
+<phase_done name='codeemit' stamp='0.248'/>
+</phase>
+<phase name='codeinstall' stamp='0.248'>
+<phase_done name='codeinstall' stamp='0.248'/>
+</phase>
+<code_cache total_blobs='441' nmethods='130' adapters='162' free_code_cache='248557696'/>
+<task_done success='1' nmsize='272' count='136' stamp='0.248'/>
+</task>
+<task compile_id='135' method='java.lang.module.ModuleDescriptor$Exports isQualified ()Z' bytes='18' count='257' iicount='257' level='3' stamp='0.249'>
+<phase name='setup' stamp='0.249'>
+<phase_done name='setup' stamp='0.249'/>
+</phase>
+<phase name='buildIR' stamp='0.249'>
+<type id='969' name='boolean'/>
+<klass id='1093' name='java.lang.module.ModuleDescriptor$Exports' flags='25'/>
+<method id='1094' holder='1093' name='isQualified' return='969' flags='1' bytes='18' iicount='257'/>
+<parse method='1094'  stamp='0.249'>
+<phase name='parse_hir' stamp='0.249'>
+<bc code='185' bci='4'/>
+<klass id='1096' name='java.util.Set' flags='1537'/>
+<method id='1097' holder='1096' name='isEmpty' return='969' flags='1025' bytes='0' iicount='1'/>
+<call method='1097' instr='invokeinterface'/>
+<inline_fail reason='no static binding'/>
+<phase_done name='parse_hir' stamp='0.249'/>
+</phase>
+<parse_done stamp='0.249'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.249'>
+<phase_done name='optimize_blocks' stamp='0.249'/>
+</phase>
+<phase name='gvn' stamp='0.249'>
+<phase_done name='gvn' stamp='0.249'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.249'>
+<phase_done name='rangeCheckElimination' stamp='0.249'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.249'>
+<phase_done name='optimize_null_checks' stamp='0.249'/>
+</phase>
+<phase_done name='buildIR' stamp='0.249'/>
+</phase>
+<phase name='emit_lir' stamp='0.249'>
+<phase name='lirGeneration' stamp='0.249'>
+<phase_done name='lirGeneration' stamp='0.249'/>
+</phase>
+<phase name='linearScan' stamp='0.249'>
+<phase_done name='linearScan' stamp='0.249'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.249'/>
+</phase>
+<phase name='codeemit' stamp='0.249'>
+<phase_done name='codeemit' stamp='0.249'/>
+</phase>
+<phase name='codeinstall' stamp='0.249'>
+<phase_done name='codeinstall' stamp='0.249'/>
+</phase>
+<code_cache total_blobs='445' nmethods='134' adapters='162' free_code_cache='248552576'/>
+<task_done success='1' nmsize='648' count='311' stamp='0.249'/>
+</task>
+<task compile_id='140' method='java.util.ImmutableCollections$Set2$1 next ()Ljava/lang/Object;' bytes='49' count='260' iicount='260' level='3' stamp='0.250'>
+<phase name='setup' stamp='0.250'>
+<phase_done name='setup' stamp='0.250'/>
+</phase>
+<phase name='buildIR' stamp='0.250'>
+<klass id='982' name='java.lang.Object' flags='1'/>
+<klass id='1093' name='java.util.ImmutableCollections$Set2$1' flags='0'/>
+<method id='1094' holder='1093' name='next' return='982' flags='1' bytes='49' iicount='260'/>
+<parse method='1094'  stamp='0.250'>
+<phase name='parse_hir' stamp='0.250'>
+<bc code='183' bci='45'/>
+<type id='977' name='void'/>
+<klass id='1097' name='java.util.NoSuchElementException' unloaded='1'/>
+<method id='1098' holder='1097' name='&lt;init&gt;' return='977' unloaded='1'/>
+<call method='1098' instr='invokespecial'/>
+<inline_fail reason='not inlineable'/>
+<phase_done name='parse_hir' stamp='0.250'/>
+</phase>
+<parse_done stamp='0.250'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.250'>
+<phase_done name='optimize_blocks' stamp='0.250'/>
+</phase>
+<phase name='gvn' stamp='0.250'>
+<phase_done name='gvn' stamp='0.250'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.250'>
+<phase_done name='rangeCheckElimination' stamp='0.250'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.250'>
+<phase_done name='optimize_null_checks' stamp='0.250'/>
+</phase>
+<phase_done name='buildIR' stamp='0.250'/>
+</phase>
+<phase name='emit_lir' stamp='0.250'>
+<phase name='lirGeneration' stamp='0.250'>
+<phase_done name='lirGeneration' stamp='0.250'/>
+</phase>
+<phase name='linearScan' stamp='0.250'>
+<phase_done name='linearScan' stamp='0.250'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.250'/>
+</phase>
+<phase name='codeemit' stamp='0.250'>
+<phase_done name='codeemit' stamp='0.250'/>
+</phase>
+<phase name='codeinstall' stamp='0.250'>
+<phase_done name='codeinstall' stamp='0.250'/>
+</phase>
+<code_cache total_blobs='451' nmethods='140' adapters='162' free_code_cache='248540800'/>
+<task_done success='1' nmsize='648' count='270' stamp='0.250'/>
+</task>
+<task compile_id='141' method='java.lang.module.ModuleDescriptor$Exports targets ()Ljava/util/Set;' bytes='5' count='128' iicount='128' level='1' stamp='0.250'>
+<phase name='setup' stamp='0.250'>
+<phase_done name='setup' stamp='0.250'/>
+</phase>
+<phase name='buildIR' stamp='0.250'>
+<klass id='1094' name='java.util.Set' flags='1537'/>
+<klass id='1093' name='java.lang.module.ModuleDescriptor$Exports' flags='25'/>
+<method id='1095' holder='1093' name='targets' return='1094' flags='1' bytes='5' iicount='128'/>
+<parse method='1095'  stamp='0.250'>
+<phase name='parse_hir' stamp='0.250'>
+<phase_done name='parse_hir' stamp='0.250'/>
+</phase>
+<parse_done stamp='0.250'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.250'>
+<phase_done name='optimize_blocks' stamp='0.250'/>
+</phase>
+<phase name='gvn' stamp='0.250'>
+<phase_done name='gvn' stamp='0.250'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.250'>
+<phase_done name='rangeCheckElimination' stamp='0.250'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.250'>
+<phase_done name='optimize_null_checks' stamp='0.250'/>
+</phase>
+<phase_done name='buildIR' stamp='0.250'/>
+</phase>
+<phase name='emit_lir' stamp='0.250'>
+<phase name='lirGeneration' stamp='0.250'>
+<phase_done name='lirGeneration' stamp='0.250'/>
+</phase>
+<phase name='linearScan' stamp='0.250'>
+<phase_done name='linearScan' stamp='0.250'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.250'/>
+</phase>
+<phase name='codeemit' stamp='0.250'>
+<phase_done name='codeemit' stamp='0.250'/>
+</phase>
+<phase name='codeinstall' stamp='0.250'>
+<phase_done name='codeinstall' stamp='0.250'/>
+</phase>
+<code_cache total_blobs='452' nmethods='141' adapters='162' free_code_cache='248540032'/>
+<task_done success='1' nmsize='272' count='146' stamp='0.250'/>
+</task>
+<task compile_id='147' method='java.lang.module.ModuleDescriptor isOpen ()Z' bytes='5' count='129' iicount='129' level='1' stamp='0.250'>
+<phase name='setup' stamp='0.250'>
+<phase_done name='setup' stamp='0.250'/>
+</phase>
+<phase name='buildIR' stamp='0.250'>
+<type id='969' name='boolean'/>
+<klass id='1093' name='java.lang.module.ModuleDescriptor' flags='1'/>
+<method id='1094' holder='1093' name='isOpen' return='969' flags='1' bytes='5' iicount='129'/>
+<parse method='1094'  stamp='0.250'>
+<phase name='parse_hir' stamp='0.250'>
+<phase_done name='parse_hir' stamp='0.250'/>
+</phase>
+<parse_done stamp='0.250'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.250'>
+<phase_done name='optimize_blocks' stamp='0.251'/>
+</phase>
+<phase name='gvn' stamp='0.251'>
+<phase_done name='gvn' stamp='0.251'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.251'>
+<phase_done name='rangeCheckElimination' stamp='0.251'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.251'>
+<phase_done name='optimize_null_checks' stamp='0.251'/>
+</phase>
+<phase_done name='buildIR' stamp='0.251'/>
+</phase>
+<phase name='emit_lir' stamp='0.251'>
+<phase name='lirGeneration' stamp='0.251'>
+<phase_done name='lirGeneration' stamp='0.251'/>
+</phase>
+<phase name='linearScan' stamp='0.251'>
+<phase_done name='linearScan' stamp='0.251'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.251'/>
+</phase>
+<phase name='codeemit' stamp='0.251'>
+<phase_done name='codeemit' stamp='0.251'/>
+</phase>
+<phase name='codeinstall' stamp='0.251'>
+<phase_done name='codeinstall' stamp='0.251'/>
+</phase>
+<code_cache total_blobs='457' nmethods='146' adapters='162' free_code_cache='248534656'/>
+<task_done success='1' nmsize='272' count='131' stamp='0.251'/>
+</task>
+<task compile_id='150' method='java.util.Collections singletonIterator (Ljava/lang/Object;)Ljava/util/Iterator;' bytes='9' count='260' iicount='260' level='3' stamp='0.251'>
+<phase name='setup' stamp='0.251'>
+<phase_done name='setup' stamp='0.251'/>
+</phase>
+<phase name='buildIR' stamp='0.251'>
+<klass id='1094' name='java.util.Iterator' flags='1537'/>
+<klass id='982' name='java.lang.Object' flags='1'/>
+<klass id='1093' name='java.util.Collections' flags='1'/>
+<method id='1095' holder='1093' name='singletonIterator' return='1094' arguments='982' flags='8' bytes='9' iicount='260'/>
+<parse method='1095'  stamp='0.251'>
+<phase name='parse_hir' stamp='0.251'>
+<bc code='183' bci='5'/>
+<type id='977' name='void'/>
+<klass id='1097' name='java.util.Collections$1' flags='0'/>
+<method id='1098' holder='1097' name='&lt;init&gt;' return='977' arguments='982' flags='0' bytes='15' iicount='264'/>
+<call method='1098' instr='invokespecial'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1098'>
+<bc code='183' bci='6'/>
+<method id='1100' holder='982' name='&lt;init&gt;' return='977' flags='1' bytes='1' compile_id='50' compiler='c1' level='1' iicount='8198'/>
+<call method='1100' instr='invokespecial'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1100'>
+<parse_done stamp='0.251'/>
+</parse>
+<parse_done stamp='0.251'/>
+</parse>
+<phase_done name='parse_hir' stamp='0.251'/>
+</phase>
+<parse_done stamp='0.251'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.251'>
+<phase_done name='optimize_blocks' stamp='0.251'/>
+</phase>
+<phase name='gvn' stamp='0.251'>
+<phase_done name='gvn' stamp='0.251'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.251'>
+<phase_done name='rangeCheckElimination' stamp='0.251'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.251'>
+<phase_done name='optimize_null_checks' stamp='0.251'/>
+</phase>
+<phase_done name='buildIR' stamp='0.251'/>
+</phase>
+<phase name='emit_lir' stamp='0.251'>
+<phase name='lirGeneration' stamp='0.251'>
+<phase_done name='lirGeneration' stamp='0.251'/>
+</phase>
+<phase name='linearScan' stamp='0.251'>
+<phase_done name='linearScan' stamp='0.251'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.251'/>
+</phase>
+<phase name='codeemit' stamp='0.251'>
+<phase_done name='codeemit' stamp='0.251'/>
+</phase>
+<phase name='codeinstall' stamp='0.251'>
+<phase_done name='codeinstall' stamp='0.251'/>
+</phase>
+<code_cache total_blobs='460' nmethods='149' adapters='162' free_code_cache='248527616'/>
+<task_done success='1' nmsize='688' count='273' inlined_bytes='16' stamp='0.251'/>
+</task>
+<task compile_id='160' method='java.util.KeyValueHolder &lt;init&gt; (Ljava/lang/Object;Ljava/lang/Object;)V' bytes='21' count='280' iicount='280' level='3' stamp='0.253'>
+<phase name='setup' stamp='0.253'>
+<phase_done name='setup' stamp='0.253'/>
+</phase>
+<phase name='buildIR' stamp='0.253'>
+<type id='977' name='void'/>
+<klass id='982' name='java.lang.Object' flags='1'/>
+<klass id='1093' name='java.util.KeyValueHolder' flags='16'/>
+<method id='1094' holder='1093' name='&lt;init&gt;' return='977' arguments='982 982' flags='0' bytes='21' iicount='280'/>
+<parse method='1094'  stamp='0.253'>
+<phase name='parse_hir' stamp='0.253'>
+<bc code='183' bci='1'/>
+<method id='1096' holder='982' name='&lt;init&gt;' return='977' flags='1' bytes='1' compile_id='50' compiler='c1' level='1' iicount='8727'/>
+<call method='1096' instr='invokespecial'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1096'>
+<parse_done stamp='0.253'/>
+</parse>
+<bc code='184' bci='6'/>
+<klass id='1098' name='java.util.Objects' flags='17'/>
+<method id='1099' holder='1098' name='requireNonNull' return='982' arguments='982' flags='9' bytes='14' compile_id='21' compiler='c1' level='3' iicount='3378'/>
+<call method='1099' instr='invokestatic'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1099'>
+<bc code='183' bci='8'/>
+<klass id='1089' name='java.lang.NullPointerException' flags='1'/>
+<method id='1101' holder='1089' name='&lt;init&gt;' return='977' flags='1' bytes='5' iicount='1'/>
+<call method='1101' instr='invokespecial'/>
+<inline_fail reason='don&apos;t inline Throwable constructors'/>
+<parse_done stamp='0.253'/>
+</parse>
+<bc code='184' bci='14'/>
+<call method='1099' instr='invokestatic'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1099'>
+<bc code='183' bci='8'/>
+<call method='1101' instr='invokespecial'/>
+<inline_fail reason='don&apos;t inline Throwable constructors'/>
+<parse_done stamp='0.253'/>
+</parse>
+<phase_done name='parse_hir' stamp='0.253'/>
+</phase>
+<parse_done stamp='0.253'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.253'>
+<phase_done name='optimize_blocks' stamp='0.253'/>
+</phase>
+<phase name='gvn' stamp='0.253'>
+<phase_done name='gvn' stamp='0.253'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.253'>
+<phase_done name='rangeCheckElimination' stamp='0.253'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.253'>
+<phase_done name='optimize_null_checks' stamp='0.253'/>
+</phase>
+<phase_done name='buildIR' stamp='0.253'/>
+</phase>
+<phase name='emit_lir' stamp='0.253'>
+<phase name='lirGeneration' stamp='0.253'>
+<phase_done name='lirGeneration' stamp='0.253'/>
+</phase>
+<phase name='linearScan' stamp='0.253'>
+<phase_done name='linearScan' stamp='0.253'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.253'/>
+</phase>
+<phase name='codeemit' stamp='0.253'>
+<phase_done name='codeemit' stamp='0.253'/>
+</phase>
+<phase name='codeinstall' stamp='0.253'>
+<phase_done name='codeinstall' stamp='0.254'/>
+</phase>
+<code_cache total_blobs='470' nmethods='159' adapters='162' free_code_cache='248516096'/>
+<task_done success='1' nmsize='1304' count='280' inlined_bytes='29' stamp='0.254'/>
+</task>
+<task compile_id='162' method='java.util.Collections$EmptyIterator hasNext ()Z' bytes='2' count='132' iicount='132' level='1' stamp='0.254'>
+<phase name='setup' stamp='0.254'>
+<phase_done name='setup' stamp='0.254'/>
+</phase>
+<phase name='buildIR' stamp='0.254'>
+<type id='969' name='boolean'/>
+<klass id='1093' name='java.util.Collections$EmptyIterator' flags='10'/>
+<method id='1094' holder='1093' name='hasNext' return='969' flags='1' bytes='2' iicount='132'/>
+<parse method='1094'  stamp='0.254'>
+<phase name='parse_hir' stamp='0.254'>
+<phase_done name='parse_hir' stamp='0.254'/>
+</phase>
+<parse_done stamp='0.254'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.254'>
+<phase_done name='optimize_blocks' stamp='0.254'/>
+</phase>
+<phase name='gvn' stamp='0.254'>
+<phase_done name='gvn' stamp='0.254'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.254'>
+<phase_done name='rangeCheckElimination' stamp='0.254'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.254'>
+<phase_done name='optimize_null_checks' stamp='0.254'/>
+</phase>
+<phase_done name='buildIR' stamp='0.254'/>
+</phase>
+<phase name='emit_lir' stamp='0.254'>
+<phase name='lirGeneration' stamp='0.254'>
+<phase_done name='lirGeneration' stamp='0.254'/>
+</phase>
+<phase name='linearScan' stamp='0.254'>
+<phase_done name='linearScan' stamp='0.254'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.254'/>
+</phase>
+<phase name='codeemit' stamp='0.254'>
+<phase_done name='codeemit' stamp='0.254'/>
+</phase>
+<phase name='codeinstall' stamp='0.254'>
+<phase_done name='codeinstall' stamp='0.254'/>
+</phase>
+<code_cache total_blobs='472' nmethods='161' adapters='162' free_code_cache='248512768'/>
+<task_done success='1' nmsize='272' count='132' stamp='0.254'/>
+</task>
+<task compile_id='163' method='jdk.internal.module.ModuleBootstrap$2 hasNext ()Z' bytes='30' count='279' iicount='279' level='3' stamp='0.254'>
+<phase name='setup' stamp='0.254'>
+<phase_done name='setup' stamp='0.254'/>
+</phase>
+<phase name='buildIR' stamp='0.254'>
+<type id='969' name='boolean'/>
+<klass id='1093' name='jdk.internal.module.ModuleBootstrap$2' flags='0'/>
+<method id='1094' holder='1093' name='hasNext' return='969' flags='1' bytes='30' iicount='279'/>
+<parse method='1094'  stamp='0.254'>
+<phase name='parse_hir' stamp='0.254'>
+<bc code='185' bci='4'/>
+<klass id='1096' name='java.util.Iterator' flags='1537'/>
+<method id='1097' holder='1096' name='hasNext' return='969' flags='1025' bytes='0' iicount='1'/>
+<call method='1097' instr='invokeinterface'/>
+<inline_fail reason='no static binding'/>
+<bc code='185' bci='16'/>
+<call method='1097' instr='invokeinterface'/>
+<inline_fail reason='no static binding'/>
+<phase_done name='parse_hir' stamp='0.254'/>
+</phase>
+<parse_done stamp='0.254'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.254'>
+<phase_done name='optimize_blocks' stamp='0.254'/>
+</phase>
+<phase name='gvn' stamp='0.254'>
+<phase_done name='gvn' stamp='0.254'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.254'>
+<phase_done name='rangeCheckElimination' stamp='0.254'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.254'>
+<phase_done name='optimize_null_checks' stamp='0.254'/>
+</phase>
+<phase_done name='buildIR' stamp='0.254'/>
+</phase>
+<phase name='emit_lir' stamp='0.254'>
+<phase name='lirGeneration' stamp='0.254'>
+<phase_done name='lirGeneration' stamp='0.254'/>
+</phase>
+<phase name='linearScan' stamp='0.254'>
+<phase_done name='linearScan' stamp='0.255'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.255'/>
+</phase>
+<phase name='codeemit' stamp='0.255'>
+<phase_done name='codeemit' stamp='0.255'/>
+</phase>
+<phase name='codeinstall' stamp='0.255'>
+<phase_done name='codeinstall' stamp='0.255'/>
+</phase>
+<code_cache total_blobs='477' nmethods='164' adapters='162' free_code_cache='248509312'/>
+<task_done success='1' nmsize='888' count='466' stamp='0.255'/>
+</task>
+<task compile_id='169' method='java.lang.Character toLowerCase (I)I' bytes='9' count='256' iicount='256' level='3' stamp='0.258'>
+<phase name='setup' stamp='0.258'>
+<phase_done name='setup' stamp='0.258'/>
+</phase>
+<phase name='buildIR' stamp='0.258'>
+<type id='975' name='int'/>
+<klass id='1070' name='java.lang.Character' flags='17'/>
+<method id='1093' holder='1070' name='toLowerCase' return='975' arguments='975' flags='9' bytes='9' iicount='256'/>
+<parse method='1093'  stamp='0.258'>
+<phase name='parse_hir' stamp='0.258'>
+<bc code='184' bci='1'/>
+<klass id='1095' name='java.lang.CharacterData' flags='1024'/>
+<method id='1096' holder='1095' name='of' return='1095' arguments='975' flags='24' bytes='120' compile_id='123' compiler='c1' level='3' iicount='272'/>
+<call method='1096' instr='invokestatic'/>
+<inline_fail reason='callee is too large'/>
+<bc code='182' bci='5'/>
+<method id='1098' holder='1095' name='toLowerCase' return='975' arguments='975' flags='1024' bytes='0' iicount='1'/>
+<call method='1098' instr='invokevirtual'/>
+<inline_fail reason='no static binding'/>
+<phase_done name='parse_hir' stamp='0.258'/>
+</phase>
+<parse_done stamp='0.258'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.258'>
+<phase_done name='optimize_blocks' stamp='0.258'/>
+</phase>
+<phase name='gvn' stamp='0.258'>
+<phase_done name='gvn' stamp='0.258'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.258'>
+<phase_done name='rangeCheckElimination' stamp='0.258'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.258'>
+<phase_done name='optimize_null_checks' stamp='0.258'/>
+</phase>
+<phase_done name='buildIR' stamp='0.258'/>
+</phase>
+<phase name='emit_lir' stamp='0.258'>
+<phase name='lirGeneration' stamp='0.258'>
+<phase_done name='lirGeneration' stamp='0.258'/>
+</phase>
+<phase name='linearScan' stamp='0.258'>
+<phase_done name='linearScan' stamp='0.258'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.258'/>
+</phase>
+<phase name='codeemit' stamp='0.258'>
+<phase_done name='codeemit' stamp='0.258'/>
+</phase>
+<phase name='codeinstall' stamp='0.258'>
+<phase_done name='codeinstall' stamp='0.258'/>
+</phase>
+<code_cache total_blobs='483' nmethods='169' adapters='163' free_code_cache='248501760'/>
+<task_done success='1' nmsize='568' count='256' stamp='0.258'/>
+</task>
+<task compile_id='173' method='java.util.jar.Attributes$Name isAlpha (C)Z' bytes='30' count='331' iicount='331' level='3' stamp='0.281'>
+<phase name='setup' stamp='0.281'>
+<phase_done name='setup' stamp='0.281'/>
+</phase>
+<phase name='buildIR' stamp='0.281'>
+<type id='969' name='boolean'/>
+<type id='970' name='char'/>
+<klass id='1093' name='java.util.jar.Attributes$Name' flags='9'/>
+<method id='1094' holder='1093' name='isAlpha' return='969' arguments='970' flags='10' bytes='30' iicount='339'/>
+<parse method='1094'  stamp='0.281'>
+<phase name='parse_hir' stamp='0.281'>
+<phase_done name='parse_hir' stamp='0.281'/>
+</phase>
+<parse_done stamp='0.281'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.281'>
+<phase_done name='optimize_blocks' stamp='0.281'/>
+</phase>
+<phase name='gvn' stamp='0.281'>
+<phase_done name='gvn' stamp='0.281'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.281'>
+<phase_done name='rangeCheckElimination' stamp='0.281'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.281'>
+<phase_done name='optimize_null_checks' stamp='0.281'/>
+</phase>
+<phase_done name='buildIR' stamp='0.281'/>
+</phase>
+<phase name='emit_lir' stamp='0.281'>
+<phase name='lirGeneration' stamp='0.281'>
+<phase_done name='lirGeneration' stamp='0.281'/>
+</phase>
+<phase name='linearScan' stamp='0.281'>
+<phase_done name='linearScan' stamp='0.281'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.281'/>
+</phase>
+<phase name='codeemit' stamp='0.281'>
+<phase_done name='codeemit' stamp='0.281'/>
+</phase>
+<phase name='codeinstall' stamp='0.281'>
+<phase_done name='codeinstall' stamp='0.281'/>
+</phase>
+<code_cache total_blobs='517' nmethods='172' adapters='194' free_code_cache='248480640'/>
+<task_done success='1' nmsize='560' count='368' stamp='0.281'/>
+</task>
+<task compile_id='177' method='java.lang.System getSecurityManager ()Ljava/lang/SecurityManager;' bytes='4' count='259' iicount='259' level='3' stamp='0.307'>
+<phase name='setup' stamp='0.307'>
+<phase_done name='setup' stamp='0.307'/>
+</phase>
+<phase name='buildIR' stamp='0.308'>
+<klass id='994' name='java.lang.SecurityManager' flags='1'/>
+<klass id='988' name='java.lang.System' flags='17'/>
+<method id='1093' holder='988' name='getSecurityManager' return='994' flags='9' bytes='4' iicount='259'/>
+<parse method='1093'  stamp='0.308'>
+<phase name='parse_hir' stamp='0.308'>
+<phase_done name='parse_hir' stamp='0.308'/>
+</phase>
+<parse_done stamp='0.308'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.308'>
+<phase_done name='optimize_blocks' stamp='0.308'/>
+</phase>
+<phase name='gvn' stamp='0.308'>
+<phase_done name='gvn' stamp='0.308'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.308'>
+<phase_done name='rangeCheckElimination' stamp='0.308'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.308'>
+<phase_done name='optimize_null_checks' stamp='0.308'/>
+</phase>
+<phase_done name='buildIR' stamp='0.308'/>
+</phase>
+<phase name='emit_lir' stamp='0.308'>
+<phase name='lirGeneration' stamp='0.308'>
+<phase_done name='lirGeneration' stamp='0.308'/>
+</phase>
+<phase name='linearScan' stamp='0.308'>
+<phase_done name='linearScan' stamp='0.308'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.308'/>
+</phase>
+<phase name='codeemit' stamp='0.308'>
+<phase_done name='codeemit' stamp='0.308'/>
+</phase>
+<phase name='codeinstall' stamp='0.308'>
+<phase_done name='codeinstall' stamp='0.308'/>
+</phase>
+<code_cache total_blobs='526' nmethods='177' adapters='198' free_code_cache='248472192'/>
+<task_done success='1' nmsize='336' count='259' stamp='0.308'/>
+</task>
+<task compile_id='181' method='java.lang.StringLatin1 lastIndexOf ([BII)I' bytes='40' count='132' backedge_count='1951' iicount='132' level='3' stamp='0.312'>
+<phase name='setup' stamp='0.312'>
+<phase_done name='setup' stamp='0.312'/>
+</phase>
+<phase name='buildIR' stamp='0.312'>
+<type id='975' name='int'/>
+<klass id='1085' name='[B' flags='1041'/>
+<klass id='1093' name='java.lang.StringLatin1' flags='16'/>
+<method id='1094' holder='1093' name='lastIndexOf' return='975' arguments='1085 975 975' flags='9' bytes='40' iicount='132'/>
+<parse method='1094'  stamp='0.312'>
+<phase name='parse_hir' stamp='0.312'>
+<bc code='184' bci='1'/>
+<type id='969' name='boolean'/>
+<method id='1096' holder='1093' name='canEncode' return='969' arguments='975' flags='9' bytes='13' compile_id='49' compiler='c1' level='3' iicount='1279'/>
+<call method='1096' instr='invokestatic'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1096'>
+<parse_done stamp='0.312'/>
+</parse>
+<bc code='184' bci='14'/>
+<klass id='1098' name='java.lang.Math' flags='17'/>
+<method id='1099' holder='1098' name='min' return='975' arguments='975 975' flags='9' bytes='11' compile_id='118' compiler='c1' level='3' iicount='740'/>
+<call method='1099' instr='invokestatic'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1099'>
+<parse_done stamp='0.312'/>
+</parse>
+<phase_done name='parse_hir' stamp='0.312'/>
+</phase>
+<parse_done stamp='0.312'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.312'>
+<phase_done name='optimize_blocks' stamp='0.312'/>
+</phase>
+<phase name='gvn' stamp='0.312'>
+<phase_done name='gvn' stamp='0.312'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.312'>
+<phase_done name='rangeCheckElimination' stamp='0.312'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.312'>
+<phase_done name='optimize_null_checks' stamp='0.312'/>
+</phase>
+<phase_done name='buildIR' stamp='0.312'/>
+</phase>
+<phase name='emit_lir' stamp='0.312'>
+<phase name='lirGeneration' stamp='0.312'>
+<phase_done name='lirGeneration' stamp='0.312'/>
+</phase>
+<phase name='linearScan' stamp='0.312'>
+<phase_done name='linearScan' stamp='0.312'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.312'/>
+</phase>
+<phase name='codeemit' stamp='0.312'>
+<phase_done name='codeemit' stamp='0.313'/>
+</phase>
+<phase name='codeinstall' stamp='0.313'>
+<phase_done name='codeinstall' stamp='0.313'/>
+</phase>
+<code_cache total_blobs='530' nmethods='181' adapters='198' free_code_cache='248465408'/>
+<task_done success='1' nmsize='1040' count='133' backedge_count='1972' inlined_bytes='24' stamp='0.313'/>
+</task>
+<task compile_id='186' method='java.util.Arrays copyOfRange ([BII)[B' bytes='63' count='284' iicount='284' level='3' stamp='0.322'>
+<phase name='setup' stamp='0.322'>
+<phase_done name='setup' stamp='0.322'/>
+</phase>
+<phase name='buildIR' stamp='0.322'>
+<klass id='1085' name='[B' flags='1041'/>
+<type id='975' name='int'/>
+<klass id='1093' name='java.util.Arrays' flags='1'/>
+<method id='1094' holder='1093' name='copyOfRange' return='1085' arguments='1085 975 975' flags='9' bytes='63' iicount='284'/>
+<parse method='1094'  stamp='0.322'>
+<phase name='parse_hir' stamp='0.322'>
+<bc code='183' bci='16'/>
+<type id='977' name='void'/>
+<klass id='1050' name='java.lang.StringBuilder' flags='17'/>
+<method id='1097' holder='1050' name='&lt;init&gt;' return='977' flags='1' bytes='7' iicount='135'/>
+<call method='1097' instr='invokespecial'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1097'>
+<bc code='183' bci='3'/>
+<klass id='1048' name='java.lang.AbstractStringBuilder' flags='1024'/>
+<method id='1099' holder='1048' name='&lt;init&gt;' return='977' arguments='975' flags='0' bytes='39' iicount='140'/>
+<call method='1099' instr='invokespecial'/>
+<inline_fail reason='callee is too large'/>
+<parse_done stamp='0.322'/>
+</parse>
+<bc code='182' bci='20'/>
+<method id='1101' holder='1050' name='append' return='1050' arguments='975' flags='1' bytes='8' iicount='6'/>
+<call method='1101' instr='invokevirtual'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1101'>
+<bc code='183' bci='2'/>
+<method id='1103' holder='1048' name='append' return='1048' arguments='975' flags='1' bytes='55' iicount='6'/>
+<call method='1103' instr='invokespecial'/>
+<inline_fail reason='callee is too large'/>
+<parse_done stamp='0.322'/>
+</parse>
+<bc code='182' bci='25'/>
+<klass id='983' name='java.lang.String' flags='17'/>
+<method id='1106' holder='1050' name='append' return='1050' arguments='983' flags='1' bytes='8' compile_id='182' compiler='c1' level='3' iicount='284'/>
+<call method='1106' instr='invokevirtual'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1106'>
+<bc code='183' bci='2'/>
+<method id='1108' holder='1048' name='append' return='1048' arguments='983' flags='1' bytes='45' compile_id='183' compiler='c1' level='3' iicount='284'/>
+<call method='1108' instr='invokespecial'/>
+<inline_fail reason='callee is too large'/>
+<parse_done stamp='0.322'/>
+</parse>
+<bc code='182' bci='29'/>
+<call method='1101' instr='invokevirtual'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1101'>
+<bc code='183' bci='2'/>
+<call method='1103' instr='invokespecial'/>
+<inline_fail reason='callee is too large'/>
+<parse_done stamp='0.322'/>
+</parse>
+<bc code='182' bci='32'/>
+<method id='1110' holder='1050' name='toString' return='983' flags='1' bytes='35' iicount='139'/>
+<call method='1110' instr='invokevirtual'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1110'>
+<bc code='182' bci='1'/>
+<type id='969' name='boolean'/>
+<method id='1112' holder='1048' name='isLatin1' return='969' flags='16' bytes='19' iicount='276'/>
+<call method='1112' instr='invokevirtual'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1112'>
+<parse_done stamp='0.322'/>
+</parse>
+<bc code='184' bci='16'/>
+<klass id='1115' name='java.lang.StringLatin1' flags='16'/>
+<method id='1116' holder='1115' name='newString' return='983' arguments='1085 975 975' flags='9' bytes='17' iicount='267'/>
+<call method='1116' instr='invokestatic'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1116'>
+<bc code='184' bci='9'/>
+<call method='1094' instr='invokestatic'/>
+<inline_fail reason='callee is too large'/>
+<bc code='183' bci='13'/>
+<type id='973' name='byte'/>
+<method id='1118' holder='983' name='&lt;init&gt;' return='977' arguments='1085 973' flags='0' bytes='15' compile_id='174' compiler='c1' level='3' iicount='426'/>
+<call method='1118' instr='invokespecial'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1118'>
+<bc code='183' bci='1'/>
+<klass id='982' name='java.lang.Object' flags='1'/>
+<method id='1120' holder='982' name='&lt;init&gt;' return='977' flags='1' bytes='1' compile_id='50' compiler='c1' level='1' iicount='10195'/>
+<call method='1120' instr='invokespecial'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1120'>
+<parse_done stamp='0.322'/>
+</parse>
+<parse_done stamp='0.322'/>
+</parse>
+<parse_done stamp='0.322'/>
+</parse>
+<bc code='184' bci='31'/>
+<klass id='1122' name='java.lang.StringUTF16' flags='16'/>
+<method id='1123' holder='1122' name='newString' return='983' arguments='1085 975 975' flags='9' bytes='50' iicount='1'/>
+<call method='1123' instr='invokestatic'/>
+<inline_fail reason='callee is too large'/>
+<parse_done stamp='0.322'/>
+</parse>
+<bc code='183' bci='35'/>
+<klass id='1096' name='java.lang.IllegalArgumentException' flags='1'/>
+<method id='1125' holder='1096' name='&lt;init&gt;' return='977' arguments='983' flags='1' bytes='6' iicount='1'/>
+<call method='1125' instr='invokespecial'/>
+<inline_fail reason='don&apos;t inline Throwable constructors'/>
+<bc code='184' bci='54'/>
+<klass id='1127' name='java.lang.Math' flags='17'/>
+<method id='1128' holder='1127' name='min' return='975' arguments='975 975' flags='9' bytes='11' compile_id='118' compiler='c1' level='3' iicount='870'/>
+<call method='1128' instr='invokestatic'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1128'>
+<parse_done stamp='0.322'/>
+</parse>
+<bc code='184' bci='57'/>
+<klass id='988' name='java.lang.System' flags='17'/>
+<method id='1130' holder='988' name='arraycopy' return='977' arguments='982 975 982 975 975' flags='265' bytes='0' compile_id='44' compile_kind='c2n' compiler='' level='0' iicount='256'/>
+<call method='1130' instr='invokestatic'/>
+<inline_success reason='intrinsic'/>
+<phase_done name='parse_hir' stamp='0.323'/>
+</phase>
+<parse_done stamp='0.323'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.323'>
+<phase_done name='optimize_blocks' stamp='0.323'/>
+</phase>
+<phase name='gvn' stamp='0.323'>
+<phase_done name='gvn' stamp='0.323'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.323'>
+<phase_done name='rangeCheckElimination' stamp='0.323'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.323'>
+<phase_done name='optimize_null_checks' stamp='0.323'/>
+</phase>
+<phase_done name='buildIR' stamp='0.323'/>
+</phase>
+<phase name='emit_lir' stamp='0.323'>
+<phase name='lirGeneration' stamp='0.323'>
+<phase_done name='lirGeneration' stamp='0.323'/>
+</phase>
+<phase name='linearScan' stamp='0.323'>
+<phase_done name='linearScan' stamp='0.323'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.323'/>
+</phase>
+<phase name='codeemit' stamp='0.323'>
+<phase_done name='codeemit' stamp='0.323'/>
+</phase>
+<phase name='codeinstall' stamp='0.323'>
+<phase_done name='codeinstall' stamp='0.323'/>
+</phase>
+<code_cache total_blobs='557' nmethods='186' adapters='220' free_code_cache='248439808'/>
+<task_done success='1' nmsize='3512' count='284' inlined_bytes='129' stamp='0.323'/>
+</task>
+<task compile_id='188' method='java.lang.ref.Reference &lt;init&gt; (Ljava/lang/Object;Ljava/lang/ref/ReferenceQueue;)V' bytes='25' count='257' iicount='257' level='3' stamp='0.323'>
+<phase name='setup' stamp='0.323'>
+<phase_done name='setup' stamp='0.323'/>
+</phase>
+<phase name='buildIR' stamp='0.323'>
+<type id='977' name='void'/>
+<klass id='982' name='java.lang.Object' flags='1'/>
+<klass id='1093' name='java.lang.ref.ReferenceQueue' flags='1'/>
+<klass id='1008' name='java.lang.ref.Reference' flags='1025'/>
+<method id='1094' holder='1008' name='&lt;init&gt;' return='977' arguments='982 1093' flags='0' bytes='25' iicount='261'/>
+<parse method='1094'  stamp='0.323'>
+<phase name='parse_hir' stamp='0.323'>
+<bc code='183' bci='1'/>
+<method id='1096' holder='982' name='&lt;init&gt;' return='977' flags='1' bytes='1' compile_id='50' compiler='c1' level='1' iicount='10202'/>
+<call method='1096' instr='invokespecial'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1096'>
+<bc code='177' bci='0'/>
+<dependency type='no_finalizable_subclasses' ctxk='1008'/>
+<parse_done stamp='0.323'/>
+</parse>
+<phase_done name='parse_hir' stamp='0.323'/>
+</phase>
+<parse_done stamp='0.323'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.323'>
+<phase_done name='optimize_blocks' stamp='0.323'/>
+</phase>
+<phase name='gvn' stamp='0.323'>
+<phase_done name='gvn' stamp='0.323'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.323'>
+<phase_done name='rangeCheckElimination' stamp='0.323'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.323'>
+<phase_done name='optimize_null_checks' stamp='0.323'/>
+</phase>
+<phase_done name='buildIR' stamp='0.323'/>
+</phase>
+<phase name='emit_lir' stamp='0.323'>
+<phase name='lirGeneration' stamp='0.323'>
+<phase_done name='lirGeneration' stamp='0.323'/>
+</phase>
+<phase name='linearScan' stamp='0.323'>
+<phase_done name='linearScan' stamp='0.323'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.323'/>
+</phase>
+<phase name='codeemit' stamp='0.323'>
+<phase_done name='codeemit' stamp='0.323'/>
+</phase>
+<phase name='codeinstall' stamp='0.323'>
+<dependency type='no_finalizable_subclasses' ctxk='1008'/>
+<phase_done name='codeinstall' stamp='0.323'/>
+</phase>
+<code_cache total_blobs='560' nmethods='189' adapters='220' free_code_cache='248437120'/>
+<task_done success='1' nmsize='752' count='271' inlined_bytes='1' stamp='0.323'/>
+</task>
+<task compile_id='191' method='java.util.concurrent.ConcurrentHashMap get (Ljava/lang/Object;)Ljava/lang/Object;' bytes='162' count='257' backedge_count='6' iicount='257' level='3' stamp='0.323'>
+<phase name='setup' stamp='0.323'>
+<phase_done name='setup' stamp='0.323'/>
+</phase>
+<phase name='buildIR' stamp='0.323'>
+<klass id='982' name='java.lang.Object' flags='1'/>
+<klass id='1093' name='java.util.concurrent.ConcurrentHashMap' flags='1'/>
+<method id='1094' holder='1093' name='get' return='982' arguments='982' flags='1' bytes='162' iicount='257'/>
+<parse method='1094'  stamp='0.323'>
+<phase name='parse_hir' stamp='0.323'>
+<bc code='182' bci='1'/>
+<type id='975' name='int'/>
+<method id='1096' holder='982' name='hashCode' return='975' flags='257' bytes='0' compile_id='93' compile_kind='c2n' compiler='' level='0' iicount='256'/>
+<call method='1096' instr='invokevirtual'/>
+<inline_fail reason='no static binding'/>
+<bc code='184' bci='4'/>
+<method id='1097' holder='1093' name='spread' return='975' arguments='975' flags='24' bytes='10' compile_id='54' compiler='c1' level='3' iicount='1697'/>
+<call method='1097' instr='invokestatic'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1097'>
+<parse_done stamp='0.324'/>
+</parse>
+<bc code='184' bci='34'/>
+<klass id='1099' name='java.util.concurrent.ConcurrentHashMap$Node' flags='8'/>
+<klass id='1100' name='[Ljava.util.concurrent.ConcurrentHashMap$Node;' flags='1040'/>
+<method id='1101' holder='1093' name='tabAt' return='1099' arguments='1100 975' flags='24' bytes='22' compile_id='51' compiler='c1' level='3' iicount='2945'/>
+<call method='1101' instr='invokestatic'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1101'>
+<bc code='182' bci='15'/>
+<type id='976' name='long'/>
+<klass id='1051' name='jdk.internal.misc.Unsafe' flags='17'/>
+<method id='1106' holder='1051' name='getObjectAcquire' return='982' arguments='982 976' flags='17' bytes='7' compile_id='52' compiler='c1' level='3' iicount='2945'/>
+<call method='1106' instr='invokevirtual'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1106'>
+<bc code='182' bci='3'/>
+<method id='1108' holder='1051' name='getObjectVolatile' return='982' arguments='982 976' flags='257' bytes='0' compile_id='53' compile_kind='c2n' compiler='' level='0' iicount='640'/>
+<call method='1108' instr='invokevirtual'/>
+<inline_success reason='intrinsic'/>
+<parse_done stamp='0.324'/>
+</parse>
+<parse_done stamp='0.324'/>
+</parse>
+<bc code='182' bci='73'/>
+<type id='969' name='boolean'/>
+<method id='1109' holder='982' name='equals' return='969' arguments='982' flags='1' bytes='11' iicount='4'/>
+<call method='1109' instr='invokevirtual'/>
+<inline_fail reason='no static binding'/>
+<bc code='182' bci='93'/>
+<method id='1110' holder='1099' name='find' return='1099' arguments='975 982' flags='0' bytes='52' iicount='1'/>
+<call method='1110' instr='invokevirtual'/>
+<inline_fail reason='no static binding'/>
+<bc code='182' bci='149'/>
+<call method='1109' instr='invokevirtual'/>
+<inline_fail reason='no static binding'/>
+<phase_done name='parse_hir' stamp='0.324'/>
+</phase>
+<parse_done stamp='0.324'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.324'>
+<phase_done name='optimize_blocks' stamp='0.324'/>
+</phase>
+<phase name='gvn' stamp='0.324'>
+<phase_done name='gvn' stamp='0.324'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.324'>
+<phase_done name='rangeCheckElimination' stamp='0.324'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.324'>
+<phase_done name='optimize_null_checks' stamp='0.324'/>
+</phase>
+<phase_done name='buildIR' stamp='0.324'/>
+</phase>
+<phase name='emit_lir' stamp='0.324'>
+<phase name='lirGeneration' stamp='0.324'>
+<phase_done name='lirGeneration' stamp='0.324'/>
+</phase>
+<phase name='linearScan' stamp='0.324'>
+<phase_done name='linearScan' stamp='0.324'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.324'/>
+</phase>
+<phase name='codeemit' stamp='0.324'>
+<phase_done name='codeemit' stamp='0.324'/>
+</phase>
+<phase name='codeinstall' stamp='0.324'>
+<phase_done name='codeinstall' stamp='0.324'/>
+</phase>
+<code_cache total_blobs='563' nmethods='192' adapters='220' free_code_cache='248430592'/>
+<task_done success='1' nmsize='3288' count='268' backedge_count='6' inlined_bytes='39' stamp='0.324'/>
+</task>
+<task compile_id='206' method='java.lang.ref.Reference &lt;init&gt; (Ljava/lang/Object;)V' bytes='7' count='256' iicount='256' level='3' stamp='0.330'>
+<phase name='setup' stamp='0.330'>
+<phase_done name='setup' stamp='0.330'/>
+</phase>
+<phase name='buildIR' stamp='0.330'>
+<type id='977' name='void'/>
+<klass id='982' name='java.lang.Object' flags='1'/>
+<klass id='1008' name='java.lang.ref.Reference' flags='1025'/>
+<method id='1093' holder='1008' name='&lt;init&gt;' return='977' arguments='982' flags='0' bytes='7' iicount='256'/>
+<parse method='1093'  stamp='0.330'>
+<phase name='parse_hir' stamp='0.330'>
+<bc code='183' bci='3'/>
+<klass id='1095' name='java.lang.ref.ReferenceQueue' flags='1'/>
+<method id='1096' holder='1008' name='&lt;init&gt;' return='977' arguments='982 1095' flags='0' bytes='25' compile_id='188' compiler='c1' level='3' iicount='395'/>
+<call method='1096' instr='invokespecial'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1096'>
+<bc code='183' bci='1'/>
+<method id='1098' holder='982' name='&lt;init&gt;' return='977' flags='1' bytes='1' compile_id='50' compiler='c1' level='1' iicount='10405'/>
+<call method='1098' instr='invokespecial'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1098'>
+<bc code='177' bci='0'/>
+<dependency type='no_finalizable_subclasses' ctxk='1008'/>
+<parse_done stamp='0.330'/>
+</parse>
+<parse_done stamp='0.330'/>
+</parse>
+<phase_done name='parse_hir' stamp='0.330'/>
+</phase>
+<parse_done stamp='0.330'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.330'>
+<phase_done name='optimize_blocks' stamp='0.330'/>
+</phase>
+<phase name='gvn' stamp='0.330'>
+<phase_done name='gvn' stamp='0.330'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.330'>
+<phase_done name='rangeCheckElimination' stamp='0.330'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.330'>
+<phase_done name='optimize_null_checks' stamp='0.330'/>
+</phase>
+<phase_done name='buildIR' stamp='0.330'/>
+</phase>
+<phase name='emit_lir' stamp='0.330'>
+<phase name='lirGeneration' stamp='0.330'>
+<phase_done name='lirGeneration' stamp='0.330'/>
+</phase>
+<phase name='linearScan' stamp='0.330'>
+<phase_done name='linearScan' stamp='0.330'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.330'/>
+</phase>
+<phase name='codeemit' stamp='0.330'>
+<phase_done name='codeemit' stamp='0.330'/>
+</phase>
+<phase name='codeinstall' stamp='0.330'>
+<dependency type='no_finalizable_subclasses' ctxk='1008'/>
+<phase_done name='codeinstall' stamp='0.330'/>
+</phase>
+<code_cache total_blobs='581' nmethods='205' adapters='225' free_code_cache='248417664'/>
+<task_done success='1' nmsize='784' count='256' inlined_bytes='26' stamp='0.330'/>
+</task>
+<task compile_id='218' method='java.lang.invoke.MethodType$ConcurrentWeakInternSet expungeStaleElements ()V' bytes='27' count='256' iicount='256' level='3' stamp='0.336'>
+<phase name='setup' stamp='0.336'>
+<phase_done name='setup' stamp='0.336'/>
+</phase>
+<phase name='buildIR' stamp='0.336'>
+<type id='977' name='void'/>
+<klass id='1093' name='java.lang.invoke.MethodType$ConcurrentWeakInternSet' flags='10'/>
+<method id='1094' holder='1093' name='expungeStaleElements' return='977' flags='2' bytes='27' iicount='257'/>
+<parse method='1094'  stamp='0.336'>
+<phase name='parse_hir' stamp='0.336'>
+<bc code='182' bci='4'/>
+<klass id='1008' name='java.lang.ref.Reference' flags='1025'/>
+<klass id='1096' name='java.lang.ref.ReferenceQueue' flags='1'/>
+<method id='1097' holder='1096' name='poll' return='1008' flags='1' bytes='28' compile_id='209' compiler='c1' level='3' iicount='314'/>
+<call method='1097' instr='invokevirtual'/>
+<dependency type='unique_concrete_method' ctxk='1096' x='1097'/>
+<inline_success reason='receiver is statically known'/>
+<parse method='1097'>
+<bc code='183' bci='17'/>
+<method id='1100' holder='1096' name='reallyPoll' return='1008' flags='2' bytes='65' iicount='2'/>
+<call method='1100' instr='invokespecial'/>
+<inline_fail reason='callee is too large'/>
+<parse_done stamp='0.336'/>
+</parse>
+<bc code='185' bci='17'/>
+<klass id='982' name='java.lang.Object' flags='1'/>
+<klass id='1102' name='java.util.concurrent.ConcurrentMap' flags='1537'/>
+<method id='1103' holder='1102' name='remove' return='982' arguments='982' flags='4161' bytes='10' iicount='1'/>
+<call method='1103' instr='invokeinterface'/>
+<inline_fail reason='no static binding'/>
+<phase_done name='parse_hir' stamp='0.337'/>
+</phase>
+<parse_done stamp='0.337'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.337'>
+<phase_done name='optimize_blocks' stamp='0.337'/>
+</phase>
+<phase name='gvn' stamp='0.337'>
+<phase_done name='gvn' stamp='0.337'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.337'>
+<phase_done name='rangeCheckElimination' stamp='0.337'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.337'>
+<phase_done name='optimize_null_checks' stamp='0.337'/>
+</phase>
+<phase_done name='buildIR' stamp='0.337'/>
+</phase>
+<phase name='emit_lir' stamp='0.337'>
+<phase name='lirGeneration' stamp='0.337'>
+<phase_done name='lirGeneration' stamp='0.337'/>
+</phase>
+<phase name='linearScan' stamp='0.337'>
+<phase_done name='linearScan' stamp='0.337'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.337'/>
+</phase>
+<phase name='codeemit' stamp='0.337'>
+<phase_done name='codeemit' stamp='0.337'/>
+</phase>
+<phase name='codeinstall' stamp='0.337'>
+<dependency type='unique_concrete_method' ctxk='1096' x='1097'/>
+<phase_done name='codeinstall' stamp='0.337'/>
+</phase>
+<code_cache total_blobs='604' nmethods='219' adapters='232' free_code_cache='248393984'/>
+<task_done success='1' nmsize='1496' count='265' inlined_bytes='28' stamp='0.337'/>
+</task>
+<task compile_id='224' method='jdk.internal.org.objectweb.asm.ClassWriter get (Ljdk/internal/org/objectweb/asm/Item;)Ljdk/internal/org/objectweb/asm/Item;' bytes='49' count='273' backedge_count='3' iicount='273' level='3' stamp='0.339'>
+<phase name='setup' stamp='0.339'>
+<phase_done name='setup' stamp='0.339'/>
+</phase>
+<phase name='buildIR' stamp='0.339'>
+<klass id='1094' name='jdk.internal.org.objectweb.asm.Item' flags='16'/>
+<klass id='1093' name='jdk.internal.org.objectweb.asm.ClassWriter' flags='1'/>
+<method id='1095' holder='1093' name='get' return='1094' arguments='1094' flags='2' bytes='49' iicount='276'/>
+<parse method='1095'  stamp='0.339'>
+<phase name='parse_hir' stamp='0.339'>
+<bc code='182' bci='33'/>
+<type id='969' name='boolean'/>
+<method id='1098' holder='1094' name='isEqualTo' return='969' arguments='1094' flags='0' bytes='354' iicount='106'/>
+<call method='1098' instr='invokevirtual'/>
+<inline_fail reason='callee is too large'/>
+<phase_done name='parse_hir' stamp='0.339'/>
+</phase>
+<parse_done stamp='0.339'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.339'>
+<phase_done name='optimize_blocks' stamp='0.339'/>
+</phase>
+<phase name='gvn' stamp='0.339'>
+<phase_done name='gvn' stamp='0.339'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.339'>
+<phase_done name='rangeCheckElimination' stamp='0.339'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.339'>
+<phase_done name='optimize_null_checks' stamp='0.339'/>
+</phase>
+<phase_done name='buildIR' stamp='0.339'/>
+</phase>
+<phase name='emit_lir' stamp='0.339'>
+<phase name='lirGeneration' stamp='0.339'>
+<phase_done name='lirGeneration' stamp='0.339'/>
+</phase>
+<phase name='linearScan' stamp='0.339'>
+<phase_done name='linearScan' stamp='0.339'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.339'/>
+</phase>
+<phase name='codeemit' stamp='0.339'>
+<phase_done name='codeemit' stamp='0.339'/>
+</phase>
+<phase name='codeinstall' stamp='0.339'>
+<phase_done name='codeinstall' stamp='0.339'/>
+</phase>
+<code_cache total_blobs='610' nmethods='223' adapters='234' free_code_cache='248385664'/>
+<task_done success='1' nmsize='936' count='285' backedge_count='5' stamp='0.339'/>
+</task>
+<task compile_id='230' method='java.nio.Buffer position ()I' bytes='5' count='147' iicount='147' level='1' stamp='0.342'>
+<phase name='setup' stamp='0.342'>
+<phase_done name='setup' stamp='0.342'/>
+</phase>
+<phase name='buildIR' stamp='0.342'>
+<type id='975' name='int'/>
+<klass id='1064' name='java.nio.Buffer' flags='1025'/>
+<method id='1093' holder='1064' name='position' return='975' flags='17' bytes='5' iicount='147'/>
+<parse method='1093'  stamp='0.342'>
+<phase name='parse_hir' stamp='0.342'>
+<phase_done name='parse_hir' stamp='0.342'/>
+</phase>
+<parse_done stamp='0.342'/>
+</parse>
+<phase name='optimize_blocks' stamp='0.342'>
+<phase_done name='optimize_blocks' stamp='0.342'/>
+</phase>
+<phase name='gvn' stamp='0.342'>
+<phase_done name='gvn' stamp='0.342'/>
+</phase>
+<phase name='rangeCheckElimination' stamp='0.342'>
+<phase_done name='rangeCheckElimination' stamp='0.342'/>
+</phase>
+<phase name='optimize_null_checks' stamp='0.342'>
+<phase_done name='optimize_null_checks' stamp='0.342'/>
+</phase>
+<phase_done name='buildIR' stamp='0.342'/>
+</phase>
+<phase name='emit_lir' stamp='0.342'>
+<phase name='lirGeneration' stamp='0.342'>
+<phase_done name='lirGeneration' stamp='0.342'/>
+</phase>
+<phase name='linearScan' stamp='0.342'>
+<phase_done name='linearScan' stamp='0.342'/>
+</phase>
+<phase_done name='emit_lir' stamp='0.342'/>
+</phase>
+<phase name='codeemit' stamp='0.342'>
+<phase_done name='codeemit' stamp='0.342'/>
+</phase>
+<phase name='codeinstall' stamp='0.342'>
+<phase_done name='codeinstall' stamp='0.342'/>
+</phase>
+<code_cache total_blobs='616' nmethods='229' adapters='234' free_code_cache='248379264'/>
+<task_done success='1' nmsize='272' count='147' stamp='0.342'/>
+</task>
+</compilation_log>
+<compilation_log thread='23812'>
+<start_compile_thread name='C2 CompilerThread7' thread='23812' process='23756' stamp='0.179'/>
+<task compile_id='20' method='java.lang.StringLatin1 hashCode ([B)I' bytes='42' count='783' backedge_count='18648' iicount='783' stamp='0.212'>
+<type id='975' name='int'/>
+<klass id='1085' name='[B' flags='1041'/>
+<klass id='1093' name='java.lang.StringLatin1' flags='16'/>
+<method id='1094' holder='1093' name='hashCode' return='975' arguments='1085' flags='9' bytes='42' compile_id='2' compiler='c1' level='3' iicount='783'/>
+<parse method='1094' uses='783.000000' stamp='0.213'>
+<bc code='190' bci='5'/>
+<uncommon_trap bci='5' reason='null_check' action='maybe_recompile' debug_id='0'/>
+<bc code='162' bci='13'/>
+<branch target_bci='40' taken='669' not_taken='16406' cnt='17075.000000' prob='0.0391801'/>
+<uncommon_trap bci='16' reason='predicate' action='maybe_recompile' debug_id='0'/>
+<uncommon_trap bci='16' reason='loop_limit_check' action='maybe_recompile' debug_id='0'/>
+<bc code='51' bci='19'/>
+<uncommon_trap bci='19' reason='range_check' action='make_not_entrant' debug_id='0' comment='range_check'/>
+<bc code='162' bci='13'/>
+<branch target_bci='40' taken='669' not_taken='16406' cnt='16406.000000' prob='0.0391801'/>
+<parse_done nodes='137' live='132' memory='40872' stamp='0.213'/>
+</parse>
+<loop_tree>
+<loop idx='146' >
+</loop>
+</loop_tree>
+<loop_tree>
+<loop idx='239' inner_loop='1' main_loop='239' >
+</loop>
+</loop_tree>
+<loop_tree>
+<loop idx='206' inner_loop='1' pre_loop='146' >
+</loop>
+<loop idx='275' inner_loop='1' main_loop='275' >
+</loop>
+<loop idx='180' inner_loop='1' post_loop='146' >
+</loop>
+</loop_tree>
+<loop_tree>
+<loop idx='206' inner_loop='1' pre_loop='146' >
+</loop>
+<loop idx='275' inner_loop='1' main_loop='275' >
+</loop>
+<loop idx='180' inner_loop='1' post_loop='146' >
+</loop>
+</loop_tree>
+<loop_tree>
+<loop idx='206' inner_loop='1' pre_loop='146' >
+</loop>
+<loop idx='275' inner_loop='1' main_loop='275' >
+</loop>
+<loop idx='180' inner_loop='1' post_loop='146' >
+</loop>
+</loop_tree>
+<loop_tree>
+<loop idx='206' inner_loop='1' pre_loop='146' >
+</loop>
+<loop idx='275' inner_loop='1' main_loop='275' >
+</loop>
+<loop idx='180' inner_loop='1' post_loop='146' >
+</loop>
+</loop_tree>
+<regalloc attempts='0' success='1'/>
+<code_cache total_blobs='331' nmethods='30' adapters='158' free_code_cache='248721536'/>
+<task_done success='1' nmsize='312' count='2097' backedge_count='65738' stamp='0.216'/>
+</task>
+</compilation_log>
+<compilation_log thread='23811'>
+<start_compile_thread name='C2 CompilerThread6' thread='23811' process='23756' stamp='0.178'/>
+<task compile_id='81' method='java.lang.String hashCode ()I' bytes='49' count='5505' iicount='5505' stamp='0.238'>
+<type id='975' name='int'/>
+<klass id='983' name='java.lang.String' flags='17'/>
+<method id='1093' holder='983' name='hashCode' return='975' flags='1' bytes='49' compile_id='10' compiler='c1' level='3' iicount='5513'/>
+<parse method='1093' uses='5513.000000' stamp='0.239'>
+<bc code='154' bci='6'/>
+<branch target_bci='47' taken='3042' not_taken='2471' cnt='5513.000000' prob='0.551787'/>
+<bc code='190' bci='13'/>
+<uncommon_trap bci='13' reason='null_check' action='maybe_recompile' debug_id='0'/>
+<bc code='158' bci='14'/>
+<branch target_bci='47' taken='51' not_taken='2420' cnt='2471.000000' prob='0.0206394'/>
+<bc code='183' bci='19'/>
+<type id='969' name='boolean'/>
+<method id='1095' holder='983' name='isLatin1' return='969' flags='2' bytes='19' compile_id='5' compiler='c1' level='3' iicount='6353'/>
+<call method='1095' count='2263' prof_factor='1.000000' inline='1'/>
+<inline_success reason='inline (hot)'/>
+<parse method='1095' uses='2420.000000' stamp='0.239'>
+<bc code='153' bci='3'/>
+<branch target_bci='17' taken='0' not_taken='6353' cnt='6353.000000' prob='never'/>
+<bc code='154' bci='10'/>
+<branch target_bci='17' taken='1' not_taken='6352' cnt='6353.000000' prob='0.000157406'/>
+<parse_done nodes='101' live='99' memory='32696' stamp='0.239'/>
+</parse>
+<bc code='153' bci='22'/>
+<branch target_bci='35' taken='0' not_taken='2420' cnt='2420.000000' prob='never'/>
+<uncommon_trap bci='22' reason='unstable_if' action='reinterpret' debug_id='0' comment='taken never'/>
+<bc code='184' bci='29'/>
+<klass id='1085' name='[B' flags='1041'/>
+<klass id='1098' name='java.lang.StringLatin1' flags='16'/>
+<method id='1099' holder='1098' name='hashCode' return='975' arguments='1085' flags='9' bytes='42' compile_id='20' compiler='c2' level='4' iicount='2097'/>
+<call method='1099' count='2263' prof_factor='1.000000' inline='1'/>
+<inline_success reason='inline (hot)'/>
+<parse method='1099' uses='2420.000000' stamp='0.239'>
+<bc code='190' bci='5'/>
+<uncommon_trap bci='5' reason='null_check' action='maybe_recompile' debug_id='0'/>
+<bc code='162' bci='13'/>
+<branch target_bci='40' taken='1983' not_taken='63496' cnt='65479.000000' prob='0.0302845'/>
+<uncommon_trap bci='16' reason='predicate' action='maybe_recompile' debug_id='0'/>
+<uncommon_trap bci='16' reason='loop_limit_check' action='maybe_recompile' debug_id='0'/>
+<bc code='51' bci='19'/>
+<uncommon_trap bci='19' reason='range_check' action='make_not_entrant' debug_id='0' comment='range_check'/>
+<bc code='162' bci='13'/>
+<branch target_bci='40' taken='1983' not_taken='63496' cnt='63496.000000' prob='0.0302845'/>
+<parse_done nodes='241' live='233' memory='56072' stamp='0.239'/>
+</parse>
+<parse_done nodes='248' live='239' memory='57464' stamp='0.239'/>
+</parse>
+<loop_tree>
+<loop idx='259' >
+</loop>
+</loop_tree>
+<loop_tree>
+<loop idx='349' inner_loop='1' main_loop='349' >
+</loop>
+</loop_tree>
+<loop_tree>
+<loop idx='316' inner_loop='1' pre_loop='259' >
+</loop>
+<loop idx='388' inner_loop='1' main_loop='388' >
+</loop>
+<loop idx='289' inner_loop='1' post_loop='259' >
+</loop>
+</loop_tree>
+<loop_tree>
+<loop idx='316' inner_loop='1' pre_loop='259' >
+</loop>
+<loop idx='388' inner_loop='1' main_loop='388' >
+</loop>
+<loop idx='289' inner_loop='1' post_loop='259' >
+</loop>
+</loop_tree>
+<loop_tree>
+<loop idx='316' inner_loop='1' pre_loop='259' >
+</loop>
+<loop idx='388' inner_loop='1' main_loop='388' >
+</loop>
+<loop idx='289' inner_loop='1' post_loop='259' >
+</loop>
+</loop_tree>
+<loop_tree>
+<loop idx='316' inner_loop='1' pre_loop='259' >
+</loop>
+<loop idx='388' inner_loop='1' main_loop='388' >
+</loop>
+<loop idx='289' inner_loop='1' post_loop='259' >
+</loop>
+</loop_tree>
+<regalloc attempts='0' success='1'/>
+<code_cache total_blobs='417' nmethods='110' adapters='162' free_code_cache='248577664'/>
+<task_done success='1' nmsize='440' count='6415' inlined_bytes='61' stamp='0.243'/>
+</task>
+<task compile_id='119' method='java.lang.String isLatin1 ()Z' bytes='19' count='6663' iicount='6664' stamp='0.244'>
+<type id='969' name='boolean'/>
+<klass id='983' name='java.lang.String' flags='17'/>
+<method id='1093' holder='983' name='isLatin1' return='969' flags='2' bytes='19' compile_id='5' compiler='c1' level='3' iicount='6667'/>
+<parse method='1093' uses='6667.000000' stamp='0.244'>
+<bc code='153' bci='3'/>
+<branch target_bci='17' taken='0' not_taken='6667' cnt='6667.000000' prob='never'/>
+<bc code='154' bci='10'/>
+<branch target_bci='17' taken='1' not_taken='6666' cnt='6667.000000' prob='0.000149992'/>
+<parse_done nodes='48' live='47' memory='24016' stamp='0.244'/>
+</parse>
+<regalloc attempts='0' success='1'/>
+<code_cache total_blobs='430' nmethods='121' adapters='162' free_code_cache='248564224'/>
+<task_done success='1' nmsize='120' count='6722' stamp='0.245'/>
+</task>
+</compilation_log>
+<compilation_log thread='23810'>
+<fragment>
+<![CDATA[
+<start_compile_thread name='C2 CompilerThread5' thread='23810' process='23756' stamp='0.178'/>
+]]>
+</fragment>
+</compilation_log>
+<compilation_log thread='23809'>
+<fragment>
+<![CDATA[
+<start_compile_thread name='C2 CompilerThread4' thread='23809' process='23756' stamp='0.178'/>
+]]>
+</fragment>
+</compilation_log>
+<compilation_log thread='23808'>
+<fragment>
+<![CDATA[
+<start_compile_thread name='C2 CompilerThread3' thread='23808' process='23756' stamp='0.177'/>
+]]>
+</fragment>
+</compilation_log>
+<compilation_log thread='23807'>
+<fragment>
+<![CDATA[
+<start_compile_thread name='C2 CompilerThread2' thread='23807' process='23756' stamp='0.177'/>
+]]>
+</fragment>
+</compilation_log>
+<compilation_log thread='23806'>
+<start_compile_thread name='C2 CompilerThread1' thread='23806' process='23756' stamp='0.177'/>
+<task compile_id='211' method='java.lang.String charAt (I)C' bytes='25' count='5734' iicount='5734' stamp='0.334'>
+<type id='970' name='char'/>
+<type id='975' name='int'/>
+<klass id='983' name='java.lang.String' flags='17'/>
+<method id='1093' holder='983' name='charAt' return='970' arguments='975' flags='1' bytes='25' compile_id='6' compiler='c1' level='3' iicount='5734'/>
+<parse method='1093' uses='5734.000000' stamp='0.334'>
+<bc code='183' bci='1'/>
+<type id='969' name='boolean'/>
+<method id='1095' holder='983' name='isLatin1' return='969' flags='2' bytes='19' compile_id='119' compiler='c2' level='4' iicount='13240'/>
+<call method='1095' count='5224' prof_factor='1.000000' inline='1'/>
+<inline_success reason='inline (hot)'/>
+<parse method='1095' uses='5734.000000' stamp='0.334'>
+<bc code='153' bci='3'/>
+<branch target_bci='17' taken='0' not_taken='13240' cnt='13240.000000' prob='never'/>
+<bc code='154' bci='10'/>
+<branch target_bci='17' taken='1' not_taken='13239' cnt='13240.000000' prob='7.55287e-05'/>
+<parse_done nodes='59' live='58' memory='25840' stamp='0.335'/>
+</parse>
+<bc code='153' bci='4'/>
+<branch target_bci='16' taken='0' not_taken='5734' cnt='5734.000000' prob='never'/>
+<uncommon_trap bci='4' reason='unstable_if' action='reinterpret' debug_id='0' comment='taken never'/>
+<bc code='184' bci='12'/>
+<klass id='1085' name='[B' flags='1041'/>
+<klass id='1098' name='java.lang.StringLatin1' flags='16'/>
+<method id='1099' holder='1098' name='charAt' return='970' arguments='1085 975' flags='9' bytes='28' compile_id='7' compiler='c1' level='3' iicount='5746'/>
+<call method='1099' count='5224' prof_factor='1.000000' inline='1'/>
+<klass id='1102' name='java.lang.StringIndexOutOfBoundsException' unloaded='1'/>
+<uncommon_trap method='1099' bci='10' reason='unloaded' action='reinterpret' index='3' debug_id='0' klass='1102'/>
+<inline_success reason='inline (hot)'/>
+<parse method='1099' uses='5734.000000' stamp='0.335'>
+<bc code='155' bci='1'/>
+<branch target_bci='10' taken='0' not_taken='5746' cnt='5746.000000' prob='never'/>
+<uncommon_trap bci='1' reason='unstable_if' action='reinterpret' debug_id='0' comment='taken never'/>
+<bc code='190' bci='6'/>
+<uncommon_trap bci='6' reason='null_check' action='maybe_recompile' debug_id='0'/>
+<bc code='161' bci='7'/>
+<branch target_bci='19' taken='5746' not_taken='0' cnt='5746.000000' prob='always'/>
+<uncommon_trap bci='7' reason='unstable_if' action='reinterpret' debug_id='0' comment='taken always'/>
+<bc code='51' bci='21'/>
+<uncommon_trap bci='21' reason='range_check' action='make_not_entrant' debug_id='0' comment='range_check'/>
+<parse_done nodes='160' live='153' memory='43840' stamp='0.335'/>
+</parse>
+<parse_done nodes='161' live='153' memory='44296' stamp='0.335'/>
+</parse>
+<regalloc attempts='1' success='1'/>
+<code_cache total_blobs='599' nmethods='214' adapters='232' free_code_cache='248396416'/>
+<task_done success='1' nmsize='216' count='6370' inlined_bytes='47' stamp='0.335'/>
+</task>
+</compilation_log>
+<compilation_log thread='23805'>
+<start_compile_thread name='C2 CompilerThread0' thread='23805' process='23756' stamp='0.177'/>
+<task compile_id='126' method='java.util.ImmutableCollections$SetN$1 hasNext ()Z' bytes='47' count='5380' backedge_count='2612' iicount='5380' stamp='0.246'>
+<type id='969' name='boolean'/>
+<klass id='1093' name='java.util.ImmutableCollections$SetN$1' flags='0'/>
+<method id='1094' holder='1093' name='hasNext' return='969' flags='1' bytes='47' compile_id='55' compiler='c1' level='3' iicount='5380'/>
+<parse method='1094' uses='5380.000000' stamp='0.246'>
+<bc code='180' bci='8'/>
+<uncommon_trap bci='8' reason='null_check' action='maybe_recompile' debug_id='0'/>
+<bc code='190' bci='11'/>
+<uncommon_trap bci='11' reason='null_check' action='maybe_recompile' debug_id='0'/>
+<bc code='162' bci='12'/>
+<branch target_bci='45' taken='170' not_taken='7807' cnt='7977.000000' prob='0.0213113'/>
+<uncommon_trap bci='15' reason='predicate' action='maybe_recompile' debug_id='0'/>
+<uncommon_trap bci='15' reason='loop_limit_check' action='maybe_recompile' debug_id='0'/>
+<bc code='180' bci='19'/>
+<uncommon_trap bci='19' reason='null_check' action='maybe_recompile' debug_id='0'/>
+<bc code='50' bci='26'/>
+<uncommon_trap bci='26' reason='null_check' action='maybe_recompile' debug_id='0'/>
+<uncommon_trap bci='26' reason='range_check' action='make_not_entrant' debug_id='0' comment='range_check'/>
+<bc code='198' bci='27'/>
+<branch target_bci='32' taken='2598' not_taken='5210' cnt='7808.000000' prob='0.332736'/>
+<bc code='162' bci='12'/>
+<branch target_bci='45' taken='170' not_taken='7807' cnt='2598.000000' prob='0.0213113'/>
+<parse_done nodes='209' live='200' memory='49896' stamp='0.246'/>
+</parse>
+<loop_tree>
+<loop idx='218' inner_loop='1' >
+</loop>
+</loop_tree>
+<loop_tree>
+<loop idx='228' >
+</loop>
+</loop_tree>
+<loop_tree>
+<loop idx='228' inner_loop='1' >
+</loop>
+</loop_tree>
+<loop_tree>
+<loop idx='228' inner_loop='1' >
+</loop>
+</loop_tree>
+<loop_tree>
+<loop idx='228' inner_loop='1' >
+</loop>
+</loop_tree>
+<regalloc attempts='0' success='1'/>
+<code_cache total_blobs='439' nmethods='128' adapters='162' free_code_cache='248555264'/>
+<task_done success='1' nmsize='216' count='6515' backedge_count='3168' stamp='0.247'/>
+</task>
+<task compile_id='161' method='java.util.HashMap hash (Ljava/lang/Object;)I' bytes='20' count='6410' iicount='6410' stamp='0.253'>
+<type id='975' name='int'/>
+<klass id='982' name='java.lang.Object' flags='1'/>
+<klass id='1093' name='java.util.HashMap' flags='1'/>
+<method id='1094' holder='1093' name='hash' return='975' arguments='982' flags='24' bytes='20' compile_id='65' compiler='c1' level='3' iicount='6430'/>
+<parse method='1094' uses='6430.000000' stamp='0.254'>
+<bc code='199' bci='1'/>
+<branch target_bci='8' taken='6430' not_taken='0' cnt='6430.000000' prob='always'/>
+<uncommon_trap bci='1' reason='unstable_if' action='reinterpret' debug_id='0' comment='taken always'/>
+<bc code='182' bci='9'/>
+<klass id='983' name='java.lang.String' flags='17'/>
+<klass id='1096' name='java.lang.module.ModuleDescriptor' flags='1'/>
+<method id='1097' holder='982' name='hashCode' return='975' flags='257' bytes='0' compile_id='93' compile_kind='c2n' compiler='' level='0' iicount='256'/>
+<call method='1097' count='6172' prof_factor='1.000000' virtual='1' inline='1' receiver='983' receiver_count='3982' receiver2='1096' receiver2_count='139'/>
+<intrinsic id='_hashCode' virtual='1' nodes='55'/>
+<parse_done nodes='100' live='98' memory='32304' stamp='0.254'/>
+</parse>
+<regalloc attempts='2' success='1'/>
+<code_cache total_blobs='476' nmethods='163' adapters='162' free_code_cache='248505600'/>
+<task_done success='1' nmsize='184' count='6695' stamp='0.255'/>
+</task>
+</compilation_log>
+<hotspot_log_done stamp='0.347'/>
+</hotspot_log>

--- a/test/jdk/com/sun/crypto/provider/Cipher/ChaCha20/ChaCha20NoReuse.java
+++ b/test/jdk/com/sun/crypto/provider/Cipher/ChaCha20/ChaCha20NoReuse.java
@@ -21,6 +21,12 @@
  * questions.
  */
 
+ /*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2025, 2025 All Rights Reserved
+ * ===========================================================================
+ */
+
 /**
  * @test
  * @bug 8153029
@@ -381,6 +387,8 @@ public class ChaCha20NoReuse {
                 }
                 SecretKey key = new SecretKeySpec(testData.key, ALG_CC20);
 
+                boolean isOpenJCEPlus = cipher.getProvider().getName().startsWith("OpenJCEPlus");
+
                 // Initialize and encrypt
                 cipher.init(testData.direction, key, spec);
                 if (algorithm.equals(ALG_CC20_P1305)) {
@@ -396,8 +404,10 @@ public class ChaCha20NoReuse {
                         cipher.updateAAD(testData.aad);
                     }
                     cipher.doFinal(testData.input);
-                    throw new RuntimeException(
-                            "Expected IllegalStateException not thrown");
+                    if (!isOpenJCEPlus) {
+                        throw new RuntimeException(
+                                "Expected IllegalStateException not thrown");
+                    }
                 } catch (IllegalStateException ise) {
                     // Do nothing, this is what we expected to happen
                 }
@@ -435,6 +445,8 @@ public class ChaCha20NoReuse {
                 SecretKey key = new SecretKeySpec(testData.key, ALG_CC20);
                 Cipher cipher = Cipher.getInstance(algorithm);
 
+                boolean isOpenJCEPlus = cipher.getProvider().getName().startsWith("OpenJCEPlus");
+
                 try {
                     // Initialize and encrypt
                     cipher.init(testData.direction, key, spec);
@@ -452,8 +464,10 @@ public class ChaCha20NoReuse {
                 try {
                     cipher.updateAAD(testData.aad);
                     cipher.doFinal(testData.input);
-                    throw new RuntimeException(
-                            "Expected IllegalStateException not thrown");
+                    if (!isOpenJCEPlus) {
+                        throw new RuntimeException(
+                                "Expected IllegalStateException not thrown");
+                    }
                 } catch (IllegalStateException ise) {
                     // Do nothing, this is what we expected to happen
                 }
@@ -562,6 +576,8 @@ public class ChaCha20NoReuse {
                 }
                 SecretKey key = new SecretKeySpec(testData.key, ALG_CC20);
 
+                boolean isOpenJCEPlus = cipher.getProvider().getName().startsWith("OpenJCEPlus");
+
                 // Initialize then decrypt
                 cipher.init(testData.direction, key, spec);
                 if (algorithm.equals(ALG_CC20_P1305)) {
@@ -574,8 +590,10 @@ public class ChaCha20NoReuse {
                 // the same key and nonce should fail.
                 try {
                     cipher.init(testData.direction, key, spec);
-                    throw new RuntimeException(
-                            "Expected InvalidKeyException not thrown");
+                    if (!isOpenJCEPlus) {
+                        throw new RuntimeException(
+                                "Expected InvalidKeyException not thrown");
+                    }
                 } catch (InvalidKeyException ike) {
                     // Do nothing, this is what we expected to happen
                 }


### PR DESCRIPTION
Modify tests involving decryption so that they pass when the provider
is OpenJCEPlus. These tests are different in later versions, allowing
different behaviour that does not require them to change. Thus this
change only affects Java 17 and earlier. The relevant OpenJCEPlus
implementation will remain unchanged and consistent across all
versions.

Changed tests:
  - Decrypt twice with no init in between
  - Fail a decryption, then try again without an init
  - Decrypt and init again with the same key and nonce as before

Back ported from: https://github.com/ibmruntimes/openj9-openjdk-jdk17/pull/507

Signed-off-by: Sabrina Lee <sabrinalee@ibm.com>