### PR TITLE
Add compatibility for a key from a different provider

### DIFF
--- a/closed/src/jdk.crypto.ec/share/classes/sun/security/ec/NativeXDHKeyAgreement.java
+++ b/closed/src/jdk.crypto.ec/share/classes/sun/security/ec/NativeXDHKeyAgreement.java
@@ -25,7 +25,7 @@
 
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2023, 2023 All Rights Reserved
+ * (c) Copyright IBM Corp. 2023, 2025 All Rights Reserved
  * ===========================================================================
  */
 
@@ -159,7 +159,18 @@ public class NativeXDHKeyAgreement extends KeyAgreementSpi {
             }
 
             if (!(key instanceof XDHPublicKeyImpl)) {
-                throw new InvalidKeyException("Unsupported key type");
+                if (!(key instanceof XECPublicKey)) {
+                    throw new InvalidKeyException("Unsupported key type");
+                }
+                try {
+                    XDHKeyFactory kf = new XDHKeyFactory();
+                    key = kf.engineTranslateKey(key);
+                } catch (Exception exception) {
+                    throw new InvalidKeyException("Unable to translate key", exception);
+                }
+                if (!(key instanceof XDHPublicKeyImpl)) {
+                    throw new InvalidKeyException("Unsupported key type");
+                }
             }
 
             XDHPublicKeyImpl publicKey = (XDHPublicKeyImpl) key;


### PR DESCRIPTION
NativeXDHKeyAgreement is updated to support keys created from a different provider than Sun using the XDHKeyFactory.

Back-ported from: https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/1067

Signed-off-by: Dev Agarwal [dev.agarwal@ibm.com](mailto:dev.agarwal@ibm.com)