### PR TITLE
Add missing initialSecurityProperties initialization and sdebug output

### DIFF
--- a/src/java.base/share/classes/java/security/Security.java
+++ b/src/java.base/share/classes/java/security/Security.java
@@ -25,7 +25,7 @@
 
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2022, 2025 All Rights Reserved
+ * (c) Copyright IBM Corp. 2022, 2026 All Rights Reserved
  * ===========================================================================
  */
 
@@ -138,6 +138,13 @@ public final class Security {
                 loadProps(null, extraPropFile, overrideAll);
             }
         }
+        initialSecurityProperties = (Properties) props.clone();
+        if (sdebug != null) {
+            for (String key : props.stringPropertyNames()) {
+                sdebug.println("Initial security property: " + key + "=" +
+                    props.getProperty(key));
+            }
+        }
 
         /*[IF CRIU_SUPPORT]*/
         // Check if CRIU checkpoint mode is enabled, if it is then reconfigure the security providers.
@@ -194,14 +201,6 @@ public final class Security {
                 }
             }
         }
-        initialSecurityProperties = (Properties) props.clone();
-        if (sdebug != null) {
-            for (String key : props.stringPropertyNames()) {
-                sdebug.println("Initial security property: " + key + "=" +
-                    props.getProperty(key));
-            }
-        }
-
     }
 
     private static boolean loadProps(File masterFile, String extraPropFile, boolean overrideAll) {


### PR DESCRIPTION
[Add missing initialSecurityProperties initialization and sdebug output](https://github.com/ibmruntimes/openj9-openjdk-jdk11/commit/94b8aebe5a46fa84ceade847357dd2b33e7d2713) 

closes https://github.com/eclipse-openj9/openj9/issues/23925

Signed-off-by: Jason Feng <fengj@ca.ibm.com>

---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).
