### PR TITLE
Update FIPS exclusion list

### DIFF
--- a/test/jdk/ProblemList-FIPS140_3_OpenJCEPlusFIPS.FIPS140-3.txt
+++ b/test/jdk/ProblemList-FIPS140_3_OpenJCEPlusFIPS.FIPS140-3.txt
@@ -152,6 +152,7 @@ com/sun/jndi/ldap/DeadSSLLdapTimeoutTest.java https://github.ibm.com/runtimes/ba
 com/sun/jndi/ldap/LdapCBPropertiesTest.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 com/sun/jndi/ldap/LdapSSLHandshakeFailureTest.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 com/sun/jndi/rmi/registry/objects/ObjectFactoryBuilderCodebaseTest.java https://github.ibm.com/runtimes/backlog/issues/1089 generic-all
+com/sun/jndi/rmi/registry/objects/RmiFactoriesFilterTest.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 com/sun/jndi/rmi/registry/RegistryContext/ContextWithNullProperties.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 com/sun/jndi/rmi/registry/RegistryContext/UnbindIdempotent.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 com/sun/net/ssl/SSLSecurity/ProviderTest.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
@@ -406,6 +407,7 @@ javax/crypto/CryptoPermission/RC2PermCheck.java https://github.com/eclipse-openj
 javax/crypto/CryptoPermission/RC4AliasPermCheck.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 javax/crypto/CryptoPermission/RSANoLimit.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 javax/crypto/EncryptedPrivateKeyInfo/GetAlgName.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
+javax/crypto/EncryptedPrivateKeyInfo/GetEncoded.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 javax/crypto/EncryptedPrivateKeyInfo/GetKeySpec.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 javax/crypto/EncryptedPrivateKeyInfo/GetKeySpecException.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 javax/crypto/EncryptedPrivateKeyInfo/GetKeySpecException2.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
@@ -879,6 +881,7 @@ sun/security/ssl/ServerHandshaker/GetPeerHost.java https://github.com/eclipse-op
 sun/security/ssl/ServerHandshaker/HelloExtensionsTest.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/ssl/SignatureScheme/CustomizedClientSchemes.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/ssl/SignatureScheme/CustomizedServerSchemes.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
+sun/security/ssl/SignatureScheme/MD5NotAllowedInTLS13CertificateSignature.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/ssl/SignatureScheme/Tls13NamedGroups.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/ssl/SocketCreation/SocketCreation.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/ssl/spi/ProviderInit.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
@@ -913,6 +916,8 @@ sun/security/ssl/SSLEngineImpl/SSLEngineDeadlock.java https://github.com/eclipse
 sun/security/ssl/SSLEngineImpl/SSLEngineDecodeBadPoint.java https://github.ibm.com/runtimes/backlog/issues/1089 generic-all
 sun/security/ssl/SSLEngineImpl/SSLEngineFailedALPN.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/ssl/SSLEngineImpl/SSLEngineKeyLimit.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
+sun/security/ssl/SSLEngineImpl/TestBadDNForPeerCA.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
+sun/security/ssl/SSLEngineImpl/TestBadDNForPeerCA12.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/ssl/SSLEngineImpl/TLS13BeginHandshake.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/ssl/SSLLogger/LoggingFormatConsistency.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/ssl/SSLSessionContextImpl/DefautlCacheSize.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all

--- a/test/jdk/ProblemList-FIPS140_3_OpenJcePlus.txt
+++ b/test/jdk/ProblemList-FIPS140_3_OpenJcePlus.txt
@@ -339,6 +339,7 @@ javax/crypto/CryptoPermission/RC2PermCheck.java https://github.com/eclipse-openj
 javax/crypto/CryptoPermission/RC4AliasPermCheck.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
 javax/crypto/CryptoPermission/RSANoLimit.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
 javax/crypto/EncryptedPrivateKeyInfo/GetAlgName.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
+javax/crypto/EncryptedPrivateKeyInfo/GetEncoded.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
 javax/crypto/EncryptedPrivateKeyInfo/GetKeySpec.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
 javax/crypto/EncryptedPrivateKeyInfo/GetKeySpecException.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
 javax/crypto/EncryptedPrivateKeyInfo/GetKeySpecException2.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
@@ -841,6 +842,7 @@ sun/security/ssl/ServerHandshaker/GetPeerHost.java https://github.com/eclipse-op
 sun/security/ssl/ServerHandshaker/HelloExtensionsTest.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
 sun/security/ssl/SignatureScheme/CustomizedClientSchemes.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
 sun/security/ssl/SignatureScheme/CustomizedServerSchemes.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
+sun/security/ssl/SignatureScheme/MD5NotAllowedInTLS13CertificateSignature.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
 sun/security/ssl/SignatureScheme/Tls13NamedGroups.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
 sun/security/ssl/SocketCreation/SocketCreation.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
 sun/security/ssl/spi/ProviderInit.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all


### PR DESCRIPTION
Some tests listed in the JDK Next exclusion list were not backported to earlier JDK versions, likely because the tests themselves had not been backported at that time.

Now, these tests need to be added to the exclusion lists for earlier JDK versions because:

1. The tests have since been backported, or
3. They are not yet backported, but once they are, they will inevitably fail since the required algorithms are not supported in FIPS mode.