### PR TITLE
Run java/rmi/reliability/benchmark/bench/serial/Main with -Xmso1m

### DIFF
--- a/test/jdk/java/rmi/reliability/benchmark/bench/serial/Main.java
+++ b/test/jdk/java/rmi/reliability/benchmark/bench/serial/Main.java
@@ -50,7 +50,7 @@
  * @build bench.serial.ReplaceTrees bench.serial.ShortArrays
  * @build bench.serial.Shorts bench.serial.SmallObjTrees
  * @build bench.serial.StreamBuffer bench.serial.Strings
- * @run main/othervm/timeout=1800 -Xmso512k -Xss2m bench.serial.Main -c jtreg-config
+ * @run main/othervm/timeout=1800 -Xmso1m -Xss2m bench.serial.Main -c jtreg-config
  * @author Mike Warres, Nigel Daley
  */
 


### PR DESCRIPTION
Increase the native stack size for aarch64 mac, and other platforms. No platform has a default which is bigger than 1m atm.

Issue https://github.com/eclipse-openj9/openj9/issues/23666

Backport https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/1230

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).
