### PR TITLE
Fix regex to accept wildcard character for constraint algorithm

### DIFF
--- a/closed/src/java.base/share/classes/openj9/internal/security/RestrictedSecurity.java
+++ b/closed/src/java.base/share/classes/openj9/internal/security/RestrictedSecurity.java
@@ -1664,7 +1664,7 @@ public final class RestrictedSecurity {
 
             // Check whether constraints are properly specified.
             final String typeRE = "\\w+";
-            final String algoRE = "[A-Za-z0-9./_:#-]+";
+            final String algoRE = "[A-Za-z0-9*./_:#-]+";
             final String attrRE = "[A-Za-z0-9=*|.:]+";
             final String usesRE = "[A-Za-z0-9._:/$]+";
             final String consRE = "\\{(" + typeRE + "),(" + algoRE + "),(" + attrRE + ")(," + usesRE + ")?\\}";


### PR DESCRIPTION
One should be able to use a wildcard `*` character for the algorithm part of a `RestrictedSecurity` provider constraint. The regex parsing that portion was wrong and missing the allowance for the character. This is fixed now.

Back-ported from: https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/1262

Signed-off-by: Kostas Tsiounis <kostas.tsiounis@ibm.com>

---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).
