### PR TITLE
Add RAM_CLASS_CACHE_SUPPORT JPP flag

### DIFF
--- a/closed/JPP.gmk
+++ b/closed/JPP.gmk
@@ -1,5 +1,5 @@
 # ===========================================================================
-# (c) Copyright IBM Corp. 2023, 2024 All Rights Reserved
+# (c) Copyright IBM Corp. 2023, 2025 All Rights Reserved
 # ===========================================================================
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
@@ -41,6 +41,10 @@ endif # OPENJ9_ENABLE_OPENJDK_METHODHANDLES
 ifeq (true,$(BUILD_OPENJCEPLUS))
   JPP_TAGS += OPENJCEPLUS_SUPPORT
 endif # BUILD_OPENJCEPLUS
+
+ifeq (true,$(OPENJ9_ENABLE_SNAPSHOTS))
+  JPP_TAGS += RAM_CLASS_CACHE_SUPPORT
+endif # OPENJ9_ENABLE_SNAPSHOTS
 
 # invoke JPP to preprocess java source files
 # $1 - configuration


### PR DESCRIPTION
The flag is required and a part of https://github.com/eclipse-openj9/openj9/pull/22289