### PR TITLE
Additonal excludes for FIPS 140-3

### DIFF
--- a/test/jdk/ProblemList-FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced.txt
+++ b/test/jdk/ProblemList-FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced.txt
@@ -291,6 +291,7 @@ javax/crypto/EncryptedPrivateKeyInfo/GetKeySpecException2.java https://github.co
 javax/crypto/EncryptedPrivateKeyInfo/GetKeySpecInvalidEncoding.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 javax/crypto/JceSecurity/SunJCE_BC_LoadOrdering.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 javax/crypto/KeyGenerator/TestGetInstance.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
+javax/crypto/KeyGenerator/TestKGParity.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
 javax/crypto/Mac/ByteBuffers.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 javax/crypto/Mac/TestGetInstance.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 javax/crypto/SealedObject/NullKeySealedObject.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all

--- a/test/jdk/ProblemList-FIPS140_3_OpenJCEPlusFIPS.FIPS140-3.txt
+++ b/test/jdk/ProblemList-FIPS140_3_OpenJCEPlusFIPS.FIPS140-3.txt
@@ -289,6 +289,7 @@ javax/crypto/EncryptedPrivateKeyInfo/GetKeySpecException2.java https://github.co
 javax/crypto/EncryptedPrivateKeyInfo/GetKeySpecInvalidEncoding.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 javax/crypto/JceSecurity/SunJCE_BC_LoadOrdering.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 javax/crypto/KeyGenerator/TestGetInstance.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
+javax/crypto/KeyGenerator/TestKGParity.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
 javax/crypto/Mac/ByteBuffers.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 javax/crypto/Mac/TestGetInstance.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 javax/crypto/SealedObject/NullKeySealedObject.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all


### PR DESCRIPTION
Back-ported from: https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/1070

Signed-off-by: Jason Katonica <katonica@us.ibm.com>

