### PR TITLE
Run java/rmi/reliability/benchmark/bench/serial/Main with -Xmso512k

### DIFF
--- a/test/jdk/java/rmi/reliability/benchmark/bench/serial/Main.java
+++ b/test/jdk/java/rmi/reliability/benchmark/bench/serial/Main.java
@@ -22,6 +22,12 @@
  */
 
 /*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2026, 2026 All Rights Reserved
+ * ===========================================================================
+ */
+
+/*
  * @test
  * @summary The Serialization benchmark test. This java class is used to run the
  *          test under JTREG.
@@ -44,7 +50,7 @@
  * @build bench.serial.ReplaceTrees bench.serial.ShortArrays
  * @build bench.serial.Shorts bench.serial.SmallObjTrees
  * @build bench.serial.StreamBuffer bench.serial.Strings
- * @run main/othervm/timeout=1800 -Xss2m bench.serial.Main -c jtreg-config
+ * @run main/othervm/timeout=1800 -Xmso512k -Xss2m bench.serial.Main -c jtreg-config
  * @author Mike Warres, Nigel Daley
  */
 


### PR DESCRIPTION
Increase the native stack size for aarch64 mac, and some other platforms. Some platforms already use 512k as the default. No platform has a default which is bigger than 512k atm.

Closes https://github.com/eclipse-openj9/openj9/issues/23666

Passing grinder with this change https://hyc-runtimes-jenkins.swg-devops.com/view/Test_grinder/job/Grinder/59568
Failing grinder without https://hyc-runtimes-jenkins.swg-devops.com/view/Test_grinder/job/Grinder/59569/