### PR TITLE
Grant sun.security package permissions to OpenJCEPlus

### DIFF
--- a/src/java.base/share/lib/security/default.policy
+++ b/src/java.base/share/lib/security/default.policy
@@ -272,7 +272,11 @@ grant codeBase "jrt:/openj9.gpu" {
 
 grant codeBase "jrt:/openjceplus" {
     permission java.io.FilePermission "<<ALL FILES>>", "read";
+    permission java.lang.RuntimePermission "accessClassInPackage.sun.security.internal.interfaces";
+    permission java.lang.RuntimePermission "accessClassInPackage.sun.security.internal.spec";
+    permission java.lang.RuntimePermission "accessClassInPackage.sun.security.pkcs";
     permission java.lang.RuntimePermission "accessClassInPackage.sun.security.util";
+    permission java.lang.RuntimePermission "accessClassInPackage.sun.security.x509";
     permission java.lang.RuntimePermission "loadLibrary.*";
     permission java.security.SecurityPermission "clearProviderProperties.*";
     permission java.security.SecurityPermission "putProviderProperty.*";


### PR DESCRIPTION
Grant `sun.security` package permissions to `jrt:/openjceplus` in `default.policy` to cover `sun.security.internal.interfaces`, `sun.security.internal.spec`, `sun.security.pkcs`, `sun.security.util` and `sun.security.x509` packages required by the OpenJCEPlus module.

Since these are changes to the default policy, they only apply to JDK 21 and earlier versions.

This is a back port PR from PR https://github.com/ibmruntimes/openj9-openjdk-jdk21/pull/459