### PR TITLE
Update base security profiles added for testing

### DIFF
--- a/closed/test/jdk/openj9/internal/security/constraints-java.security
+++ b/closed/test/jdk/openj9/internal/security/constraints-java.security
@@ -1,5 +1,5 @@
 # ===========================================================================
-# (c) Copyright IBM Corp. 2025, 2025 All Rights Reserved
+# (c) Copyright IBM Corp. 2025, 2026 All Rights Reserved
 # ===========================================================================
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
@@ -21,9 +21,7 @@
 RestrictedSecurity.TestConstraints.Version.desc.name = Test Base Profile
 RestrictedSecurity.TestConstraints.Version.desc.default = false
 RestrictedSecurity.TestConstraints.Version.desc.fips = false
-RestrictedSecurity.TestConstraints.Version.desc.hash = SHA256:ee4d544adefe3f0ed4afe061f43648fd616ba802694bd6cb1918d0a4dd2e7716
-RestrictedSecurity.TestConstraints.Version.desc.number = Certificate #XXX
-RestrictedSecurity.TestConstraints.Version.desc.policy =
+RestrictedSecurity.TestConstraints.Version.desc.hash = SHA256:01b7758f3ee283949a866ee9400c7f00ab49395914036c2f8251e83d40c93682
 RestrictedSecurity.TestConstraints.Version.fips.mode = test
 
 RestrictedSecurity.TestConstraints.Version.jce.provider.1 = sun.security.provider.Sun [ \

--- a/closed/test/jdk/openj9/internal/security/property-java.security
+++ b/closed/test/jdk/openj9/internal/security/property-java.security
@@ -1,5 +1,5 @@
 # ===========================================================================
-# (c) Copyright IBM Corp. 2024, 2024 All Rights Reserved
+# (c) Copyright IBM Corp. 2024, 2026 All Rights Reserved
 # ===========================================================================
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
@@ -21,10 +21,7 @@
 RestrictedSecurity.TestBase.Version.desc.name = Test Base Profile
 RestrictedSecurity.TestBase.Version.desc.default = false
 RestrictedSecurity.TestBase.Version.desc.fips = true
-RestrictedSecurity.TestBase.Version.desc.hash = SHA256:0ca32676ac2ae92d0469cbf293f3a69416c5d0312c80473319452f4d6995d234
-RestrictedSecurity.TestBase.Version.desc.number = Certificate #XXX
-RestrictedSecurity.TestBase.Version.desc.policy = https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/
-RestrictedSecurity.TestBase.Version.desc.sunsetDate = 2026-09-21
+RestrictedSecurity.TestBase.Version.desc.hash = SHA256:5694e96a9990cae706ea0c712e19924dcab88ebf8aa303e1aac99c1b07f6c8ab
 RestrictedSecurity.TestBase.Version.fips.mode = 140-3
 
 RestrictedSecurity.TestBase.Version.tls.disabledNamedCurves =
@@ -66,10 +63,7 @@ RestrictedSecurity.TestBase.Version-Extended.jce.provider.11 = com.sun.security.
 RestrictedSecurity.Test-Profile.Base.desc.name = Test-Profile.Base
 RestrictedSecurity.Test-Profile.Base.desc.default = true
 RestrictedSecurity.Test-Profile.Base.desc.fips = true
-RestrictedSecurity.Test-Profile.Base.desc.hash = SHA256:4fab3014e91072587e76c6ebb393ceea710d76582069d46a70eab31c30f57e45
-RestrictedSecurity.Test-Profile.Base.desc.number = Certificate #XXX
-RestrictedSecurity.Test-Profile.Base.desc.policy = https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/
-RestrictedSecurity.Test-Profile.Base.desc.sunsetDate = 2026-09-21
+RestrictedSecurity.Test-Profile.Base.desc.hash = SHA256:irrelevant
 RestrictedSecurity.Test-Profile.Base.fips.mode = 140-3
 
 RestrictedSecurity.Test-Profile.Base.tls.disabledAlgorithmsWrongTypo =
@@ -83,7 +77,7 @@ RestrictedSecurity.Test-Profile.Base.securerandom.algorithm = SHA512DRBG
 
 #
 # Test-Profile.Extended_1
-# Test profile - extenstion profile misspell properties
+# Test profile - extension profile misspell properties
 #
 RestrictedSecurity.Test-Profile.Extended_1.desc.nameWrongTypo = Test-Profile.Extended_1
 RestrictedSecurity.Test-Profile.Extended_1.desc.default = true
@@ -119,10 +113,7 @@ RestrictedSecurity.Test-Profile.Extended_2.jce.providerWrongTypo = sun.security.
 RestrictedSecurity.Test-Profile-MultiDefault.Base.desc.name = Test-Profile-MultiDefault.Base
 RestrictedSecurity.Test-Profile-MultiDefault.Base.desc.default = true
 RestrictedSecurity.Test-Profile-MultiDefault.Base.desc.fips = true
-RestrictedSecurity.Test-Profile-MultiDefault.Base.desc.hash = SHA256:adf136024d9c047f3ffb1dac41e5f553eee5e7b6dec13bfc13b431a2a8a2525d
-RestrictedSecurity.Test-Profile-MultiDefault.Base.desc.number = Certificate #XXX
-RestrictedSecurity.Test-Profile-MultiDefault.Base.desc.policy = https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/
-RestrictedSecurity.Test-Profile-MultiDefault.Base.desc.sunsetDate = 2026-09-21
+RestrictedSecurity.Test-Profile-MultiDefault.Base.desc.hash = SHA256:7acd2a9b1a4438c4f56ac7d04d806bc7c6cb9d0d552f750c2c45744b09bb0aa3
 RestrictedSecurity.Test-Profile-MultiDefault.Base.fips.mode = 140-3
 
 RestrictedSecurity.Test-Profile-MultiDefault.Base.jce.provider.1 = sun.security.provider.Sun
@@ -183,9 +174,6 @@ RestrictedSecurity.Test-Profile.Extended_4.jce.providerWrongTypo.1 = sun.securit
 RestrictedSecurity.Test-Profile-BaseWithoutHash.desc.name = Test-Profile-BaseWithoutHash
 RestrictedSecurity.Test-Profile-BaseWithoutHash.desc.default = true
 RestrictedSecurity.Test-Profile-BaseWithoutHash.desc.fips = true
-RestrictedSecurity.Test-Profile-BaseWithoutHash.desc.number = Certificate #XXX
-RestrictedSecurity.Test-Profile-BaseWithoutHash.desc.policy = https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/
-RestrictedSecurity.Test-Profile-BaseWithoutHash.desc.sunsetDate = 2026-09-21
 RestrictedSecurity.Test-Profile-BaseWithoutHash.fips.mode = 140-3
 
 RestrictedSecurity.Test-Profile-BaseWithoutHash.jce.provider.1 = sun.security.provider.Sun
@@ -200,10 +188,7 @@ RestrictedSecurity.Test-Profile-BaseWithoutHash.securerandom.algorithm = SHA512D
 RestrictedSecurity.Test-Profile-Hash_1.desc.name = Test-Profile-Hash_1
 RestrictedSecurity.Test-Profile-Hash_1.desc.default = true
 RestrictedSecurity.Test-Profile-Hash_1.desc.fips = true
-RestrictedSecurity.Test-Profile-Hash_1.desc.hash = SHA2564fab3014e91072587e76c6ebb393ceea710d76582069d46a70eab31c30f57e45
-RestrictedSecurity.Test-Profile-Hash_1.desc.number = Certificate #XXX
-RestrictedSecurity.Test-Profile-Hash_1.desc.policy = https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/
-RestrictedSecurity.Test-Profile-Hash_1.desc.sunsetDate = 2026-09-21
+RestrictedSecurity.Test-Profile-Hash_1.desc.hash = SHA256wrong
 RestrictedSecurity.Test-Profile-Hash_1.fips.mode = 140-3
 
 RestrictedSecurity.Test-Profile-Hash_1.jce.provider.1 = sun.security.provider.Sun
@@ -218,10 +203,7 @@ RestrictedSecurity.Test-Profile-Hash_1.securerandom.algorithm = SHA512DRBG
 RestrictedSecurity.Test-Profile-Hash_2.desc.name = Test-Profile-Hash_2
 RestrictedSecurity.Test-Profile-Hash_2.desc.default = true
 RestrictedSecurity.Test-Profile-Hash_2.desc.fips = true
-RestrictedSecurity.Test-Profile-Hash_2.desc.hash = SHA256:4fab3014e91072587e76c6ebb393ceea710d76582069d46a70eab31c30f57e45
-RestrictedSecurity.Test-Profile-Hash_2.desc.number = Certificate #XXX
-RestrictedSecurity.Test-Profile-Hash_2.desc.policy = https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/
-RestrictedSecurity.Test-Profile-Hash_2.desc.sunsetDate = 2026-09-21
+RestrictedSecurity.Test-Profile-Hash_2.desc.hash = SHA256:wrong
 RestrictedSecurity.Test-Profile-Hash_2.fips.mode = 140-3
 
 RestrictedSecurity.Test-Profile-Hash_2.jce.provider.1 = sun.security.provider.Sun
@@ -236,10 +218,7 @@ RestrictedSecurity.Test-Profile-Hash_2.securerandom.algorithm = SHA512DRBG
 RestrictedSecurity.Test-Profile-SetProperty.Base.desc.name = Test-Profile-SetProperty.Base
 RestrictedSecurity.Test-Profile-SetProperty.Base.desc.default = false
 RestrictedSecurity.Test-Profile-SetProperty.Base.desc.fips = true
-RestrictedSecurity.Test-Profile-SetProperty.Base.desc.hash = SHA256:c6348b840ab42f891e3bde552b8d908be37571804750312aabe8f17e48830564
-RestrictedSecurity.Test-Profile-SetProperty.Base.desc.number = Certificate #XXX
-RestrictedSecurity.Test-Profile-SetProperty.Base.desc.policy = https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/
-RestrictedSecurity.Test-Profile-SetProperty.Base.desc.sunsetDate = 2026-09-21
+RestrictedSecurity.Test-Profile-SetProperty.Base.desc.hash = SHA256:c4facd909f44c484feb39dcc4caad1025e5f880e5e5f5099682c94f41901a932
 RestrictedSecurity.Test-Profile-SetProperty.Base.fips.mode = 140-3
 
 RestrictedSecurity.Test-Profile-SetProperty.Base.tls.disabledAlgorithms = \
@@ -334,10 +313,7 @@ RestrictedSecurity.Test-Profile-PolicySunsetFormat.Base.securerandom.algorithm =
 RestrictedSecurity.Test-Profile-SecureRandomCheck_1.desc.name = Test-Profile-SecureRandomCheck_1
 RestrictedSecurity.Test-Profile-SecureRandomCheck_1.desc.default = true
 RestrictedSecurity.Test-Profile-SecureRandomCheck_1.desc.fips = true
-RestrictedSecurity.Test-Profile-SecureRandomCheck_1.desc.hash = SHA256:e71c49d65fd291efe75993ccbe6999e6cfb26bf9ef3e8424cb086c7e2a225ce6
-RestrictedSecurity.Test-Profile-SecureRandomCheck_1.desc.number = Certificate #XXX
-RestrictedSecurity.Test-Profile-SecureRandomCheck_1.desc.policy = https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/
-RestrictedSecurity.Test-Profile-SecureRandomCheck_1.desc.sunsetDate = 2026-09-21
+RestrictedSecurity.Test-Profile-SecureRandomCheck_1.desc.hash = SHA256:irrelevant
 RestrictedSecurity.Test-Profile-SecureRandomCheck_1.fips.mode = 140-3
 
 RestrictedSecurity.Test-Profile-SecureRandomCheck_1.jce.provider.1 = sun.security.provider.Sun
@@ -352,10 +328,7 @@ RestrictedSecurity.Test-Profile-SecureRandomCheck_1.securerandom.algorithm = SHA
 RestrictedSecurity.Test-Profile-SecureRandomCheck_2.desc.name = Test-Profile-SecureRandomCheck_2
 RestrictedSecurity.Test-Profile-SecureRandomCheck_2.desc.default = true
 RestrictedSecurity.Test-Profile-SecureRandomCheck_2.desc.fips = true
-RestrictedSecurity.Test-Profile-SecureRandomCheck_2.desc.hash = SHA256:e71c49d65fd291efe75993ccbe6999e6cfb26bf9ef3e8424cb086c7e2a225ce6
-RestrictedSecurity.Test-Profile-SecureRandomCheck_2.desc.number = Certificate #XXX
-RestrictedSecurity.Test-Profile-SecureRandomCheck_2.desc.policy = https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/
-RestrictedSecurity.Test-Profile-SecureRandomCheck_2.desc.sunsetDate = 2026-09-21
+RestrictedSecurity.Test-Profile-SecureRandomCheck_2.desc.hash = SHA256:irrelevant
 RestrictedSecurity.Test-Profile-SecureRandomCheck_2.fips.mode = 140-3
 
 RestrictedSecurity.Test-Profile-SecureRandomCheck_2.jce.provider.1 = sun.security.provider.Sun
@@ -369,13 +342,9 @@ RestrictedSecurity.Test-Profile-SecureRandomCheck_2.securerandom.provider = Open
 RestrictedSecurity.Test-Profile-Constraint_1.desc.name = Test-Profile-Constraint_1
 RestrictedSecurity.Test-Profile-Constraint_1.desc.default = true
 RestrictedSecurity.Test-Profile-Constraint_1.desc.fips = true
-RestrictedSecurity.Test-Profile-Constraint_1.desc.hash = SHA256:76dacdfdc5b5811d9b45e72b5b154de6419616556f8f7479819971bba89c41bb
-RestrictedSecurity.Test-Profile-Constraint_1.desc.number = Certificate #XXX
-RestrictedSecurity.Test-Profile-Constraint_1.desc.policy = https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/
-RestrictedSecurity.Test-Profile-Constraint_1.desc.sunsetDate = 2026-09-21
 RestrictedSecurity.Test-Profile-Constraint_1.fips.mode = 140-3
 
-RestrictedSecurity.Test-Profile-Constraint_1.jce.provider.1 = com.sun.crypto.provider.SunJCE  \
+RestrictedSecurity.Test-Profile-Constraint_1.jce.provider.1 = com.sun.crypto.provider.SunJCE \
     {AlgorithmParameterGenerator, AESGCM, *}, \
     {AlgorithmParameterGenerator, CCM, *}]
 
