### PR TITLE
Remove useless Valhalla configuration code

### DIFF
--- a/closed/autoconf/custom-hook.m4
+++ b/closed/autoconf/custom-hook.m4
@@ -392,25 +392,6 @@ AC_DEFUN([OPENJ9_CONFIGURE_CRAC_AND_CRIU_SUPPORT],
   AC_SUBST(OPENJ9_ENABLE_CRIU_SUPPORT)
 ])
 
-AC_DEFUN([OPENJ9_CONFIGURE_INLINE_TYPES],
-[
-  AC_MSG_CHECKING([for inline types])
-  AC_ARG_ENABLE([inline-types], [AS_HELP_STRING([--enable-inline-types], [enable Inline-Type support @<:@disabled@:>@])])
-  OPENJ9_ENABLE_INLINE_TYPES=false
-
-  if test "x$enable_inline_types" = xyes ; then
-    AC_MSG_RESULT([yes (explicitly enabled)])
-    OPENJ9_ENABLE_INLINE_TYPES=true
-  elif test "x$enable_inline_types" = xno ; then
-    AC_MSG_RESULT([no (explicitly disabled)])
-  elif test "x$enable_inline_types" = x ; then
-    AC_MSG_RESULT([no (default)])
-  else
-    AC_MSG_ERROR([--enable-inline-types accepts no argument])
-  fi
-  AC_SUBST(OPENJ9_ENABLE_INLINE_TYPES)
-])
-
 AC_DEFUN([OPENJ9_CONFIGURE_JFR],
 [
   AC_ARG_ENABLE([jfr], [AS_HELP_STRING([--enable-jfr], [enable JFR support @<:@platform dependent@:>@])])


### PR DESCRIPTION
Value types are only available in Java 28+.

This is a back-port of ibmruntimes/openj9-openjdk-jdk27#18.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).