@@ -389,10 +358,6 @@ RestrictedSecurity.Test-Profile-Constraint_1.securerandom.algorithm = SHA512DRBG
 RestrictedSecurity.Test-Profile-Constraint_2.desc.name = Test-Profile-Constraint_2
 RestrictedSecurity.Test-Profile-Constraint_2.desc.default = true
 RestrictedSecurity.Test-Profile-Constraint_2.desc.fips = true
-RestrictedSecurity.Test-Profile-Constraint_2.desc.hash = SHA256:76dacdfdc5b5811d9b45e72b5b154de6419616556f8f7479819971bba89c41bb
-RestrictedSecurity.Test-Profile-Constraint_2.desc.number = Certificate #XXX
-RestrictedSecurity.Test-Profile-Constraint_2.desc.policy = https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/
-RestrictedSecurity.Test-Profile-Constraint_2.desc.sunsetDate = 2026-09-21
 RestrictedSecurity.Test-Profile-Constraint_2.fips.mode = 140-3
 
 RestrictedSecurity.Test-Profile-Constraint_2.jce.provider.1 = com.sun.crypto.provider.SunJCE [ \
@@ -409,10 +374,6 @@ RestrictedSecurity.Test-Profile-Constraint_2.securerandom.algorithm = SHA512DRBG
 RestrictedSecurity.Test-Profile-Constraint_3.desc.name = Test-Profile-Constraint_3
 RestrictedSecurity.Test-Profile-Constraint_3.desc.default = true
 RestrictedSecurity.Test-Profile-Constraint_3.desc.fips = true
-RestrictedSecurity.Test-Profile-Constraint_3.desc.hash = SHA256:76dacdfdc5b5811d9b45e72b5b154de6419616556f8f7479819971bba89c41bb
-RestrictedSecurity.Test-Profile-Constraint_3.desc.number = Certificate #XXX
-RestrictedSecurity.Test-Profile-Constraint_3.desc.policy = https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/
-RestrictedSecurity.Test-Profile-Constraint_3.desc.sunsetDate = 2026-09-21
 RestrictedSecurity.Test-Profile-Constraint_3.fips.mode = 140-3
 
 RestrictedSecurity.Test-Profile-Constraint_3.jce.provider.1 = com.sun.crypto.provider.SunJCE [ {} ]
@@ -427,10 +388,6 @@ RestrictedSecurity.Test-Profile-Constraint_3.securerandom.algorithm = SHA512DRBG
 RestrictedSecurity.Test-Profile-Constraint_Attributes.desc.name = Test-Profile-Constraint_Attributes
 RestrictedSecurity.Test-Profile-Constraint_Attributes.desc.default = true
 RestrictedSecurity.Test-Profile-Constraint_Attributes.desc.fips = true
-RestrictedSecurity.Test-Profile-Constraint_Attributes.desc.hash = SHA256:76dacdfdc5b5811d9b45e72b5b154de6419616556f8f7479819971bba89c41bb
-RestrictedSecurity.Test-Profile-Constraint_Attributes.desc.number = Certificate #XXX
-RestrictedSecurity.Test-Profile-Constraint_Attributes.desc.policy = https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/
-RestrictedSecurity.Test-Profile-Constraint_Attributes.desc.sunsetDate = 2026-09-21
 RestrictedSecurity.Test-Profile-Constraint_Attributes.fips.mode = 140-3
 
 RestrictedSecurity.Test-Profile-Constraint_Attributes.jce.provider.1 = com.sun.crypto.provider.SunJCE
@@ -447,10 +404,7 @@ RestrictedSecurity.Test-Profile-Constraint_Attributes.securerandom.algorithm = S
 RestrictedSecurity.Test-Profile-ConstraintChanged_1.Base.desc.name = Test-Profile-ConstraintChanged_1.Base
 RestrictedSecurity.Test-Profile-ConstraintChanged_1.Base.desc.default = false
 RestrictedSecurity.Test-Profile-ConstraintChanged_1.Base.desc.fips = true
-RestrictedSecurity.Test-Profile-ConstraintChanged_1.Base.desc.hash = SHA256:e71c49d65fd291efe75993ccbe6999e6cfb26bf9ef3e8424cb086c7e2a225ce6
-RestrictedSecurity.Test-Profile-ConstraintChanged_1.Base.desc.number = Certificate #XXX
-RestrictedSecurity.Test-Profile-ConstraintChanged_1.Base.desc.policy = https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/
-RestrictedSecurity.Test-Profile-ConstraintChanged_1.Base.desc.sunsetDate = 2026-09-21
+RestrictedSecurity.Test-Profile-ConstraintChanged_1.Base.desc.hash = SHA256:irrelevant
 RestrictedSecurity.Test-Profile-ConstraintChanged_1.Base.fips.mode = 140-3
 
 RestrictedSecurity.Test-Profile-ConstraintChanged_1.Base.jce.provider.1 = com.sun.crypto.provider.SunJCE [ \
@@ -480,10 +434,7 @@ RestrictedSecurity.Test-Profile-ConstraintChanged_1.Extension.jce.provider.1 = s
 RestrictedSecurity.Test-Profile-ConstraintChanged_2.Base.desc.name = Test-Profile-ConstraintChanged_2.Base
 RestrictedSecurity.Test-Profile-ConstraintChanged_2.Base.desc.default = false
 RestrictedSecurity.Test-Profile-ConstraintChanged_2.Base.desc.fips = true
-RestrictedSecurity.Test-Profile-ConstraintChanged_2.Base.desc.hash = SHA256:e71c49d65fd291efe75993ccbe6999e6cfb26bf9ef3e8424cb086c7e2a225ce6
-RestrictedSecurity.Test-Profile-ConstraintChanged_2.Base.desc.number = Certificate #XXX
-RestrictedSecurity.Test-Profile-ConstraintChanged_2.Base.desc.policy = https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/
-RestrictedSecurity.Test-Profile-ConstraintChanged_2.Base.desc.sunsetDate = 2026-09-21
+RestrictedSecurity.Test-Profile-ConstraintChanged_2.Base.desc.hash = SHA256:irrelevant
 RestrictedSecurity.Test-Profile-ConstraintChanged_2.Base.fips.mode = 140-3
 
 RestrictedSecurity.Test-Profile-ConstraintChanged_2.Base.jce.provider.1 = com.sun.crypto.provider.SunJCE [ \
@@ -513,10 +464,6 @@ RestrictedSecurity.Test-Profile-ConstraintChanged_2.Extension.jce.provider.2 = s
 RestrictedSecurity.Test-Profile-ConstraintChanged_3.Base.desc.name = Test-Profile-ConstraintChanged_3.Base
 RestrictedSecurity.Test-Profile-ConstraintChanged_3.Base.desc.default = true
 RestrictedSecurity.Test-Profile-ConstraintChanged_3.Base.desc.fips = true
-RestrictedSecurity.Test-Profile-ConstraintChanged_3.Base.desc.hash = SHA256:e71c49d65fd291efe75993ccbe6999e6cfb26bf9ef3e8424cb086c7e2a225ce6
-RestrictedSecurity.Test-Profile-ConstraintChanged_3.Base.desc.number = Certificate #XXX
-RestrictedSecurity.Test-Profile-ConstraintChanged_3.Base.desc.policy = https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/
-RestrictedSecurity.Test-Profile-ConstraintChanged_3.Base.desc.sunsetDate = 2026-09-21
 RestrictedSecurity.Test-Profile-ConstraintChanged_3.Base.fips.mode = 140-3
 
 RestrictedSecurity.Test-Profile-ConstraintChanged_3.Base.jce.provider.1 =  com.sun.crypto.provider.SunJCE [ + \
@@ -533,10 +480,7 @@ RestrictedSecurity.Test-Profile-ConstraintChanged_3.Base.securerandom.algorithm 
 RestrictedSecurity.Test-Profile-SameStartWithoutVersion.desc.name = Test-Profile-SameStartWithoutVersion
 RestrictedSecurity.Test-Profile-SameStartWithoutVersion.desc.default = true
 RestrictedSecurity.Test-Profile-SameStartWithoutVersion.desc.fips = true
-RestrictedSecurity.Test-Profile-SameStartWithoutVersion.desc.hash = SHA256:92693ffabd97694f750d645934cb6d0d3f13e4cade30070fd2479b7b9bcb7f42
-RestrictedSecurity.Test-Profile-SameStartWithoutVersion.desc.number = Certificate #XXX
-RestrictedSecurity.Test-Profile-SameStartWithoutVersion.desc.policy = https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/
-RestrictedSecurity.Test-Profile-SameStartWithoutVersion.desc.sunsetDate = 2026-09-21
+RestrictedSecurity.Test-Profile-SameStartWithoutVersion.desc.hash = SHA256:aaa3c69850b89b6fc2bad5d677b9f324d317744b4561ee11837c0f579b7859df
 RestrictedSecurity.Test-Profile-SameStartWithoutVersion.fips.mode = 140-3
 
 RestrictedSecurity.Test-Profile-SameStartWithoutVersion.jce.provider.1 = sun.security.provider.Sun
@@ -549,10 +493,7 @@ RestrictedSecurity.Test-Profile-SameStartWithoutVersion.securerandom.algorithm =
 RestrictedSecurity.Test-Profile-SameStartWithoutVersionPart.desc.name = Test-Profile-SameStartWithoutVersionPart
 RestrictedSecurity.Test-Profile-SameStartWithoutVersionPart.desc.default = true
 RestrictedSecurity.Test-Profile-SameStartWithoutVersionPart.desc.fips = true
-RestrictedSecurity.Test-Profile-SameStartWithoutVersionPart.desc.hash = SHA256:2c893d75043da09c3dba8d8b24cb71dc1c7ceac5fb8bf362a35847418a933a06
-RestrictedSecurity.Test-Profile-SameStartWithoutVersionPart.desc.number = Certificate #XXX
-RestrictedSecurity.Test-Profile-SameStartWithoutVersionPart.desc.policy = https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/
-RestrictedSecurity.Test-Profile-SameStartWithoutVersionPart.desc.sunsetDate = 2026-09-21
+RestrictedSecurity.Test-Profile-SameStartWithoutVersionPart.desc.hash = SHA256:928f8805d9b73266890af72360afdaaa847d223e7e89e2def37e5c256c47aa20
 RestrictedSecurity.Test-Profile-SameStartWithoutVersionPart.fips.mode = 140-3
 
 RestrictedSecurity.Test-Profile-SameStartWithoutVersionPart.jce.provider.1 = sun.security.provider.Sun

--- a/closed/test/jdk/openj9/internal/security/provider-java.security
+++ b/closed/test/jdk/openj9/internal/security/provider-java.security
@@ -1,5 +1,5 @@
 # ===========================================================================
-# (c) Copyright IBM Corp. 2024, 2024 All Rights Reserved
+# (c) Copyright IBM Corp. 2024, 2026 All Rights Reserved
 # ===========================================================================
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
@@ -21,10 +21,7 @@
 RestrictedSecurity.TestBase.Version.desc.name = Test Base Profile
 RestrictedSecurity.TestBase.Version.desc.default = false
 RestrictedSecurity.TestBase.Version.desc.fips = true
-RestrictedSecurity.TestBase.Version.desc.hash = SHA256:24859dcd916c3d301c0a8d0a58f96f7c3a493cadad48ff1c91a5151f2cdd2d49
-RestrictedSecurity.TestBase.Version.desc.number = Certificate #XXX
-RestrictedSecurity.TestBase.Version.desc.policy = https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/
-RestrictedSecurity.TestBase.Version.desc.sunsetDate = 2026-09-21
+RestrictedSecurity.TestBase.Version.desc.hash = SHA256:5694e96a9990cae706ea0c712e19924dcab88ebf8aa303e1aac99c1b07f6c8ab
 RestrictedSecurity.TestBase.Version.fips.mode = 140-3
 
 RestrictedSecurity.TestBase.Version.tls.disabledNamedCurves =


### PR DESCRIPTION
Remove redundant specifications added to security profiles.

Back-ported from: https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/1192

Signed-off-by: Dev Agarwal [dev.agarwal@ibm.com](mailto:dev.agarwal@ibm.com)